### PR TITLE
fix(security): reduce /health disclosure + audit followups (2026-05-24)

### DIFF
--- a/docs/SECURITY_AUDIT_2026_05_24.md
+++ b/docs/SECURITY_AUDIT_2026_05_24.md
@@ -1,0 +1,57 @@
+# Security audit followups — 2026-05-24
+
+Following the joint Sage + Groot codebase review on 2026-05-24, this document records the immediate code-level remediation that landed in PR `security/audit-followups-2026-05-24`.
+
+## Findings addressed
+
+### 1. `/health` endpoint disclosure (Groot finding, audit report 2026-05-24T12:14)
+
+**Problem:** Public `/health` returned:
+
+```json
+{
+  "status": "healthy",
+  "service": "rivaflow-api",
+  "version": "0.5.0",
+  "commit": "<git sha>",
+  "email": {"enabled": true, "method": "sendgrid"},
+  "database": "connected"
+}
+```
+
+Anyone reaching the public URL could enumerate version, commit, email provider, and DB state — useful for legitimate monitoring, but also a free reconnaissance surface for attackers.
+
+**Fix:** `rivaflow/api/routes/health.py` — public `/health` now returns `{"status": "healthy"}` only. Internal DB check still propagates 503 to load balancers and Render.
+
+Detailed health is moved to `/health/detailed`, gated by `X-Admin-Token` matching the `HEALTH_DETAILED_TOKEN` environment variable. Returns 404 (not 401/403) when missing/wrong to conceal endpoint existence from unauthenticated probes.
+
+### 2. GitLeaks findings classification (Groot audit 2026-05-24T12:13)
+
+GitLeaks found 14 historical findings in `rivaflow`, all classified by Sage:
+
+| File | Lines | Classification |
+|---|---|---|
+| `rivaflow/docs/api-reference.md` | 47, 48, 85, 86, 108, 115 | Documentation JWT examples (placeholders, prefix `eyJ0eXAiOiJKV1QiLCJhbGc...`) |
+| `rivaflow/CHAT_RUNBOOK.md` | 88, 117, 123, 337 | History-only (file no longer in HEAD) |
+| `tests/test_email_service.py` | 34 | Test placeholder `SG.test-key-123` |
+| `tests/test_security.py` | 173 | Test JWT pattern check |
+| `rivaflow/TEST_FAILURE_FIX_PLAN.md` | 89 | History-only |
+| `rivaflow/tests/unit/test_security.py` | 164 | Test JWT pattern check |
+
+**Conclusion:** No live secrets in HEAD. History-only residue in 2 deleted files is non-rotating cost (placeholders, not real secrets).
+
+**No action needed** beyond this classification record. If a true secret is ever flagged in future scans, rotate the credential immediately and use `git filter-repo` to scrub.
+
+## Followups not in this PR (separate work)
+
+- **Sentry DSN environment variable** — SDK is wired (`api/main.py:120`) but `SENTRY_DSN` not set on Render → events not flowing. Add the env var after creating Sentry project.
+- **Render health check path** — Render's rivaflow-api-v2 has empty health check path. Setting to `/health/live` is recommended (no DB roundtrip, fast probe).
+- **Duplicate `web/` vs `rivaflow/web/` trees** — Groot flagged this as a future sync foot-gun. Top-level `/web/` is the duplicate; canonical is `rivaflow/web/` per Render config. To be consolidated in a separate PR after deploy-path verification.
+- **Postgres HA / multi-region** — `rivaflow-db-v2` is `basic_256mb`, single Singapore region, no HA, no read replicas. Single-point-of-failure. Upgrade path: Render's `standard_1gb` plan + replica when traffic warrants.
+
+## Related
+
+- Groot review bridge note: `~/.claude/MEMORY/bridge/from-groot/20260524-092527-codebase-review-groot.md`
+- Groot Render audit: `~/.claude/MEMORY/bridge/from-groot/20260524-121431-render-branch-audit.md`
+- Groot GitLeaks audit: `~/.claude/MEMORY/bridge/from-groot/20260524-121333-gitleaks-audit.md`
+- Sage access policy: `~/.claude/projects/-Users-rubertwolff/memory/reference_groot_access_policy.md`

--- a/rivaflow/rivaflow/api/routes/health.py
+++ b/rivaflow/rivaflow/api/routes/health.py
@@ -74,7 +74,9 @@ def health_check():
 
 @router.get("/health/detailed", tags=["monitoring"], include_in_schema=False)
 @route_error_handler("detailed_health_check", detail="Detailed health check failed")
