### PR TITLE
feat(api-keys): user-equivalent API keys for service-to-service auth

### DIFF
--- a/rivaflow/rivaflow/api/main.py
+++ b/rivaflow/rivaflow/api/main.py
@@ -39,6 +39,7 @@ from rivaflow.api.routes import (
     admin_gyms,
     admin_users,
     analytics,
+    api_keys,
     auth,
     checkins,
     coach_preferences,
@@ -290,6 +291,7 @@ app.include_router(glossary.router, prefix="/api/v1/glossary", tags=["glossary"]
 app.include_router(friends.router, prefix="/api/v1/friends", tags=["friends"])
 app.include_router(groups.router, prefix="/api/v1/groups", tags=["groups"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
+app.include_router(api_keys.router, prefix="/api/v1/users/me", tags=["api-keys"])
 app.include_router(analytics.router, prefix="/api/v1/analytics", tags=["analytics"])
 app.include_router(goals.router, prefix="/api/v1/goals", tags=["goals"])
 app.include_router(

--- a/rivaflow/rivaflow/api/routes/api_keys.py
+++ b/rivaflow/rivaflow/api/routes/api_keys.py
@@ -1,0 +1,106 @@
+"""API key management endpoints (feat/api-keys).
+
+Per-user API keys with user-equivalent permissions. Raw key returned exactly
+once at creation; thereafter only metadata + the display prefix are visible.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from rivaflow.core.dependencies import get_current_user
+from rivaflow.core.error_handling import route_error_handler
+from rivaflow.core.models import (
+    ApiKeyCreate,
+    ApiKeyCreatedResponse,
+    ApiKeyMetadata,
+)
+from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get(
+    "/api-keys",
+    response_model=list[ApiKeyMetadata],
+    tags=["api-keys"],
+)
+@route_error_handler("list_api_keys", detail="Failed to list API keys")
+def list_api_keys(current_user: dict = Depends(get_current_user)) -> list[dict]:
+    """List the authenticated user's API keys (active + revoked).
+
+    Never returns the raw key. To see the actual value of a key, you must
+    generate a new one — old raw values are deliberately unrecoverable.
+    """
+    user_id: int = current_user["id"]
+    return ApiKeyRepository.list_by_user(user_id)
+
+
+@router.post(
+    "/api-keys",
+    response_model=ApiKeyCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["api-keys"],
+)
+@route_error_handler("create_api_key", detail="Failed to create API key")
+def create_api_key(
+    req: ApiKeyCreate,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """Generate a new API key.
+
+    The raw key value is returned EXACTLY ONCE in this response. The server
+    only persists a SHA-256 hash. Subsequent list/get calls never include the
+    raw value.
+
+    Use the returned key as an HTTP Bearer credential:
+
+        Authorization: Bearer rf_pk_<the-key>
+
+    Keys carry the same authorization as the issuing user.
+    """
+    user_id: int = current_user["id"]
+    raw_key = ApiKeyRepository.generate_raw_key()
+    row = ApiKeyRepository.create(user_id=user_id, name=req.name, raw_key=raw_key)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to persist API key",
+        )
+    logger.info(
+        "API key created — user_id=%s name=%s prefix=%s",
+        user_id,
+        req.name,
+        row["key_prefix"],
+    )
+    return {**row, "raw_key": raw_key}
+
+
+@router.delete(
+    "/api-keys/{api_key_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["api-keys"],
+)
+@route_error_handler("revoke_api_key", detail="Failed to revoke API key")
+def revoke_api_key(
+    api_key_id: int,
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    """Revoke an API key.
+
+    Idempotent: revoking an already-revoked or non-existent key returns 404 so
+    the client knows there was no live key to revoke.
+    """
+    user_id: int = current_user["id"]
+    ok = ApiKeyRepository.revoke(api_key_id, user_id)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="API key not found or already revoked",
+        )
+    logger.info("API key revoked — id=%s user_id=%s", api_key_id, user_id)
+    return None

--- a/rivaflow/rivaflow/core/dependencies.py
+++ b/rivaflow/rivaflow/core/dependencies.py
@@ -9,6 +9,10 @@ from jwt.exceptions import PyJWTError
 from rivaflow.core.auth import decode_access_token
 from rivaflow.core.exceptions import AuthenticationError, ForbiddenError
 from rivaflow.core.utils.cache import get_cache
+from rivaflow.db.repositories.api_key_repo import (
+    KEY_PREFIX_LITERAL,
+    ApiKeyRepository,
+)
 from rivaflow.db.repositories.user_repo import UserRepository
 
 logger = logging.getLogger(__name__)
@@ -16,32 +20,98 @@ logger = logging.getLogger(__name__)
 # User cache TTL — short enough that permission changes propagate quickly
 _USER_CACHE_TTL = 60  # seconds
 
-# HTTP Bearer token security scheme
+# HTTP Bearer token security scheme — accepts either a JWT (existing) OR an
+# API key (`rf_pk_...`). Both arrive in `Authorization: Bearer <value>`; we
+# discriminate by the key prefix below.
 security = HTTPBearer()
+
+
+def _load_user_with_cache(user_id: int) -> dict:
+    """Resolve a user id → user dict, cached for _USER_CACHE_TTL seconds.
+
+    Shared by both the JWT path and the API key path so subsequent requests
+    within the cache window don't re-hit the database.
+    """
+    cache = get_cache()
+    cache_key = f"user:{user_id}"
+    from rivaflow.core.utils.cache import _MISSING
+
+    cached_user = cache.get(cache_key)
+    if cached_user is not _MISSING:
+        return cached_user  # type: ignore[no-any-return]
+
+    user_repo = UserRepository()
+    user = user_repo.get_by_id(user_id)
+
+    if user is None:
+        raise AuthenticationError(message="User not found")
+
+    if not user.get("is_active"):
+        raise AuthenticationError(message="User account is inactive")
+
+    # Strip sensitive fields before caching/returning.
+    user.pop("hashed_password", None)
+
+    cache.set(cache_key, user, _USER_CACHE_TTL)
+    return user
 
 
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> dict:
     """
-    Dependency to extract and validate JWT token from Authorization header.
+    Dependency that authenticates either a JWT or an API key from
+    `Authorization: Bearer <token>`.
 
-    Uses a short-lived in-memory cache to avoid hitting the database
-    on every single authenticated request.
+    Discrimination:
+        - Token starts with `rf_pk_` → look up `api_keys` by SHA-256 hash,
+          confirm not revoked, bump `last_used_at`, return owning user.
+        - Otherwise → decode as a short-lived access JWT and load the user.
+
+    Uses a short-lived in-memory cache (post-resolution) so the database is
+    not hit on every authenticated request.
 
     Args:
-        credentials: HTTP Authorization credentials (Bearer token)
+        credentials: HTTP Authorization credentials (Bearer token).
 
     Returns:
         User dictionary with id, email, first_name, last_name, etc.
 
     Raises:
-        AuthenticationError: If token is invalid, expired, or user not found
+        AuthenticationError: If the credential is invalid, expired, revoked,
+        or the user is missing/inactive.
     """
     token = credentials.credentials
 
+    # ── API key path ────────────────────────────────────────────────────────
+    if token.startswith(KEY_PREFIX_LITERAL):
+        try:
+            key_hash = ApiKeyRepository.hash_key(token)
+            api_key = ApiKeyRepository.get_active_by_hash(key_hash)
+            if api_key is None:
+                raise AuthenticationError(message="Invalid or revoked API key")
+
+            user = _load_user_with_cache(api_key["user_id"])
+
+            # Best-effort last-used bump — never fatal to the auth path.
+            try:
+                ApiKeyRepository.update_last_used(api_key["id"])
+            except Exception as bump_err:  # pragma: no cover — non-critical
+                logger.warning(
+                    "update_last_used failed for api_key id=%s: %s",
+                    api_key["id"],
+                    bump_err,
+                )
+
+            return user
+        except AuthenticationError:
+            raise
+        except (ValueError, KeyError, TypeError) as e:
+            logger.error("API key authentication error: %s", e)
+            raise AuthenticationError(message="Authentication failed")
+
+    # ── JWT path (existing behaviour) ───────────────────────────────────────
     try:
-        # Decode JWT token
         payload = decode_access_token(token)
         if payload is None:
             raise AuthenticationError(message="Could not validate credentials")
@@ -51,40 +121,13 @@ async def get_current_user(
         if user_id is None:
             raise AuthenticationError(message="Invalid authentication credentials")
 
-        # Check cache first
-        cache = get_cache()
-        cache_key = f"user:{user_id}"
-        from rivaflow.core.utils.cache import _MISSING
-
-        cached_user = cache.get(cache_key)
-        if cached_user is not _MISSING:
-            return cached_user  # type: ignore[no-any-return]
-
-        # Cache miss — fetch from database
-        user_repo = UserRepository()
-        user = user_repo.get_by_id(user_id)
-
-        if user is None:
-            raise AuthenticationError(message="User not found")
-
-        # Check if user is active
-        if not user.get("is_active"):
-            raise AuthenticationError(message="User account is inactive")
-
-        # Remove sensitive fields
-        user.pop("hashed_password", None)
-
-        # Cache the user for subsequent requests
-        cache.set(cache_key, user, _USER_CACHE_TTL)
-
-        return user
+        return _load_user_with_cache(user_id)
 
     except PyJWTError:
         raise AuthenticationError(message="Could not validate credentials")
     except AuthenticationError:
         raise
     except (ValueError, KeyError, TypeError) as e:
-        # Log unexpected errors and return generic 401
         logger.error("Authentication error: %s", e)
         raise AuthenticationError(message="Authentication failed")
 

--- a/rivaflow/rivaflow/core/models.py
+++ b/rivaflow/rivaflow/core/models.py
@@ -358,3 +358,34 @@ class Video(VideoCreate):
 
     id: int
     created_at: datetime
+
+
+# ─── API Keys (PR feat/api-keys) ─────────────────────────────────────────────
+
+
+class ApiKeyCreate(BaseModel):
+    """Input for creating a new API key."""
+
+    name: str = Field(
+        ..., min_length=1, max_length=120, description="Human label, e.g. 'Sage MCP'"
+    )
+
+
+class ApiKeyMetadata(BaseModel):
+    """API key as returned in list/lookup responses — never includes the raw secret."""
+
+    id: int
+    name: str
+    key_prefix: str  # e.g. "rf_pk_a1b2c3"
+    created_at: datetime
+    last_used_at: datetime | None = None
+    revoked_at: datetime | None = None
+
+
+class ApiKeyCreatedResponse(ApiKeyMetadata):
+    """Response payload returned ONCE at creation time — contains the raw key."""
+
+    raw_key: str = Field(
+        ...,
+        description="The actual API key value. Store it now — it will never be shown again.",
+    )

--- a/rivaflow/rivaflow/db/migrations/107_create_api_keys.sql
+++ b/rivaflow/rivaflow/db/migrations/107_create_api_keys.sql
@@ -1,0 +1,16 @@
+-- 107_create_api_keys.sql
+-- SQLite local-dev variant of 107_create_api_keys_pg.sql.
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    key_hash TEXT NOT NULL UNIQUE,
+    key_prefix TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_used_at TEXT,
+    revoked_at TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS api_keys_user_id_idx ON api_keys (user_id);
+CREATE INDEX IF NOT EXISTS api_keys_key_hash_idx ON api_keys (key_hash);

--- a/rivaflow/rivaflow/db/migrations/107_create_api_keys_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/107_create_api_keys_pg.sql
@@ -1,0 +1,23 @@
+-- 107_create_api_keys_pg.sql
+-- Add api_keys table for user-owned API key authentication (PG).
+--
+-- A user can mint named API keys with the same authorization scope as their
+-- own user account ("simple, user-equivalent keys" — Sage MCP integration spec).
+-- Keys are stored as SHA-256 hashes; raw values are revealed exactly once at
+-- creation and never persisted in plaintext.
+CREATE TABLE IF NOT EXISTS api_keys (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    key_hash TEXT NOT NULL UNIQUE,
+    key_prefix TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMP WITH TIME ZONE,
+    revoked_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS api_keys_user_id_idx ON api_keys (user_id);
+CREATE INDEX IF NOT EXISTS api_keys_key_hash_idx ON api_keys (key_hash);
+CREATE INDEX IF NOT EXISTS api_keys_user_active_idx
+    ON api_keys (user_id)
+    WHERE revoked_at IS NULL;

--- a/rivaflow/rivaflow/db/repositories/api_key_repo.py
+++ b/rivaflow/rivaflow/db/repositories/api_key_repo.py
@@ -74,14 +74,12 @@ class ApiKeyRepository(BaseRepository):
             )
 
             cursor.execute(
-                convert_query(
-                    """
+                convert_query("""
                     SELECT id, user_id, name, key_prefix, created_at,
                            last_used_at, revoked_at
                     FROM api_keys
                     WHERE id = ?
-                    """
-                ),
+                    """),
                 (api_key_id,),
             )
             row = cursor.fetchone()

--- a/rivaflow/rivaflow/db/repositories/api_key_repo.py
+++ b/rivaflow/rivaflow/db/repositories/api_key_repo.py
@@ -1,0 +1,151 @@
+"""Repository for API key authentication tokens.
+
+Per `feat/api-keys` PR — user-equivalent API keys for service-to-service use
+(Sage MCP integration today; future iOS sync / external webhooks tomorrow).
+Keys are stored as SHA-256 hashes; raw key material is only revealed once at
+creation time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+from rivaflow.db.database import convert_query, execute_insert, get_connection
+from rivaflow.db.repositories.base_repository import BaseRepository
+
+# Public-facing prefix for all RivaFlow API keys: "rf_pk_" + 32 hex chars.
+# `rf` = RivaFlow, `pk` = "personal key" (room to add e.g. `rf_sk_` for service
+# keys later without colliding).
+KEY_PREFIX_LITERAL = "rf_pk_"
+KEY_BODY_LENGTH = 32  # hex characters after the prefix
+KEY_DISPLAY_PREFIX_LENGTH = len(KEY_PREFIX_LITERAL) + 6  # "rf_pk_" + first 6 of body
+
+
+class ApiKeyRepository(BaseRepository):
+    """Data access layer for the api_keys table."""
+
+    @staticmethod
+    def generate_raw_key() -> str:
+        """Generate a fresh API key — returned only once at creation time."""
+        return KEY_PREFIX_LITERAL + secrets.token_hex(KEY_BODY_LENGTH // 2)
+
+    @staticmethod
+    def hash_key(raw_key: str) -> str:
+        """SHA-256 hash of a raw key — what we persist + match against."""
+        return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def display_prefix(raw_key: str) -> str:
+        """Short identifier safe to show in lists: first 12 chars."""
+        return raw_key[:KEY_DISPLAY_PREFIX_LENGTH]
+
+    @staticmethod
+    def create(
+        *,
+        user_id: int,
+        name: str,
+        raw_key: str,
+    ) -> dict:
+        """Create a new API key row.
+
+        Args:
+            user_id: Owning user.
+            name: Human label (e.g. "Sage MCP", "iOS app").
+            raw_key: Already-generated raw key (caller hashes via
+                `ApiKeyRepository.hash_key` and we store only the hash).
+
+        Returns:
+            Created row as dict (without the raw key — caller is responsible
+            for returning the raw key to the user exactly once).
+        """
+        key_hash = ApiKeyRepository.hash_key(raw_key)
+        key_prefix = ApiKeyRepository.display_prefix(raw_key)
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            api_key_id = execute_insert(
+                cursor,
+                """
+                INSERT INTO api_keys (user_id, name, key_hash, key_prefix)
+                VALUES (?, ?, ?, ?)
+                """,
+                (user_id, name, key_hash, key_prefix),
+            )
+
+            cursor.execute(
+                convert_query("""
+                    SELECT id, user_id, name, key_prefix, created_at,
+                           last_used_at, revoked_at
+                    FROM api_keys
+                    WHERE id = ?
+                    """),
+                (api_key_id,),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+    @staticmethod
+    def list_by_user(user_id: int) -> list[dict]:
+        """Return all API keys belonging to a user (active + revoked).
+
+        Raw key material is NEVER returned — only metadata + the display prefix.
+        """
+        return BaseRepository._fetchall(
+            """
+            SELECT id, user_id, name, key_prefix, created_at,
+                   last_used_at, revoked_at
+            FROM api_keys
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            """,
+            (user_id,),
+        )
+
+    @staticmethod
+    def get_active_by_hash(key_hash: str) -> dict | None:
+        """Lookup by hash, only returns non-revoked keys.
+
+        Used by the auth dependency on every request that authenticates with
+        an API key. The query is indexed on key_hash for O(1).
+        """
+        return BaseRepository._fetchone(
+            """
+            SELECT id, user_id, name, key_prefix, created_at,
+                   last_used_at, revoked_at
+            FROM api_keys
+            WHERE key_hash = ? AND revoked_at IS NULL
+            """,
+            (key_hash,),
+        )
+
+    @staticmethod
+    def update_last_used(api_key_id: int) -> None:
+        """Bump last_used_at to now. Called from the auth path post-validation."""
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                convert_query(
+                    """UPDATE api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?"""
+                ),
+                (api_key_id,),
+            )
+
+    @staticmethod
+    def revoke(api_key_id: int, user_id: int) -> bool:
+        """Mark the key revoked. Returns True iff a row was updated.
+
+        Guarded by user_id so a user can only revoke their own keys (route layer
+        already checks via current_user; double-checking here defends against
+        repository misuse).
+        """
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                convert_query("""
+                    UPDATE api_keys
+                    SET revoked_at = CURRENT_TIMESTAMP
+                    WHERE id = ? AND user_id = ? AND revoked_at IS NULL
+                    """),
+                (api_key_id, user_id),
+            )
+            return cursor.rowcount > 0

--- a/rivaflow/rivaflow/db/repositories/api_key_repo.py
+++ b/rivaflow/rivaflow/db/repositories/api_key_repo.py
@@ -46,7 +46,7 @@ class ApiKeyRepository(BaseRepository):
         user_id: int,
         name: str,
         raw_key: str,
-    ) -> dict:
+    ) -> dict | None:
         """Create a new API key row.
 
         Args:
@@ -57,7 +57,8 @@ class ApiKeyRepository(BaseRepository):
 
         Returns:
             Created row as dict (without the raw key — caller is responsible
-            for returning the raw key to the user exactly once).
+            for returning the raw key to the user exactly once), or None if
+            the post-insert SELECT mysteriously returns no row.
         """
         key_hash = ApiKeyRepository.hash_key(raw_key)
         key_prefix = ApiKeyRepository.display_prefix(raw_key)
@@ -73,12 +74,14 @@ class ApiKeyRepository(BaseRepository):
             )
 
             cursor.execute(
-                convert_query("""
+                convert_query(
+                    """
                     SELECT id, user_id, name, key_prefix, created_at,
                            last_used_at, revoked_at
                     FROM api_keys
                     WHERE id = ?
-                    """),
+                    """
+                ),
                 (api_key_id,),
             )
             row = cursor.fetchone()

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,140 @@
+"""Tests for /api/v1/users/me/api-keys endpoints + dual-credential auth.
+
+Per feat/api-keys PR — covers:
+  - create returns the raw key exactly once
+  - list never includes raw key material
+  - revoke makes the key unusable
+  - Bearer rf_pk_<...> authenticates an authorized request
+  - Bearer <jwt> still authenticates after the auth path changes
+  - revoked keys return 401
+"""
+
+from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
+
+
+class TestApiKeyGeneration:
+    """Raw-key generation properties."""
+
+    def test_generate_raw_key_has_prefix(self):
+        key = ApiKeyRepository.generate_raw_key()
+        assert key.startswith("rf_pk_"), f"expected rf_pk_ prefix, got: {key[:8]}"
+
+    def test_generate_raw_key_is_unique(self):
+        seen = {ApiKeyRepository.generate_raw_key() for _ in range(200)}
+        assert len(seen) == 200, "raw keys must be unique under repeated generation"
+
+    def test_hash_key_is_deterministic(self):
+        key = "rf_pk_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert ApiKeyRepository.hash_key(key) == ApiKeyRepository.hash_key(key)
+
+    def test_hash_key_differs_per_input(self):
+        a = ApiKeyRepository.hash_key("rf_pk_aaaa")
+        b = ApiKeyRepository.hash_key("rf_pk_bbbb")
+        assert a != b
+
+    def test_display_prefix_length(self):
+        key = "rf_pk_a1b2c3d4e5f6g7h8i9j0"
+        # "rf_pk_" + 6 chars = 12
+        assert ApiKeyRepository.display_prefix(key) == "rf_pk_a1b2c3"
+
+
+class TestApiKeyEndpoints:
+    """Live endpoint flow: create → list → use → revoke."""
+
+    def test_create_returns_raw_key_exactly_once(self, client, auth_headers):
+        resp = client.post(
+            "/api/v1/users/me/api-keys",
+            headers=auth_headers,
+            json={"name": "Sage MCP"},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["name"] == "Sage MCP"
+        assert data["raw_key"].startswith("rf_pk_")
+        assert data["key_prefix"].startswith("rf_pk_")
+        assert data["revoked_at"] is None
+
+    def test_list_never_includes_raw_key(self, client, auth_headers):
+        client.post(
+            "/api/v1/users/me/api-keys",
+            headers=auth_headers,
+            json={"name": "list-test"},
+        )
+        resp = client.get("/api/v1/users/me/api-keys", headers=auth_headers)
+        assert resp.status_code == 200
+        for entry in resp.json():
+            assert "raw_key" not in entry, "list endpoint must never include raw_key"
+            assert "key_hash" not in entry, "list endpoint must never include key_hash"
+
+    def test_api_key_authenticates_subsequent_request(self, client, auth_headers):
+        created = client.post(
+            "/api/v1/users/me/api-keys",
+            headers=auth_headers,
+            json={"name": "auth-test"},
+        ).json()
+        raw_key = created["raw_key"]
+
+        # Use the raw key as a Bearer credential
+        resp = client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_revoke_makes_key_unusable(self, client, auth_headers):
+        created = client.post(
+            "/api/v1/users/me/api-keys",
+            headers=auth_headers,
+            json={"name": "revoke-test"},
+        ).json()
+        raw_key = created["raw_key"]
+        api_key_id = created["id"]
+
+        # Revoke
+        del_resp = client.delete(
+            f"/api/v1/users/me/api-keys/{api_key_id}",
+            headers=auth_headers,
+        )
+        assert del_resp.status_code == 204
+
+        # Subsequent use returns 401
+        resp = client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+        assert resp.status_code == 401
+
+    def test_revoke_twice_returns_404(self, client, auth_headers):
+        created = client.post(
+            "/api/v1/users/me/api-keys",
+            headers=auth_headers,
+            json={"name": "double-revoke-test"},
+        ).json()
+        api_key_id = created["id"]
+        client.delete(f"/api/v1/users/me/api-keys/{api_key_id}", headers=auth_headers)
+        second = client.delete(
+            f"/api/v1/users/me/api-keys/{api_key_id}",
+            headers=auth_headers,
+        )
+        assert second.status_code == 404
+
+    def test_create_requires_name(self, client, auth_headers):
+        resp = client.post(
+            "/api/v1/users/me/api-keys",
+            headers=auth_headers,
+            json={},
+        )
+        assert resp.status_code == 422
+
+    def test_jwt_still_works_after_dual_auth_change(self, client, auth_headers):
+        """Existing JWT-based clients must keep working after the dual-auth refactor."""
+        resp = client.get("/api/v1/auth/me", headers=auth_headers)
+        assert resp.status_code == 200
+
+    # NB: cross-user revoke isolation is enforced at the SQL layer in
+    # ApiKeyRepository.revoke() via `WHERE id = ? AND user_id = ?`. A route-
+    # level test would need a `second_user_auth_headers` fixture which doesn't
+    # exist in conftest yet — if added later, the test would be:
+    #
+    #     second user DELETEs first user's api_key_id → expect 404
+    #     first user's key still authenticates → 200


### PR DESCRIPTION
## Summary

Adds per-user API keys to RivaFlow. Users mint named keys; raw key is returned **exactly once** at creation; thereafter only SHA-256 hashes are persisted. Keys carry the same authorization as the issuing user (simple shape — granular scopes deferred).

**Auth dependency** now accepts either credential via standard `Authorization: Bearer <token>`:
- Token starts with `rf_pk_` → SHA-256 lookup → check `revoked_at IS NULL` → bump `last_used_at` → return owning user
- Otherwise → decode as short-lived access JWT (existing behaviour, unchanged)

Fully backwards-compatible — all existing JWT flows continue working.

## Motivation

Sage's MCP server (`sage-mcp` on pai-relay) needs a stable credential to call RivaFlow on my behalf for upcoming **BJJ diary capture** (Telegram → Groot → Sage MCP → RivaFlow). Storing my actual password in a service config is unacceptable; service-account-with-long-JWT is fragile. This is the right primitive — used by Sage MCP today, reusable by future iOS sync / webhooks / third parties.

## API surface (new)

| Method | Path | Returns |
|---|---|---|
| `POST` | `/api/v1/users/me/api-keys` | 201 + `ApiKeyCreatedResponse` (incl. raw_key, ONCE) |
| `GET` | `/api/v1/users/me/api-keys` | 200 + `list[ApiKeyMetadata]` (no raw key, no hash) |
| `DELETE` | `/api/v1/users/me/api-keys/{id}` | 204 (404 if not found / already revoked) |

Key format: `rf_pk_` + 32 hex chars (`secrets.token_hex`). Display prefix in lists: first 12 chars (e.g. `rf_pk_a1b2c3`).

## Files

| File | Purpose |
|---|---|
| `db/migrations/107_create_api_keys_pg.sql` | Postgres table + indexes (user_id, key_hash, partial active) |
| `db/migrations/107_create_api_keys.sql` | SQLite local-dev variant |
| `db/repositories/api_key_repo.py` | CRUD + `generate_raw_key()`, `hash_key()`, `get_active_by_hash()` |
| `api/routes/api_keys.py` | FastAPI router (3 endpoints) |
| `core/models.py` | `ApiKeyCreate`, `ApiKeyMetadata`, `ApiKeyCreatedResponse` |
| `core/dependencies.py` | Dual-credential `get_current_user` |
| `api/main.py` | Register router at `/api/v1/users/me` |
| `tests/test_api_keys.py` | 7 test cases (generation properties + endpoint flow + auth path) |

## Frontend (deferred)

UI (Settings → API Keys) intentionally **not** in this PR. The backend alone unblocks Sage MCP integration, which is the immediate need. Will follow up with `feat/api-keys-ui` once you've generated the first key + plugged it into Sage MCP and confirmed end-to-end.

## Test plan

- [ ] CI green on backend tests (12 new test cases for api_keys + existing suite untouched)
- [ ] CI green on Code Quality (black-formatted) + Dependency Security Scan (no new deps)
- [ ] Local: migration applies cleanly to both pg + sqlite
- [ ] After deploy: I generate my first key via `POST /api/v1/users/me/api-keys` with a JWT, paste it to Sage via hidden-stdin, sage-mcp uses it to call `/sessions/range/...` successfully

## Rollback

- Revert this PR
- Render auto-deploys the revert
- `api_keys` table remains in the DB but is orphaned (no harm; can drop later)

## Followups (not in this PR)

- Frontend Settings UI
- Granular scopes (`sessions:write`, etc.) — currently MVP is user-equivalent
- Optional UI to show \`last_used_at\` for spotting abandoned keys
- Optional admin endpoint to inspect any user's keys (for support) — locked down

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sage)