### PR TITLE
fix(db): don't mark migrations applied when non-optional statements fail (root cause of #61)

### DIFF
--- a/rivaflow/rivaflow/db/database.py
+++ b/rivaflow/rivaflow/db/database.py
@@ -356,6 +356,7 @@ def _apply_migrations(
                 # Split on semicolons and execute separately
                 statements = [s.strip() for s in sql.split(";") if s.strip()]
                 stmt_failures = 0
+                hard_failures = 0  # non-optional failures (not CREATE EXTENSION)
                 for statement in statements:
                     if not statement:
                         continue
@@ -382,6 +383,13 @@ def _apply_migrations(
                         cursor.execute("RELEASE SAVEPOINT migration_stmt")
                     except Exception as e:
                         stmt_failures += 1
+                        # CREATE EXTENSION failures are tolerated (e.g. pgvector
+                        # not installed); any other failed statement is a "hard"
+                        # failure meaning the schema change did not take effect.
+                        if not clean_statement.upper().lstrip().startswith(
+                            "CREATE EXTENSION"
+                        ):
+                            hard_failures += 1
                         logger.warning(
                             f"Statement failed (rolling back): "
                             f"{clean_statement[:100]}... - {e}"
@@ -394,9 +402,22 @@ def _apply_migrations(
                             f"Migration {migration}: ALL {stmt_failures} "
                             f"statement(s) failed — aborting deployment"
                         )
+                    if hard_failures:
+                        # A non-optional statement failed → the schema change did
+                        # NOT fully take effect. Do NOT record this migration as
+                        # applied, so it retries on the next boot rather than
+                        # leaving a silent gap (root cause of the missing api_keys
+                        # table / issue #61). Persist whatever DID succeed.
+                        logger.error(
+                            f"Migration {migration}: {hard_failures} non-optional "
+                            f"statement(s) failed — NOT recording as applied; will "
+                            f"retry next boot"
+                        )
+                        conn.commit()
+                        continue
                     logger.warning(
                         f"Migration {migration}: {stmt_failures} of "
-                        f"{len(statements)} statement(s) failed (non-fatal)"
+                        f"{len(statements)} optional statement(s) failed (non-fatal)"
                     )
 
             # Record this migration as applied


### PR DESCRIPTION
## Why
Issue #61 ("api-key creation 500s") had a deeper root cause than the route. The `api_keys` table **never existed on the VPS Postgres**, yet migration `107_create_api_keys.sql` was recorded as applied (2026-05-26).

`_apply_migrations` wraps each statement in a `SAVEPOINT` and only aborts if **all** statements fail; on partial failure it logs a warning and **records the migration as applied anyway**. So a `CREATE TABLE` written in SQLite dialect (`INTEGER PRIMARY KEY AUTOINCREMENT`, `datetime('now')`) fails on Postgres, gets swallowed, and the migration is marked done — a permanent silent gap. The existing `_ensure_critical_columns()` band-aid exists precisely because of this failure class; it just didn't cover the `api_keys` table.

## Fix
Distinguish **optional** from **hard** statement failures:
- `CREATE EXTENSION` failures stay tolerated (e.g. pgvector not installed) — unchanged.
- Any other failed statement is a **hard** failure → the schema change didn't take effect → **do not record the migration as applied** (commit what succeeded, retry next boot).

This fixes the whole class, not just `api_keys`, with no change to the intentional pgvector tolerance.

## Note
The HTTP create-key route itself is fine on Postgres — `execute_insert` already uses `RETURNING id`. The only fault was the missing table. The `api_keys` table has already been created on prod manually (idempotent `107_create_api_keys_pg.sql`) and an `rf_pk_…` key minted for the Sage MCP integration; this PR prevents the silent-gap recurrence.

## Test
- `python -m py_compile` clean; failure-classifier unit-checked (CREATE TABLE/INDEX/ALTER → hard; CREATE EXTENSION → optional).
- Full suite needs a Postgres `DATABASE_URL` — deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)