-def detailed_health_check(x_admin_token: str | None = Header(default=None, alias="X-Admin-Token")):
+def detailed_health_check(
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token")
+):
     """
     Auth-gated detailed health — version, commit, email config, DB state.
 

--- a/rivaflow/rivaflow/api/routes/health.py
+++ b/rivaflow/rivaflow/api/routes/health.py
@@ -1,10 +1,25 @@
-"""Health check endpoint for monitoring and load balancer checks."""
+"""Health check endpoints — public minimal + auth-gated detailed.
+
+Security note (audit 2026-05-24 — Groot bridge review):
+    The previous `/health` exposed `version`, `commit`, `email` provider, and
+    `database` status to any unauthenticated caller. Useful for legitimate
+    monitoring but also a free reconnaissance surface for attackers.
+
+    Current shape:
+    - `/health`           — public, returns `{"status": "healthy"}` only.
+                            Still performs the internal DB check so 503 cascades.
+    - `/health/detailed`  — gated by `HEALTH_DETAILED_TOKEN` header. Returns
+                            404 (not 401/403) when the token is wrong/missing
+                            so the endpoint's existence isn't disclosed.
+    - `/health/ready`     — public, FastAPI-style readiness probe.
+    - `/health/live`      — public, FastAPI-style liveness probe (no DB).
+"""
 
 import logging
 import os
 from pathlib import Path
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Header, status
 from fastapi.responses import JSONResponse
 
 from rivaflow.core.error_handling import route_error_handler
@@ -19,22 +34,64 @@ _APP_VERSION = _VERSION_FILE.read_text().strip() if _VERSION_FILE.exists() else 
 router = APIRouter()
 
 
+def _check_database() -> tuple[bool, str]:
+    """Internal DB connectivity check. Returns (healthy, status_label)."""
+    try:
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1 as health_check")
+            result = cursor.fetchone()
+            if result and result["health_check"] == 1:
+                return True, "connected"
+            return False, "error"
+    except Exception as e:
+        logger.error("Health check database error: %s", e)
+        return False, "disconnected"
+
+
 @router.get("/health", tags=["monitoring"])
 @route_error_handler("health_check", detail="Health check failed")
 def health_check():
     """
-    Health check endpoint for load balancers and monitoring.
+    Public health check — returns minimal `{"status": "healthy"}` payload.
+
+    Still performs the internal DB check so 503 propagates correctly to
+    load balancers and Render's platform monitoring. Detail is intentionally
+    suppressed to avoid reconnaissance exposure.
 
     Returns:
     - 200 OK if service is healthy
     - 503 Service Unavailable if database connection fails
-
-    This endpoint is used by:
-    - Render platform health checks
-    - Load balancers
-    - Monitoring systems (UptimeRobot, Pingdom, etc.)
     """
-    health_status = {
+    db_ok, _ = _check_database()
+    if not db_ok:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"status": "unhealthy"},
+        )
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"status": "healthy"})
+
+
+@router.get("/health/detailed", tags=["monitoring"], include_in_schema=False)
+@route_error_handler("detailed_health_check", detail="Detailed health check failed")
+def detailed_health_check(x_admin_token: str | None = Header(default=None, alias="X-Admin-Token")):
+    """
+    Auth-gated detailed health — version, commit, email config, DB state.
+
+    Requires `X-Admin-Token` header matching the `HEALTH_DETAILED_TOKEN` env var.
+    Returns 404 (not 401/403) when missing/wrong so the endpoint's existence
+    is not disclosed to unauthenticated probes.
+
+    Internal use only. Do NOT expose publicly via tunnel or domain.
+    """
+    expected_token = os.getenv("HEALTH_DETAILED_TOKEN")
+    if not expected_token or x_admin_token != expected_token:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Not Found"},
+        )
+
+    health_status: dict = {
         "status": "healthy",
         "service": "rivaflow-api",
         "version": _APP_VERSION,
@@ -46,31 +103,17 @@ def health_check():
         from rivaflow.core.services.email_service import EmailService
 
         _email = EmailService()
-        health_status["email"] = {  # type: ignore[assignment]
+        health_status["email"] = {
             "enabled": _email.enabled,
             "method": _email.method or "none",
         }
     except Exception:
-        health_status["email"] = {"enabled": False, "method": "error"}  # type: ignore[assignment]
+        health_status["email"] = {"enabled": False, "method": "error"}
 
     # Check database connectivity
-    try:
-        with get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("SELECT 1 as health_check")
-            result = cursor.fetchone()
-            if result and result["health_check"] == 1:
-                health_status["database"] = "connected"
-            else:
-                health_status["database"] = "error"
-                health_status["status"] = "unhealthy"
-                return JSONResponse(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    content=health_status,
-                )
-    except Exception as e:
-        logger.error("Health check database error: %s", e)
-        health_status["database"] = "disconnected"
+    db_ok, db_label = _check_database()
+    health_status["database"] = db_label
+    if not db_ok:
         health_status["status"] = "unhealthy"
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=health_status
@@ -83,9 +126,10 @@ def health_check():
 @route_error_handler("readiness_check", detail="Readiness check failed")
 def readiness_check():
     """
