### PR TITLE
feat(whoop): Phase 1a subscription-free WHOOP ingest [GATED — review only]

### DIFF
--- a/rivaflow/rivaflow/api/main.py
+++ b/rivaflow/rivaflow/api/main.py
@@ -42,6 +42,7 @@ from rivaflow.api.routes import (
     api_keys,
     auth,
     garmin,
+    whoop,
     checkins,
     coach_preferences,
     dashboard,
@@ -295,6 +296,7 @@ app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
 app.include_router(api_keys.router, prefix="/api/v1/users/me", tags=["api-keys"])
 app.include_router(analytics.router, prefix="/api/v1/analytics", tags=["analytics"])
 app.include_router(garmin.router, prefix="/api/v1", tags=["garmin"])
+app.include_router(whoop.router, prefix="/api/v1", tags=["whoop"])
 app.include_router(goals.router, prefix="/api/v1/goals", tags=["goals"])
 app.include_router(
     training_goals.router,

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -114,8 +114,8 @@ def ingest(payload: WhoopIngest, current_user: dict = Depends(get_current_user))
 @route_error_handler("whoop_capture_health", detail="Failed to fetch WHOOP capture health")
 def capture_health(current_user: dict = Depends(get_current_user)) -> dict:
     """Last-seen heartbeat + recent ingest volume for gap detection."""
-    from rivaflow.db.repositories.base_repository import BaseRepository
     from rivaflow.db.database import convert_query
+    from rivaflow.db.repositories.base_repository import BaseRepository
 
     latest = BaseRepository._fetchone(
         convert_query(

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -1,0 +1,127 @@
+"""Subscription-free WHOOP data-platform endpoints (Phase 1a).
+
+- POST /whoop/ingest — batched, idempotent, raw-first ingest from the Goose iOS app
+  (WhoopVpsUploader). Stores every raw BLE frame (even undecoded) plus decoded
+  HR / RR / HRV / battery streams, all scoped to the authenticated user.
+- GET  /whoop/capture-health — last-seen heartbeat + recent ingest volume, for
+  gap detection (WHOOP is the only biometric source now that Garmin is gone).
+
+Session-level rollups and the R22 decode land in later phases; this owns capture.
+See docs DATA-PLATFORM-BUILD-PLAN.md in the goose-whoop5 repo.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from rivaflow.core.dependencies import get_current_user
+from rivaflow.core.error_handling import route_error_handler
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/whoop", tags=["whoop"])
+
+
+class RawFrame(BaseModel):
+    ts: str
+    char_uuid: str
+    hex: str
+    packet_type: int | None = None
+    seq: int | None = None
+    session_id: str | None = None
+
+
+class HrSample(BaseModel):
+    ts: str
+    bpm: int
+    session_id: str | None = None
+
+
+class RrSample(BaseModel):
+    ts: str
+    rr_ms: int
+    session_id: str | None = None
+
+
+class HrvSample(BaseModel):
+    ts: str
+    rmssd: float | None = None
+    rr_count: int | None = None
+    window_s: int | None = None
+    at_rest: bool | None = None
+
+
+class BatterySample(BaseModel):
+    ts: str
+    soc: int | None = None
+    charging: bool | None = None
+
+
+class WhoopIngest(BaseModel):
+    """Batched upload from the Goose iOS app (offline-buffered, retry-safe)."""
+
+    device: str | None = None
+    kind: str | None = "realtime"  # 'realtime' | 'historical_drain'
+    batch_id: str | None = None
+    raw_frames: list[RawFrame] = Field(default_factory=list)
+    hr: list[HrSample] = Field(default_factory=list)
+    rr: list[RrSample] = Field(default_factory=list)
+    hrv: list[HrvSample] = Field(default_factory=list)
+    battery: list[BatterySample] = Field(default_factory=list)
+
+
+def _span(payload: WhoopIngest) -> tuple[str | None, str | None]:
+    """Min/max ts across everything in the batch (for the capture-health heartbeat)."""
+    ts = (
+        [f.ts for f in payload.raw_frames] + [s.ts for s in payload.hr]
+        + [s.ts for s in payload.rr] + [s.ts for s in payload.hrv]
+        + [s.ts for s in payload.battery]
+    )
+    return (min(ts), max(ts)) if ts else (None, None)
+
+
+@router.post("/ingest")
+@route_error_handler("whoop_ingest", detail="Failed to ingest WHOOP data")
+def ingest(payload: WhoopIngest, current_user: dict = Depends(get_current_user)) -> dict:
+    """Idempotent raw-first ingest for the authenticated user."""
+    user_id: int = current_user["id"]
+
+    raw = WhoopRepository.ingest_raw_frames(user_id, [f.model_dump() for f in payload.raw_frames])
+    hr = WhoopRepository.ingest_hr(user_id, [s.model_dump() for s in payload.hr])
+    rr = WhoopRepository.ingest_rr(user_id, [s.model_dump() for s in payload.rr])
+    hrv = WhoopRepository.ingest_hrv(user_id, [s.model_dump() for s in payload.hrv])
+    battery = WhoopRepository.ingest_battery(user_id, [s.model_dump() for s in payload.battery])
+
+    counts = {
+        "raw": raw["received"], "rejected": raw["rejected"],
+        "hr": hr, "rr": rr, "hrv": hrv, "battery": battery,
+    }
+    span_start, span_end = _span(payload)
+    WhoopRepository.log_ingest(user_id, payload.device, payload.kind, counts, span_start, span_end)
+
+    logger.info(
+        "WHOOP ingest — user_id=%s device=%s kind=%s raw=%s rejected=%s hr=%s rr=%s hrv=%s batt=%s",
+        user_id, payload.device, payload.kind, raw["received"], raw["rejected"], hr, rr, hrv, battery,
+    )
+    return {"accepted": counts, "span": {"start": span_start, "end": span_end}}
+
+
+@router.get("/capture-health")
+@route_error_handler("whoop_capture_health", detail="Failed to fetch WHOOP capture health")
+def capture_health(current_user: dict = Depends(get_current_user)) -> dict:
+    """Last-seen heartbeat + recent ingest volume for gap detection."""
+    from rivaflow.db.repositories.base_repository import BaseRepository
+    from rivaflow.db.database import convert_query
+
+    latest = BaseRepository._fetchone(
+        convert_query(
+            "SELECT ingested_at, device, kind, raw_frames, hr, rr, hrv, span_start, span_end "
+            "FROM whoop_ingest_log WHERE user_id = ? ORDER BY ingested_at DESC LIMIT 1"
+        ),
+        (current_user["id"],),
+    )
+    return {"latest": latest}

--- a/rivaflow/rivaflow/db/migrations/109_whoop_ingest.sql
+++ b/rivaflow/rivaflow/db/migrations/109_whoop_ingest.sql
@@ -1,0 +1,52 @@
+-- 109_whoop_ingest.sql
+-- Subscription-free WHOOP data platform — Phase 1a ingest tables (SQLite / local dev).
+-- See 109_whoop_ingest_pg.sql for the PostgreSQL (production) variant + design notes.
+-- RAW-FIRST: whoop_raw_frames is the immutable source of truth; decoded tables are rebuildable.
+-- All tables user-scoped; ingest idempotent (dedup on frame hash / ts).
+
+CREATE TABLE IF NOT EXISTS whoop_raw_frames (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts            TEXT    NOT NULL,              -- ISO-8601
+    frame_sha256  TEXT    NOT NULL,              -- hex sha256, dedup key
+    session_id    TEXT,
+    char_uuid     TEXT    NOT NULL,
+    packet_type   INTEGER,
+    seq           INTEGER,
+    frame_hex     TEXT    NOT NULL,
+    decoded       INTEGER NOT NULL DEFAULT 0,
+    ingested_at   TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (user_id, ts, frame_sha256)
+);
+CREATE INDEX IF NOT EXISTS idx_whoop_raw_user_ts ON whoop_raw_frames (user_id, ts);
+
+CREATE TABLE IF NOT EXISTS whoop_hr (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TEXT NOT NULL, bpm INTEGER NOT NULL, session_id TEXT,
+    PRIMARY KEY (user_id, ts)
+);
+CREATE TABLE IF NOT EXISTS whoop_rr (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TEXT NOT NULL, rr_ms INTEGER NOT NULL, session_id TEXT,
+    PRIMARY KEY (user_id, ts, rr_ms)
+);
+CREATE TABLE IF NOT EXISTS whoop_hrv (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TEXT NOT NULL, rmssd REAL, rr_count INTEGER, window_s INTEGER, at_rest INTEGER,
+    PRIMARY KEY (user_id, ts)
+);
+CREATE TABLE IF NOT EXISTS whoop_battery (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TEXT NOT NULL, soc INTEGER, charging INTEGER,
+    PRIMARY KEY (user_id, ts)
+);
+
+CREATE TABLE IF NOT EXISTS whoop_ingest_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ingested_at TEXT NOT NULL DEFAULT (datetime('now')),
+    device TEXT, kind TEXT,
+    raw_frames INTEGER, hr INTEGER, rr INTEGER, hrv INTEGER, battery INTEGER,
+    deduped INTEGER, span_start TEXT, span_end TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_whoop_ingest_log_user ON whoop_ingest_log (user_id, ingested_at DESC);

--- a/rivaflow/rivaflow/db/migrations/109_whoop_ingest_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/109_whoop_ingest_pg.sql
@@ -1,0 +1,62 @@
+-- 109_whoop_ingest_pg.sql
+-- Subscription-free WHOOP data platform — Phase 1a ingest tables (PostgreSQL / production).
+-- See 109_whoop_ingest.sql for the SQLite (local dev) variant.
+--
+-- RAW-FIRST: whoop_raw_frames is the immutable, append-only source of truth (every strap frame,
+-- even undecoded). Decoded stream tables are derived and rebuildable from it. All tables are
+-- user-scoped and the ingest is idempotent (dedup on frame hash / ts).
+--
+-- Tables are prefixed whoop_* in the public schema (matches garmin_daily + the existing whoop_*
+-- session columns, and preserves SQLite/PG dialect parity) rather than a PG-only CREATE SCHEMA.
+-- Prod hardening TODO (issue): daily-partition + compress whoop_raw_frames, archive cold to R2.
+
+-- Immutable raw frame log — source of truth
+CREATE TABLE IF NOT EXISTS whoop_raw_frames (
+    id            BIGSERIAL PRIMARY KEY,
+    user_id       INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts            TIMESTAMPTZ NOT NULL,
+    frame_sha256  TEXT        NOT NULL,          -- hex sha256, dedup key
+    session_id    TEXT,
+    char_uuid     TEXT        NOT NULL,          -- e.g. 'fd4b0004' / '2a37'
+    packet_type   INTEGER,                       -- decoded type if known, else NULL
+    seq           INTEGER,
+    frame_hex     TEXT        NOT NULL,
+    decoded       BOOLEAN     NOT NULL DEFAULT FALSE,
+    ingested_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, ts, frame_sha256)
+);
+CREATE INDEX IF NOT EXISTS idx_whoop_raw_user_ts ON whoop_raw_frames (user_id, ts);
+
+-- Decoded streams (rebuildable from raw_frames)
+CREATE TABLE IF NOT EXISTS whoop_hr (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TIMESTAMPTZ NOT NULL, bpm SMALLINT NOT NULL, session_id TEXT,
+    PRIMARY KEY (user_id, ts)
+);
+CREATE TABLE IF NOT EXISTS whoop_rr (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TIMESTAMPTZ NOT NULL, rr_ms INTEGER NOT NULL, session_id TEXT,
+    PRIMARY KEY (user_id, ts, rr_ms)             -- multiple RR can share a ts
+);
+CREATE TABLE IF NOT EXISTS whoop_hrv (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TIMESTAMPTZ NOT NULL, rmssd REAL, rr_count SMALLINT, window_s INTEGER,
+    at_rest BOOLEAN,                             -- HRV only trustworthy at rest (motion-artifact guard)
+    PRIMARY KEY (user_id, ts)
+);
+CREATE TABLE IF NOT EXISTS whoop_battery (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts TIMESTAMPTZ NOT NULL, soc SMALLINT, charging BOOLEAN,
+    PRIMARY KEY (user_id, ts)
+);
+
+-- Capture-health heartbeat — drives gap detection (single biometric source now)
+CREATE TABLE IF NOT EXISTS whoop_ingest_log (
+    id BIGSERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    device TEXT, kind TEXT,                      -- 'realtime' | 'historical_drain'
+    raw_frames INTEGER, hr INTEGER, rr INTEGER, hrv INTEGER, battery INTEGER,
+    deduped INTEGER, span_start TIMESTAMPTZ, span_end TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_whoop_ingest_log_user ON whoop_ingest_log (user_id, ingested_at DESC);

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -1,0 +1,121 @@
+"""Repository for the subscription-free WHOOP data platform (Phase 1a ingest).
+
+Populated by the Goose iOS app's WhoopVpsUploader. Raw-first + idempotent:
+whoop_raw_frames is the immutable source of truth; decoded streams are rebuildable
+from it. Every write is user-scoped and dedup-safe (ON CONFLICT DO NOTHING), so the
+app can retry a batch after a flaky connection without creating duplicates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from rivaflow.db.database import convert_query, get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def _is_hex(s: str) -> bool:
+    """True only for a valid, even-length hex string (guards the raw-frame ingest)."""
+    if not s or len(s) % 2 != 0:
+        return False
+    try:
+        bytes.fromhex(s)
+        return True
+    except ValueError:
+        return False
+
+
+class WhoopRepository:
+    """Idempotent, user-scoped ingest for the whoop_* stream tables."""
+
+    @staticmethod
+    def _insert_ignore(query: str, rows: list[tuple]) -> int:
+        """executemany an INSERT ... ON CONFLICT DO NOTHING; returns rows *received*.
+        (Exact dedup counts are driver-dependent under executemany; ON CONFLICT
+        guarantees idempotency regardless.)"""
+        if not rows:
+            return 0
+        with get_connection() as conn:
+            conn.cursor().executemany(convert_query(query), rows)
+        return len(rows)
+
+    @staticmethod
+    def ingest_raw_frames(user_id: int, frames: list[dict]) -> dict:
+        rows: list[tuple] = []
+        rejected = 0
+        for f in frames:
+            hex_ = (f.get("hex") or "").strip().lower()
+            if not _is_hex(hex_):
+                rejected += 1
+                continue
+            sha = hashlib.sha256(hex_.encode("ascii")).hexdigest()
+            rows.append(
+                (user_id, f["ts"], sha, f.get("session_id"), f["char_uuid"],
+                 f.get("packet_type"), f.get("seq"), hex_)
+            )
+        received = WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_raw_frames "
+            "(user_id, ts, frame_sha256, session_id, char_uuid, packet_type, seq, frame_hex) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT (user_id, ts, frame_sha256) DO NOTHING",
+            rows,
+        )
+        if rejected:
+            logger.warning("whoop raw ingest — user_id=%s rejected=%s non-hex frames", user_id, rejected)
+        return {"received": received, "rejected": rejected}
+
+    @staticmethod
+    def ingest_hr(user_id: int, samples: list[dict]) -> int:
+        rows = [(user_id, s["ts"], s["bpm"], s.get("session_id")) for s in samples]
+        return WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_hr (user_id, ts, bpm, session_id) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT (user_id, ts) DO NOTHING",
+            rows,
+        )
+
+    @staticmethod
+    def ingest_rr(user_id: int, samples: list[dict]) -> int:
+        rows = [(user_id, s["ts"], s["rr_ms"], s.get("session_id")) for s in samples]
+        return WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_rr (user_id, ts, rr_ms, session_id) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT (user_id, ts, rr_ms) DO NOTHING",
+            rows,
+        )
+
+    @staticmethod
+    def ingest_hrv(user_id: int, samples: list[dict]) -> int:
+        rows = [
+            (user_id, s["ts"], s.get("rmssd"), s.get("rr_count"), s.get("window_s"), s.get("at_rest"))
+            for s in samples
+        ]
+        return WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_hrv (user_id, ts, rmssd, rr_count, window_s, at_rest) "
+            "VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT (user_id, ts) DO NOTHING",
+            rows,
+        )
+
+    @staticmethod
+    def ingest_battery(user_id: int, samples: list[dict]) -> int:
+        rows = [(user_id, s["ts"], s.get("soc"), s.get("charging")) for s in samples]
+        return WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_battery (user_id, ts, soc, charging) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT (user_id, ts) DO NOTHING",
+            rows,
+        )
+
+    @staticmethod
+    def log_ingest(user_id: int, device: str | None, kind: str | None, counts: dict,
+                   span_start: str | None, span_end: str | None) -> None:
+        query = convert_query(
+            "INSERT INTO whoop_ingest_log "
+            "(user_id, device, kind, raw_frames, hr, rr, hrv, battery, deduped, span_start, span_end) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        with get_connection() as conn:
+            conn.cursor().execute(query, (
+                user_id, device, kind, counts.get("raw", 0), counts.get("hr", 0),
+                counts.get("rr", 0), counts.get("hrv", 0), counts.get("battery", 0),
+                counts.get("rejected", 0), span_start, span_end,
+            ))


### PR DESCRIPTION
## ⚠️ Gated — do NOT merge/deploy yet
Phase 1a of the WHOOP data platform (see `goose-whoop5` repo: `docs/DATA-PLATFORM-BUILD-PLAN.md`, `vps/INGEST-CONTRACT.md`). Since Garmin is lost, Goose/WHOOP is now the only biometric source — this banks **every strap frame** into your own DB, raw-first.

## What's here
- **Migrations** `109_whoop_ingest.sql` / `_pg.sql` — user-scoped `whoop_raw_frames` (immutable source of truth) + `whoop_hr/rr/hrv/battery` + `whoop_ingest_log` (capture-health heartbeat). Prefixed tables (dialect parity with garmin_daily), not a PG schema.
- **`WhoopRepository`** — idempotent (`ON CONFLICT DO NOTHING`), hex-validated raw frames, `convert_query`/`get_connection` like `garmin_daily_repo`.
- **`POST /api/v1/whoop/ingest`** + **`GET /api/v1/whoop/capture-health`** — `get_current_user` api-key auth, `@route_error_handler`, mirrors `garmin.py`. Fed by the Goose iOS `WhoopVpsUploader` (built next).

## Before merge/deploy (checklist)
- [ ] Review schema + endpoint
- [ ] Run migration 109 on a **staging** DB first
- [ ] Add tests (mirror garmin tests)
- [ ] Build the Goose `WhoopVpsUploader` (step 3) + end-to-end verify: wear → frames land in DB
- [ ] **Then** approve prod deploy

## Design notes / TODO
- Raw volume: partition `whoop_raw_frames` by day + compress + archive cold to R2 (prod hardening).
- HRV `at_rest` flag carried because wrist-PPG HRV is only valid at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)