### PR TITLE
fix(deps): bump fastapi+starlette to clear CVE PYSEC-2026-161

### DIFF
--- a/rivaflow/requirements.txt
+++ b/rivaflow/requirements.txt
@@ -3,7 +3,8 @@
 # Run `pip-audit` periodically to check for vulnerabilities
 
 # Core framework
-fastapi==0.128.4
+fastapi==0.135.4  # Bumped from 0.128.4 to allow starlette>=1.0.1 (CVE PYSEC-2026-161). Range now starlette>=0.46.0.
+starlette==1.0.1  # CVE PYSEC-2026-161 fix (was 0.52.1 transitively from fastapi 0.128.4)
 uvicorn[standard]==0.40.0
 gunicorn==23.0.0
 typer==0.21.1

--- a/rivaflow/rivaflow/core/services/user_service.py
+++ b/rivaflow/rivaflow/core/services/user_service.py
@@ -171,8 +171,12 @@ class UserService:
                     # Belt rank is publicly discoverable (it's training context, not PII).
                     "current_grade": profile.get("current_grade"),
                     # Gym, location, state, and bio are restricted to connected users.
-                    "default_gym": profile.get("default_gym") if can_see_full_profile else None,
-                    "location": profile.get("location") if can_see_full_profile else None,
+                    "default_gym": (
+                        profile.get("default_gym") if can_see_full_profile else None
+                    ),
+                    "location": (
+                        profile.get("location") if can_see_full_profile else None
+                    ),
                     "state": profile.get("state") if can_see_full_profile else None,
                     "bio": profile.get("bio") if can_see_full_profile else None,
                 }


### PR DESCRIPTION
## Summary

Bump fastapi 0.128.4 → 0.135.4 and pin starlette==1.0.1 to clear **CVE PYSEC-2026-161** (published since 2026-05-18, currently blocking Dependency Security Scan on all PRs).

## Why this bump shape

- starlette 0.52.1 is vulnerable; 1.0.1 is the fix.
- fastapi 0.128.4 caps `starlette<1.0.0`, so the patch can't apply without a fastapi bump.
- fastapi 0.135.0 is the smallest version that drops the upper bound (now `starlette>=0.46.0`).
- fastapi 0.135.4 is the latest patch within 0.135.x — safer than jumping to 0.136.

## Breaking-change exposure scan (0.128 → 0.135)

- `ORJSONResponse` / `UJSONResponse` deprecated — `grep -rn 'ORJSONResponse\\|UJSONResponse' rivaflow/` returns nothing. ✓ No app-side change required.

## Risk

7 minor version jumps in 3 months. Unrelated API drift possible. CI is the verification surface — backend tests + CodeQL + frontend tests.

## Test plan

- [ ] Dependency Security Scan: should now pass (no known CVEs)
- [ ] Backend Tests (Python): existing test suite is the regression detector
- [ ] CodeQL Security Analysis (python): structural check
- [ ] Locally: `pip install -r rivaflow/requirements.txt` resolves clean
- [ ] After deploy: smoke-test `/health`, login, key endpoints

## Rollback

Revert this commit, redeploy. starlette 0.52.1 returns; CVE bleeds again.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sage)