### PR TITLE
feat(ops): Telegram alerts on deploy/backup failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,11 @@ rivaflow-postdeploy-*/
 .playwright-cli/
 playwright-report/
 test-results/
+
+# VPS-only runtime secrets (never commit)
+.notify.env
+.env.prod
+.tunnel.env
+.backup.env
+.renderdb.conn
+*.token

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # RivaFlow DB backup -> restic on Cloudflare R2 (offsite). Run via cron.
 set -euo pipefail
+# Alert on any failure (Telegram via notify.sh; no-op if unconfigured)
+trap 'rc=$?; bash "$(dirname "$0")/notify.sh" "BACKUP FAILED (line $LINENO, rc=$rc)"' ERR
 cd /opt/rivaflow
 set -a; . ./.env.prod; set +a            # S3_* creds
 . ./.backup.env                          # RESTIC_PASSWORD

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -16,7 +16,9 @@ git reset --hard origin/main 2>/dev/null || { log "reset failed"; exit 1; }
 if ! ( sudo -n docker compose -f docker-compose.prod.yml build && \
        sudo -n docker compose -f docker-compose.prod.yml up -d ); then
   log "build/up FAILED -> rollback to $PREV"
-  git reset --hard "$PREV"; sudo -n docker compose -f docker-compose.prod.yml up -d --build; exit 1
+  git reset --hard "$PREV"; sudo -n docker compose -f docker-compose.prod.yml up -d --build
+  bash "$(dirname "$0")/notify.sh" "DEPLOY FAILED (build/up) for ${REMOTE:0:8} — rolled back to ${PREV:0:8}"
+  exit 1
 fi
 
 ok=0
@@ -26,7 +28,9 @@ for i in $(seq 1 24); do
 done
 if [ "$ok" != 1 ]; then
   log "health check FAILED -> rollback to $PREV"
-  git reset --hard "$PREV"; sudo -n docker compose -f docker-compose.prod.yml up -d --build; exit 1
+  git reset --hard "$PREV"; sudo -n docker compose -f docker-compose.prod.yml up -d --build
+  bash "$(dirname "$0")/notify.sh" "DEPLOY health-check FAILED for ${REMOTE:0:8} — rolled back to ${PREV:0:8}"
+  exit 1
 fi
 
 log "deploy OK -> $REMOTE"

--- a/deploy/notify.sh
+++ b/deploy/notify.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Telegram alert helper for RivaFlow VPS ops (deploy/backup failures).
+# Reads creds from /opt/rivaflow/.notify.env (gitignored). No-ops gracefully if
+# unconfigured, so it NEVER breaks the caller.
+#   Usage: notify.sh "message text"
+#   .notify.env needs: TELEGRAM_BOT_TOKEN=...  TELEGRAM_CHAT_ID=...
+set -u
+msg="${1:-RivaFlow alert}"
+ENVF=/opt/rivaflow/.notify.env
+[ -f "$ENVF" ] || { echo "notify: no $ENVF — skipping"; exit 0; }
+. "$ENVF"
+[ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] || { echo "notify: creds unset — skipping"; exit 0; }
+host=$(hostname 2>/dev/null || echo vps)
+curl -s -m 10 -o /dev/null \
+  -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+  --data-urlencode "text=⚠️ RivaFlow [${host}]: ${msg}" \
+  --data-urlencode "disable_web_page_preview=true" \
+  && echo "notify: sent"


### PR DESCRIPTION
Adds Telegram alerting for VPS deploy + backup failures (the jinja2 outage needed manual detection). `deploy/notify.sh` reads creds from `/opt/rivaflow/.notify.env` and no-ops gracefully if unconfigured. Wired into deploy.sh (failure+rollback) and backup.sh (ERR trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)