### PR TITLE
hotfix: add missing jinja2 dep (prod boot fix)

### DIFF
--- a/rivaflow/requirements.txt
+++ b/rivaflow/requirements.txt
@@ -59,3 +59,4 @@ python-json-logger==3.3.0
 # together==1.5.35
 # sentence-transformers==3.3.1
 # tiktoken==0.8.0
+jinja2==3.1.6


### PR DESCRIPTION
**PROD-DOWN HOTFIX.** The api worker fails to boot: `ImportError: jinja2 must be installed to use Jinja2Templates` (the app imports Jinja2Templates but jinja2 was missing from requirements.txt — a latent inconsistency on main, exposed by a clean rebuild). Adds jinja2==3.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)