-    Readiness check - indicates service is ready to accept traffic.
+    Readiness check — indicates service is ready to accept traffic.
 
     Kubernetes/container platforms use this to know when to route traffic.
+    Public; minimal payload.
     """
     return {"status": "ready", "service": "rivaflow-api"}
 
@@ -94,9 +138,9 @@ def readiness_check():
 @route_error_handler("liveness_check", detail="Liveness check failed")
 def liveness_check():
     """
-    Liveness check - indicates service process is alive.
+    Liveness check — indicates service process is alive.
 
     Kubernetes/container platforms use this to detect hung processes.
-    Returns immediately without database checks.
+    Returns immediately without database checks. Public; minimal payload.
     """
     return {"status": "alive", "service": "rivaflow-api"}

--- a/rivaflow/rivaflow/core/services/user_service.py
+++ b/rivaflow/rivaflow/core/services/user_service.py
@@ -171,8 +171,12 @@ class UserService:
                     # Belt rank is publicly discoverable (it's training context, not PII).
                     "current_grade": profile.get("current_grade"),
                     # Gym, location, state, and bio are restricted to connected users.
-                    "default_gym": profile.get("default_gym") if can_see_full_profile else None,
-                    "location": profile.get("location") if can_see_full_profile else None,
+                    "default_gym": (
+                        profile.get("default_gym") if can_see_full_profile else None
+                    ),
+                    "location": (
+                        profile.get("location") if can_see_full_profile else None
+                    ),
                     "state": profile.get("state") if can_see_full_profile else None,
                     "bio": profile.get("bio") if can_see_full_profile else None,
                 }

--- a/tests/test_health_routes.py
+++ b/tests/test_health_routes.py
@@ -1,8 +1,15 @@
-"""Integration tests for health check endpoints."""
+"""Integration tests for health check endpoints.
+
+Updated 2026-05-24 — /health reduced to minimal status payload to prevent
+reconnaissance disclosure; /health/detailed added as auth-gated endpoint.
+"""
+
+import os
+from unittest.mock import patch
 
 
 class TestHealthCheck:
-    """Main health check endpoint tests."""
+    """Public minimal health check endpoint tests."""
 
     def test_health_returns_200(self, client):
         """Test GET /health returns 200 OK."""
@@ -15,30 +22,80 @@ class TestHealthCheck:
         data = response.json()
         assert data["status"] == "healthy"
 
-    def test_health_includes_database(self, client):
-        """Test health response includes database check."""
+    def test_health_does_not_disclose_commit(self, client):
+        """Public /health must NOT expose commit hash (reconnaissance surface)."""
         response = client.get("/health")
         data = response.json()
-        assert "database" in data
-        assert data["database"] == "connected"
+        assert "commit" not in data, "Public /health must not expose commit SHA"
 
-    def test_health_includes_commit(self, client):
-        """Test health response includes commit field."""
+    def test_health_does_not_disclose_version(self, client):
+        """Public /health must NOT expose version (reconnaissance surface)."""
         response = client.get("/health")
         data = response.json()
-        assert "commit" in data
+        assert "version" not in data, "Public /health must not expose app version"
 
-    def test_health_includes_service_name(self, client):
-        """Test health response includes service name."""
+    def test_health_does_not_disclose_email_config(self, client):
+        """Public /health must NOT expose email provider (recon surface)."""
         response = client.get("/health")
         data = response.json()
-        assert data["service"] == "rivaflow-api"
+        assert "email" not in data, "Public /health must not expose email config"
 
-    def test_health_includes_version(self, client):
-        """Test health response includes version field."""
+    def test_health_does_not_disclose_database_label(self, client):
+        """Public /health must NOT expose database connection label."""
         response = client.get("/health")
         data = response.json()
-        assert "version" in data
+        assert "database" not in data, "Public /health must not expose DB label"
+
+    def test_health_does_not_disclose_service_name(self, client):
+        """Public /health must NOT expose service identifier."""
+        response = client.get("/health")
+        data = response.json()
+        assert "service" not in data, "Public /health must not expose service name"
+
+
+class TestDetailedHealthCheck:
+    """Auth-gated detailed health endpoint tests.
+
+    Returns 404 when token is missing/wrong so endpoint existence is concealed.
+    """
+
+    def test_detailed_health_404_without_token(self, client):
+        """No X-Admin-Token → 404 (not 401/403; conceals existence)."""
+        response = client.get("/health/detailed")
+        assert response.status_code == 404
+
+    def test_detailed_health_404_with_wrong_token(self, client):
+        """Wrong X-Admin-Token → 404."""
+        with patch.dict(os.environ, {"HEALTH_DETAILED_TOKEN": "expected-secret"}):
+            response = client.get(
+                "/health/detailed", headers={"X-Admin-Token": "wrong-secret"}
+            )
+            assert response.status_code == 404
+
+    def test_detailed_health_404_when_env_var_unset(self, client):
+        """Unset HEALTH_DETAILED_TOKEN env var → 404 even with any token (fail closed)."""
+        # Ensure the env var is genuinely unset for this test
+        if "HEALTH_DETAILED_TOKEN" in os.environ:
+            del os.environ["HEALTH_DETAILED_TOKEN"]
+        response = client.get(
+            "/health/detailed", headers={"X-Admin-Token": "any-value"}
+        )
+        assert response.status_code == 404
+
+    def test_detailed_health_200_with_correct_token(self, client):
+        """Correct X-Admin-Token → 200 + full payload."""
+        with patch.dict(os.environ, {"HEALTH_DETAILED_TOKEN": "expected-secret"}):
+            response = client.get(
+                "/health/detailed", headers={"X-Admin-Token": "expected-secret"}
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "healthy"
+            assert data["service"] == "rivaflow-api"
+            assert "version" in data
+            assert "commit" in data
+            assert "email" in data
+            assert "database" in data
 
 
 class TestReadinessCheck:


### PR DESCRIPTION
## Summary

Following the joint Sage + Groot codebase review on 2026-05-24, this PR addresses the highest-priority code-level finding: **public `/health` exposed reconnaissance-grade detail to unauthenticated probes**.

- 🔴 Public `/health` returns `{"status": "healthy"}` only. DB check still cascades 503.
- 🟡 New `/health/detailed` gated by `X-Admin-Token` matching `HEALTH_DETAILED_TOKEN` env var. Returns 404 to conceal endpoint existence when token is missing/wrong.
- ✅ Tests updated: anti-disclosure assertions + auth-flow coverage.
- 📝 `docs/SECURITY_AUDIT_2026_05_24.md` records findings + open followups.

## Context

Groot's read-only Render+GitHub audit (2026-05-24T12:14) flagged the disclosure as the highest priority production-API issue. GitLeaks scan ran in parallel — 14 findings, all classified by Sage as test placeholders or history-only doc examples (zero live secrets in HEAD).

## Diff highlights

**Before** (public):
```json
{"status":"healthy","service":"rivaflow-api","version":"0.5.0","commit":"c7b43de1e2d2","email":{"enabled":true,"method":"sendgrid"},"database":"connected"}
```

**After** (public):
```json
{"status":"healthy"}
```

**`/health/detailed` without token:**
```
HTTP/1.1 404 Not Found
{"detail":"Not Found"}
```

**`/health/detailed` with `X-Admin-Token: <expected>`:** full historical payload.

## Test plan

- [ ] CI: existing test_health_routes.py replaced with new shape — all 13 tests should pass
- [ ] Local: `curl https://rivaflow-api-v2.onrender.com/health` should return minimal payload after deploy
- [ ] Local: `curl -H "X-Admin-Token: <wrong>" .../health/detailed` should return 404
- [ ] After deploy: set `HEALTH_DETAILED_TOKEN` env var on Render before relying on `/health/detailed`

## Open followups (not in this PR)

- Set `SENTRY_DSN` env var on Render — SDK is wired but DSN missing → no events flowing
- Set Render's health check path to `/health/live` (currently empty)
- Consolidate duplicate `/web/` vs `rivaflow/web/` trees (sync foot-gun)
- Plan Postgres HA / multi-region upgrade

## Risk + rollback

- Tests cover the new shape; deploy-time risk is low
- Existing monitors that parsed `/health` for version/commit will need to switch to `/health/detailed` (with token) or `/health/live`
- Rollback: revert this commit, redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sage)