### PR TITLE
fix(ops): RivaFlow alerts via existing Hermes Telegram (hermes send)

### DIFF
--- a/deploy/notify.sh
+++ b/deploy/notify.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
-# Telegram alert helper for RivaFlow VPS ops (deploy/backup failures).
-# Reads creds from /opt/rivaflow/.notify.env (gitignored). No-ops gracefully if
-# unconfigured, so it NEVER breaks the caller.
+# RivaFlow VPS ops alerts (deploy/backup failures) -> routed through the EXISTING
+# Hermes/Groot Telegram connection via `hermes send` (reuses the gateway's
+# Telegram creds — no new bot, no token stored here). No-ops gracefully on any
+# failure so it NEVER breaks the caller.
 #   Usage: notify.sh "message text"
-#   .notify.env needs: TELEGRAM_BOT_TOKEN=...  TELEGRAM_CHAT_ID=...
 set -u
-msg="${1:-RivaFlow alert}"
-ENVF=/opt/rivaflow/.notify.env
-[ -f "$ENVF" ] || { echo "notify: no $ENVF — skipping"; exit 0; }
-. "$ENVF"
-[ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] || { echo "notify: creds unset — skipping"; exit 0; }
 host=$(hostname 2>/dev/null || echo vps)
-curl -s -m 10 -o /dev/null \
-  -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-  --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
-  --data-urlencode "text=⚠️ RivaFlow [${host}]: ${msg}" \
-  --data-urlencode "disable_web_page_preview=true" \
-  && echo "notify: sent"
+printf '%s' "⚠️ RivaFlow [${host}]: ${1:-alert}" \
+  | sudo -n -u pai-hermes env HERMES_HOME=/home/pai-hermes/.hermes \
+      hermes send -t telegram -f - --quiet 2>/dev/null \
+  && echo "notify: sent via hermes/telegram" \
+  || echo "notify: hermes send unavailable (non-fatal)"


### PR DESCRIPTION
Routes deploy/backup failure alerts through Groot's EXISTING Telegram connection via `hermes send` — no new bot/token, no .notify.env. Reuses the gateway's configured Telegram (sends to Ruby, chat 7953335397; test alert already verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)