### PR TITLE
feat(whoop): shared reads + Phase 2 readiness & BJJ analytics

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -13,8 +13,9 @@ See docs DATA-PLATFORM-BUILD-PLAN.md in the goose-whoop5 repo.
 from __future__ import annotations
 
 import logging
+from datetime import date
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from rivaflow.core.dependencies import get_current_user
@@ -125,3 +126,49 @@ def capture_health(current_user: dict = Depends(get_current_user)) -> dict:
         (current_user["id"],),
     )
     return {"latest": latest}
+
+
+# ── Read + analytics (Phase 2 / shared access: RivaFlow UI, health dashboard, LLM/MCP) ──
+
+
+@router.get("/hr")
+@route_error_handler("whoop_hr", detail="Failed to fetch WHOOP heart rate")
+def hr_series(
+    hours: int = Query(6, ge=1, le=168),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    """Recent HR series (last `hours`)."""
+    return WhoopRepository.recent_hr(current_user["id"], hours)
+
+
+@router.get("/hrv")
+@route_error_handler("whoop_hrv", detail="Failed to fetch WHOOP HRV")
+def hrv_series(
+    days: int = Query(30, ge=1, le=365),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    """At-rest HRV (RMSSD) series over the last `days` — the recovery signal."""
+    return WhoopRepository.hrv_range(current_user["id"], days)
+
+
+@router.get("/readiness")
+@route_error_handler("whoop_readiness", detail="Failed to compute readiness")
+def readiness(current_user: dict = Depends(get_current_user)) -> dict:
+    """Ruby Readiness Score — at-rest HRV vs rolling baseline. Sabbath-silent (Sunday rest)."""
+    from rivaflow.core.whoop_analytics import compute_readiness
+
+    is_sabbath = date.today().weekday() == 6  # Sunday = Ruby's rest day (adjust if Saturday-Sabbath)
+    return compute_readiness(current_user["id"], today_is_sabbath=is_sabbath)
+
+
+@router.get("/session-analytics")
+@route_error_handler("whoop_session_analytics", detail="Failed to compute BJJ session analytics")
+def session_analytics(
+    start: str,
+    end: str,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """BJJ roll analytics for a [start, end] window: HR zones, avg/max, best between-round recovery."""
+    from rivaflow.core.whoop_analytics import bjj_session_analytics
+
+    return bjj_session_analytics(current_user["id"], start, end)

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -1,0 +1,104 @@
+"""WHOOP analytics — Ruby Readiness Score + BJJ roll HR analytics.
+
+Computed on-VPS from the whoop_* stream tables (Phase 2). Personal / n-of-1: every score is relative
+to Ruby's OWN rolling baseline, not population norms. Cold-start returns a "building baseline" state
+until enough data has accrued. Wrist-PPG HRV is only trustworthy at rest, so readiness uses at-rest
+HRV only, and BJJ session analytics use HR (not HRV) because motion corrupts beat-to-beat intervals.
+"""
+
+from __future__ import annotations
+
+from statistics import mean, pstdev
+
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+# Ruby's profile-tuned constants
+MAX_HR = 190                      # HR-zone ceiling (44yo; refine from measured max later)
+READINESS_MIN_BASELINE_DAYS = 5   # cold-start guard before a score is meaningful
+
+
+def compute_readiness(user_id: int, today_is_sabbath: bool = False) -> dict:
+    """Readiness from at-rest HRV vs the user's rolling 7-day baseline (Plews/Buchheit style).
+
+    Sabbath-silent: on a rest day it blesses the rest instead of scoring. Conservative bands for a
+    masters, NSAID-sensitive, low-endurance athlete — 'Strained' pushes toward technical work, not hard rolls.
+    """
+    if today_is_sabbath:
+        return {"state": "Rest", "headline": "Sabbath — rest is prescribed. No score today.",
+                "driver": "sabbath", "score": None}
+
+    hrv = WhoopRepository.hrv_range(user_id, days=14, at_rest_only=True)
+    vals = [h["rmssd"] for h in hrv if h.get("rmssd") is not None]
+    if len(vals) < READINESS_MIN_BASELINE_DAYS:
+        return {"state": "Building",
+                "headline": f"Building your HRV baseline ({len(vals)}/{READINESS_MIN_BASELINE_DAYS} days).",
+                "driver": "cold_start", "score": None, "samples": len(vals)}
+
+    baseline = vals[-7:] if len(vals) >= 7 else vals
+    b_mean = mean(baseline)
+    b_sd = pstdev(baseline) or 1.0
+    today = vals[-1]
+    z = (today - b_mean) / b_sd
+
+    if z >= 0.5:
+        state, head = "Prime", "HRV above baseline — green light to train hard."
+    elif z >= -0.5:
+        state, head = "Balanced", "HRV in your normal range — train as planned."
+    elif z >= -1.5:
+        state, head = "Strained", "HRV below baseline — technical/skills over hard rolls today."
+    else:
+        state, head = "Rundown", "HRV well below baseline — prioritise recovery."
+
+    return {
+        "state": state, "headline": head, "driver": "hrv_vs_baseline",
+        "score": max(0, min(100, round(50 + z * 20))),
+        "today_rmssd": round(today, 1), "baseline_rmssd": round(b_mean, 1),
+        "z": round(z, 2), "baseline_days": len(baseline),
+    }
+
+
+def hr_zone(bpm: int, max_hr: int = MAX_HR) -> int:
+    """5-zone model (% of max HR)."""
+    pct = bpm / max_hr
+    if pct < 0.60:
+        return 1
+    if pct < 0.70:
+        return 2
+    if pct < 0.80:
+        return 3
+    if pct < 0.90:
+        return 4
+    return 5
+
+
+def bjj_session_analytics(user_id: int, start_iso: str, end_iso: str) -> dict:
+    """Per-session HR analytics for a BJJ window: time-in-zone, avg/max, and best between-round HR
+    recovery (a hard fitness marker that improves as you progress). HR only — HRV is invalid in motion.
+    Fields mirror RivaFlow's garmin_* session columns so WHOOP sessions sit beside Garmin.
+    """
+    hr = WhoopRepository.hr_range(user_id, start_iso, end_iso)
+    bpms = [h["bpm"] for h in hr if h.get("bpm")]
+    if not bpms:
+        return {"available": False,
+                "reason": "No HR captured in this window — reboot the strap before the next session."}
+
+    zone_secs = {z: 0 for z in range(1, 6)}
+    for b in bpms:
+        zone_secs[hr_zone(b)] += 1   # standard-HR stream is ~1 sample/sec
+
+    # Best 60s HR drop after a peak — approximates between-round recovery.
+    best_recovery = 0
+    for i in range(len(bpms)):
+        window = bpms[i:i + 60]
+        if len(window) >= 30:
+            best_recovery = max(best_recovery, window[0] - min(window))
+
+    return {
+        "available": True,
+        "avg_hr": round(mean(bpms)),
+        "max_hr": max(bpms),
+        "duration_sec": len(bpms),
+        "hr_zone_secs": zone_secs,
+        "best_60s_hr_recovery": best_recovery,
+        "samples": len(bpms),
+    }

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from datetime import UTC, datetime, timedelta
 
 from rivaflow.db.database import convert_query, get_connection
+from rivaflow.db.repositories.base_repository import BaseRepository
 
 logger = logging.getLogger(__name__)
 
@@ -119,3 +121,50 @@ class WhoopRepository:
                 counts.get("rr", 0), counts.get("hrv", 0), counts.get("battery", 0),
                 counts.get("rejected", 0), span_start, span_end,
             ))
+
+    # ── Read side (shared: RivaFlow UI, health dashboard, LLM/MCP all consume these) ──
+
+    @staticmethod
+    def hr_range(user_id: int, start_iso: str, end_iso: str) -> list[dict]:
+        """HR samples within [start, end], ascending — for session zones + charts."""
+        return BaseRepository._fetchall(
+            convert_query(
+                "SELECT ts, bpm FROM whoop_hr WHERE user_id = ? AND ts >= ? AND ts <= ? ORDER BY ts ASC"
+            ),
+            (user_id, start_iso, end_iso),
+        )
+
+    @staticmethod
+    def hrv_range(user_id: int, days: int = 30, at_rest_only: bool = True) -> list[dict]:
+        """HRV (RMSSD) samples over the last `days`, ascending — drives the readiness baseline.
+        Wrist-PPG HRV is only trustworthy at rest, so at_rest_only filters the noise by default."""
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+        rest = "AND at_rest = ? " if at_rest_only else ""
+        params = (user_id, True, cutoff) if at_rest_only else (user_id, cutoff)
+        return BaseRepository._fetchall(
+            convert_query(
+                "SELECT ts, rmssd FROM whoop_hrv WHERE user_id = ? AND rmssd IS NOT NULL "
+                f"{rest}AND ts >= ? ORDER BY ts ASC"
+            ),
+            params,
+        )
+
+    @staticmethod
+    def recent_hr(user_id: int, hours: int = 6) -> list[dict]:
+        """Recent HR series (last `hours`) — for the live/health dashboard."""
+        cutoff = (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+        return BaseRepository._fetchall(
+            convert_query("SELECT ts, bpm FROM whoop_hr WHERE user_id = ? AND ts >= ? ORDER BY ts ASC"),
+            (user_id, cutoff),
+        )
+
+    @staticmethod
+    def latest_capture(user_id: int) -> dict | None:
+        """Most recent ingest heartbeat (capture-health)."""
+        return BaseRepository._fetchone(
+            convert_query(
+                "SELECT ingested_at, device, kind, raw_frames, hr, rr, span_start, span_end "
+                "FROM whoop_ingest_log WHERE user_id = ? ORDER BY ingested_at DESC LIMIT 1"
+            ),
+            (user_id,),
+        )


### PR DESCRIPTION
Shared read endpoints (hr/hrv/capture-health) + Phase 2 readiness (HRV-baseline, Sabbath-silent, cold-start guarded) + BJJ session analytics. Ruff+syntax clean. Additive, no schema change. Readiness populates once HRV flows. Same pre-existing-red CI as #67 (unrelated). 🤖 Generated with Claude Code