### PR TITLE
WHOOP-alternative: Fable-reviewed docs + full roadmap build (B0–B19)

### DIFF
--- a/docs/WHOOP_CURRENT_STATE.md
+++ b/docs/WHOOP_CURRENT_STATE.md
@@ -1,8 +1,16 @@
-# WHOOP-Alternative — Current State (Technical) · 2026-07-04
+# WHOOP-Alternative — Current State (Technical) · 2026-07-04 (Fable second-pass review)
 
 A factual record of what we have built and what our data can support. Companion docs:
-`WHOOP_SERVERSIDE_ARCHITECTURE.md` (design), `WHOOP_RESEARCH_REFERENCES.md` (brand research + 147 sources),
+`WHOOP_SERVERSIDE_ARCHITECTURE.md` (design), `WHOOP_RESEARCH_REFERENCES.md` (brand research + 146 sources),
 `WHOOP_FUTURE_STATE_PLAN.md` (research-backed roadmap).
+
+> **⚠️ Safety & Scope (applies to every metric below and every surface that renders them).**
+> This is an experimental, personal **n-of-1 wellness** system. It is **not a medical device**, not diagnostic,
+> and not intended to detect, prevent, or treat any disease. Nothing here is medical advice — seek care for
+> symptoms regardless of what any score says. Metrics are derived from **firmware-emitted optical pulse intervals**,
+> not ECG or validated clinical pipelines, and are blind to temperature and blood oxygen. The personal build is
+> **firewalled** from anything shipped to other RivaFlow users: no health/illness/rhythm feature ships to third
+> parties without medical-device review.
 
 ## 1. Architecture
 **Self-hosted, server-side.** The phone is a thin **capture + display** client; the RivaFlow VPS is the **brain**.
@@ -23,49 +31,96 @@ The upload batch contains **only four arrays** — that is the entire real-time 
 |---|---|---|---|
 | `whoop_raw_frames` | **every** BLE notification (proprietary `fd4b0001-0007`, `61080001-0007`, std HR `0x2A37`, battery) | as emitted | Immutable source of truth; hex + char_uuid + fractional-second ISO ts; `decoded=FALSE` for the proprietary optical/IMU streams |
 | `whoop_hr` | standard `0x2A37` Heart Rate Measurement (parsed client-side) | ~1 Hz | the only decoded HR stream |
-| `whoop_rr` | RR-intervals off `0x2A37` (1/1024 s → ms) | per beat | **the beat-to-beat tachogram — our richest asset** |
+| `whoop_rr` | RR-intervals off `0x2A37` (1/1024 s → ms) | per beat | the beat-to-beat tachogram — our richest asset, **with the caveat below** |
 | `whoop_battery` | `0x2A19`/`0x2BED` | on change | soc + charging (for wear-time/coverage) |
-Plus a phone HR-history uploader backfills up to 48h of the device HR store on connect (overnight coverage).
-Current volumes (indicative): ~325k raw frames / ~19k HR / ~13k RR.
+
+**⚠️ What the RR series actually is (load-bearing caveat).** These are **optical pulse-to-pulse intervals (PPI)**
+that WHOOP's firmware already beat-detected and emitted over the standard `0x2A37` field — **not ECG RR**. They are
+*decoded* (they come off the standard HR characteristic, not the locked proprietary stream), but they are still
+optical-derived and **quality-bounded by WHOOP's undisclosed on-strap beat detection**. The **raw optical waveform**
+needed to compute an independent Signal-Quality Index is exactly the **locked R22 stream**, so we inherit WHOOP's
+beat-detection artifact (pulse-transit jitter, missed/extra beats, ectopy) with **no independent quality flag to
+reject it**. Every RR-derived metric downstream (RMSSD, frequency-domain, Poincaré, resp-rate) is bounded by this.
+
+**⚠️ Two kinds of night — do not conflate.** RR exists **only while the phone holds a live BLE connection** to the
+strap. The phone HR-history uploader backfills up to 48 h of WHOOP's on-device store on connect, but that store is
+**coarse HR-only** (minute-level aggregates, **no RR**). So a night is either a **live window** (1 Hz HR + per-beat RR,
+usable for HRV) or a **backfilled window** (coarse HR trend only, **not** usable for HRV/resp-rate/HRR). Overnight —
+the window readiness and the prevention engine depend on — is exactly when the phone is most likely charging away
+from the strap, so RR may be structurally under-supplied on the nights that matter most.
+
+Current volumes (**single-session snapshot, not steady-state coverage**): ~325k raw frames / ~19k HR (~5 h of live
+signal) / ~13k RR (~3.6 h). This is roughly one partial session — **far short of the multi-week record** the future
+baselines (14–21 d, 28 d ACWR, 5-day cold-start) assume. Coverage-in-days, tracked separately for HR and RR, is the
+real gate on those builds — see `WHOOP_FUTURE_STATE_PLAN.md`.
 
 ## 3. What we COMPUTE today (server-side, `rivaflow/core/whoop_analytics.py`)
 All bucketed + displayed in **Australia/Melbourne** local time.
 | Metric | Endpoint | Method |
 |---|---|---|
-| Readiness | `/whoop/readiness` | at-rest RMSSD vs rolling baseline z-score (Plews/Buchheit); Sabbath-silent; 5-day cold-start |
-| HRV (RMSSD) | `/whoop/hrv` | resting-band RR (667–1500 ms), successive-diff, outliers>400 ms dropped |
-| Resting HR | `/whoop/resting-hr` | 5th-percentile of the day's HR |
+| Readiness | `/whoop/readiness` | at-rest **ln**RMSSD vs rolling baseline z-score (Plews/Buchheit); Sabbath-silent; 5-day cold-start |
+| HRV (RMSSD) | `/whoop/hrv` | resting-band RR, successive-diff; artifact handling below |
+| Resting HR | `/whoop/resting-hr` | ⚠️ currently 5th-percentile of the day's HR — **not** the nocturnal-minimum definition competitors use (see limitation) |
 | Sleep | `/whoop/sleep` | HR-based window (5-min-bucket median + wake-bridging) + quality vs >9 h need |
-| Respiratory rate | `/whoop/respiratory` | RR oscillation (RSA), zero-crossing over resting RR |
+| Respiratory rate | `/whoop/respiratory` | RR oscillation (RSA), zero-crossing over resting RR — ⚠️ **needs-validation** (crude vs a band-passed estimate; see below) |
 | Cardio load / strain | `/whoop/cardio-load` | HR-zone TRIMP, ~0–21 scale |
 | Stress | `/whoop/stress` | HR elevation within HR-reserve |
 | BJJ session | `/whoop/session-analytics` | HR zones, avg/max, best-60 s recovery |
 | One-call rollup | `/whoop/summary` | all of the above |
-| Dashboard | `/whoop/view?key=…` | server-rendered HTML (6 cards, 2-min refresh) |
-The **slim iOS app** (`SlimHomeView`) fetches `/whoop/summary` and renders it — no on-device compute.
-**Known limitation:** `MAX_HR = 190` is hardcoded (44yo generic), which distorts zones/strain/stress for Ruby.
+| Dashboard | `/whoop/view?key=…` | server-rendered HTML (6 cards, 2-min refresh — see anxiety-loop note in the plan) |
+| The **slim iOS app** (`SlimHomeView`) | — | fetches `/whoop/summary` and renders it — no on-device compute |
 
-## 4. What our data COULD support but we HAVEN'T built (from the audit)
-All reproducible from the HR + RR we already bank:
-- **Frequency-domain HRV** (LF, HF, VLF, total power, LF:HF) via FFT/Lomb-Scargle on the resting RR tachogram — sympatho-vagal *balance*, not just RMSSD magnitude.
-- **More time-domain + non-linear HRV:** SDNN, pNN50/pNN20, HRV triangular index, **Poincaré SD1/SD2/ratio** (Lorenz plots).
-- **DFA α1** — aerobic/anaerobic threshold + durability from exercise RR (research-grade).
-- **Full-resolution HR curve** (native ~1 Hz — we currently collapse to a daily percentile).
-- **HR-recovery (HRR)** 60 s/120 s post-peak as a standalone fitness/mortality trend (we only compute it per BJJ session).
-- **Nocturnal HRV trajectory + sleeping-HR dip / onset**; cardiac drift / aerobic decoupling within a session.
-- **Circadian/autonomic rhythm** (time-of-day HR/HRV curves, cosinor amplitude/acrophase, HR-dip at night).
-- **Training-load ACWR** (7d acute : 28d chronic) — injury-risk.
-- **Multi-signal illness/anomaly detection** (RHR elevation + HRV suppression + respiratory-rate rise, personal-baseline deviation).
-- **RR-irregularity screen** (AFib-class) from the nocturnal tachogram — *see the red-team caution in the plan.*
-- **Recovery-vs-load coupling** (prior-day load → next-day readiness), **VO₂max estimate** (RHR+HRV+demographics), **wear-time/coverage** analytics.
+**Known limitations (each is a P0/P1 fix in the plan):**
+- **`MAX_HR = 190` is hardcoded** — this is a **~30 yo default (220−30)**, ~13 bpm above Ruby's age-predicted ~177
+  (Tanaka 208−0.7·44 ≈ 177; 220−age ≈ 176). It distorts every zone/strain/stress computation.
+- **HRV baseline math should run on the log scale.** RMSSD is right-skewed/log-normal; z-scores and baselines
+  belong on **lnRMSSD** (as Plews/Buchheit and WHOOP do) or they over-flag low-HRV days and under-flag high ones.
+- **Resting band + artifact filter are too crude for a bradycardic athlete.** The current resting band and a fixed
+  absolute successive-difference drop clip genuine slow nocturnal beats and let single-ectopic jumps inflate RMSSD.
+  Target: widen the bradycardic bound (~36–133 bpm / percentile-adaptive to his own nocturnal minimum) and use a
+  **relative (Malik-style, >20%) filter + beat interpolation**, reporting the artifact-correction rate per value.
+- **RHR is a 24 h percentile, not nocturnal.** Redefine as lowest sustained nocturnal HR (rolling 5-min minimum in
+  the sleep window), optionally with the timing of the minimum (Oura Recovery-Index style).
+- **No independent signal-QC gate exists yet** — the only defence is the diff-drop above. A QC/characterisation
+  build is the true first step of the roadmap.
+
+## 4. What our data COULD support (see the roadmap — this is a pointer, not a parallel list)
+All of the following — **except the decode-gated AFib screen noted below** — are reproducible from the **HR + RR we
+already bank**; each is scoped, prioritised, tagged for feasibility/surface, and given acceptance criteria in
+`WHOOP_FUTURE_STATE_PLAN.md` (the single source of truth for
+the roadmap). Summarised so nothing reproducible silently disappears between docs:
+- **Frequency-domain HRV** (LF, HF, total power, LF:HF) via Lomb-Scargle on the resting RR tachogram — note LF:HF is
+  a **descriptive ratio, not a sympatho-vagal balance** measure (see plan).
+- **More time-domain + non-linear HRV:** SDNN, pNN50/pNN20, Poincaré SD1/SD2 (SD1≡RMSSD/√2, so SD2/SD1 ratio and DFA
+  are the genuinely additive signals).
+- **DFA α1** — aerobic (≈0.75) *and* anaerobic (≈0.5) threshold markers; **research-grade and artifact-fragile**.
+- **Full-resolution HR curve** (native ~1 Hz, **live windows only**).
+- **HR-recovery (HRR)** as a within-person fitness trend (currently per-BJJ-session only).
+- **Nocturnal HRV trajectory + sleeping-HR dip / onset**; cardiac drift / decoupling within a session.
+- **Circadian/autonomic rhythm** (time-of-day HR/HRV curves, cosinor amplitude/acrophase, HR-dip at night) —
+  reproducible and directly relevant to his fixed >9 h sleep-need and Sabbath rhythm; **carried into the plan** (P2).
+- **Sleep consistency / regularity** (onset/offset variability) — cheap, universally shipped by competitors.
+- **Training-load ACWR** (7 d : 28 d) — injury-risk; **data-gated** (needs the days of coverage).
+- **Multi-signal baseline-deviation watch** (personal-baseline deviation — the prevention engine).
+- **RR-irregularity screen** (AFib-class) — ⚠️ **blocked on the locked R22 raw-PPG SQI; deferred** (see plan red team).
+- **Recovery-vs-load coupling**, **VO₂max estimate** (banded), **wear-time/coverage** analytics.
 
 ## 5. What is genuinely LOCKED (needs un-cracked decode)
-The proprietary optical (R22/R17) + IMU (K21/K10) frames are **banked raw** (`decoded=FALSE`) but not decoded by any subscription-free project:
+The proprietary optical (R22/R17) + IMU (K21/K10) frames are **banked raw** (`decoded=FALSE`) but not decoded by any
+subscription-free project:
 - **SpO₂ / blood oxygen** — R22 optical PPG.
 - **Skin / peripheral temperature** — temperature-event / NormalHistory family.
 - **Steps / motion / actigraphy / posture** — K21 IMU (workaround: iPhone pedometer, deferred).
 - **Sleep staging** (light/deep/REM) — needs fused motion + optical.
 - **WHOOP's exact cloud scores** (recovery %, strain, sleep score) — closed models; ours are honest independents.
+- **Raw-PPG signal quality** — the waveform an FDA-cleared AFib/SpO₂ pipeline gates on is inside R22, so any
+  rhythm-screen is effectively **decode-gated**, not merely experimental.
+
+**Systemic consequence — no motion channel.** Because the IMU is locked, we have **no accelerometer to motion-gate
+or artifact-reject** HRV/stress/resp-rate the way every competitor does (their stress/HRV pipelines all use accel to
+separate exercise from rest and drop motion epochs). Our only substitute is an **HR-stability heuristic** to detect
+rest/sleep windows — a weaker proxy, not an equivalent. Daytime/live HRV metrics inherit this limitation.
+
 Because the raw is preserved, a future R22/K21 decode retroactively unlocks all of the above from history.
 
-*Current-state audit by the research council, 2026-07-04. Key files: `GooseSwift/GooseBLEClient.swift`, `rivaflow/rivaflow/core/whoop_analytics.py`, `api/routes/whoop.py`, migration `109_whoop_ingest`.*
+*Current-state audit by the research council + Fable second-pass, 2026-07-04. Key files: `GooseSwift/GooseBLEClient.swift`, `rivaflow/rivaflow/core/whoop_analytics.py`, `api/routes/whoop.py`, migration `109_whoop_ingest`.*

--- a/docs/WHOOP_FUTURE_STATE_PLAN.md
+++ b/docs/WHOOP_FUTURE_STATE_PLAN.md
@@ -1,89 +1,111 @@
-# WHOOP-Alternative — Future-State Plan · 2026-07-04
+# WHOOP-Alternative — Future-State Plan · 2026-07-04 (Fable second-pass review)
 
 Research-backed roadmap to turn our HR + RR data into a **best-in-class insight + prevention** tracker —
 "not just stats, but great insights into my body and prevention." Built by a Council (sports scientist,
 HRV/autonomic researcher, cardio-data-scientist, product lead) from the brand research, then stress-tested
-by a Red Team. Cross-check sources in `WHOOP_RESEARCH_REFERENCES.md`; current build in `WHOOP_CURRENT_STATE.md`.
+by a Red Team, then hardened by a five-lens Fable second pass (physiology, feasibility, product, red-team,
+references). Cross-check sources in `WHOOP_RESEARCH_REFERENCES.md`; current build in `WHOOP_CURRENT_STATE.md`.
+
+> **⚠️ Safety & Scope (standing boundary — applies to the whole system and both surfaces).**
+> Experimental, personal **n-of-1 wellness**. **Not a medical device**, not diagnostic, not for detecting or
+> preventing disease; nothing here is medical advice — seek care for symptoms regardless of any score. All
+> signals derive from firmware-emitted **optical pulse intervals**, blind to temperature and blood oxygen.
+> "Prevention" here means **baseline-deviation watch**, not disease detection. The personal build is firewalled
+> from anything shipped to other RivaFlow users — no health/illness/rhythm feature ships to third parties
+> without medical-device review.
 
 **Design constraints:** phone stays **slim** (fetch + display); rich graphs live in a **web deep-dive**; all
-compute stays **server-side** (2-min GitOps iteration); everything scored vs Ruby's **own rolling baseline**,
-never population norms; **Sabbath-aware** (wellness nudges silent Sunday — but illness/safety flags always fire).
+compute stays **server-side** (2-min GitOps iteration); everything scored vs Ruby's **own rolling baseline**
+(**robust estimator — median/MAD, not mean±SD** — see prevention engine), never population norms; **no motion
+sensor**, so HRV/stress/resp-rate are restricted to rest/sleep windows detected by an HR-stability heuristic
+(a partial substitute for competitors' accelerometer gate). **Sabbath-aware** per the explicit tier→channel map
+below (performance nudges silent Sunday; illness/safety flags always fire).
 **Profile lens:** 44yo, BJJ blue→purple + CrossFit, high-strength/low-endurance DNA, NSAID-sensitive, >9 h sleep-need.
 
 ## Strategic pillars
 1. **Recovery Intelligence** — one honest HRV-led "push vs rest" call vs his baseline (WHOOP Recovery / Oura Readiness / Fitbit Daily Readiness core — fully reproducible from HR+RR).
 2. **Training Load & Injury Prevention** — strain target, acute:chronic load ratio, per-session recovery cost, tuned for a masters grappler so load never outruns recovery.
-3. **Illness & Autonomic Early-Warning** (the prevention centrepiece) — multi-signal deviation-from-baseline + nocturnal screening; matters more given NSAID-sensitivity (early rest beats late medication).
-4. **Sleep & Recovery Debt** — honours the >9 h DNA sleep-need with need/debt accrual + HR-based quality.
-5. **Longevity & Trend Intelligence** — cardiovascular-age proxy, resilience/cumulative-stress, frequency & non-linear HRV, weekly/monthly assessments (web deep-dive).
-6. **Honest n-of-1 Science** — personal baselines, frequency-domain + Poincaré HRV unlocked, behaviour-correlation engine, faith-first surfacing.
+3. **Baseline-Deviation Watch** (the prevention centrepiece) — multi-signal deviation-from-baseline; matters more given NSAID-sensitivity (early rest beats late medication). *Renamed from "Illness Early-Warning" to avoid medical-device intended-use framing.*
+4. **Sleep & Recovery Debt** — honours the >9 h DNA sleep-need with need/debt accrual + HR-based quality + **sleep regularity** (onset/offset consistency — cheap, universally shipped).
+5. **Longevity & Trend Intelligence** — cardiovascular-age *proxy* (web-only, caveated), resilience/cumulative-stress, frequency & non-linear HRV, **circadian/chronotype** rhythm, weekly/monthly assessments (web deep-dive).
+6. **Honest n-of-1 Science** — robust personal baselines, frequency-domain + Poincaré HRV unlocked (quality-gated), behaviour-correlation engine, faith-first surfacing.
 
-## 🛡️ The Prevention Engine (centrepiece)
+## Traceability matrix (the single spine — every build appears once)
+Feasibility legend: `now` = codeable + data available · `Nd` = needs N days of coverage · `~Nses` = needs ~N tagged sessions · `research` = experimental · `decode-gated` = blocked on locked R22/K21.
+Surface: **slim** (always-visible phone) / **web** (deep-dive) / **both**.
+
+| # | Build | Pillar | Prio | Feasibility | Surface | Web panel | Acceptance criterion (the "done" bar) |
+|---|---|---|---|---|---|---|---|
+| B0 | **RR/HR signal characterisation & QC gate** | 6 | **P0** | now | web | Data-integrity | Artifact-% per segment computed; clean-segment gate defined; ectopy-corrected + interpolated series feeds all downstream metrics; artifact-% shown beside each value |
+| B1 | **Personalised Max-HR calibration** | 1,2 | **P0** | ~5ses | both | Load & Injury | Artifact-rejected sustained plateau (≥10–30 s near-max), not a 1-sample spike; value carries an uncertainty band; flagged "floor — sub-maximal" when below Tanaka; zones shift for Ruby |
+| B2 | **Multi-input Readiness** (lnRMSSD-led) | 1 | **P0** | now | both | HRV Lab | Morning verdict fuses lnRMSSD (led) + nocturnal-RHR trend + resp-rate + sleep (down-weighted); reproduces the WHOOP-Recovery/Fitbit-Readiness shape; green carries the "green ≠ healthy" caveat |
+| B3 | **Capture-coverage / wear-time guard** (HR **and** RR tracked separately) | 6 | **P0** | now | both | Data-integrity | RR-minutes/night + contiguous-segment length tracked; nights below RR threshold excluded from all baselines; coverage-in-days surfaced |
+| B4 | **Frequency-domain + non-linear HRV** | 5,6 | **P0** | now | web | HRV Lab | LF/HF/total-power via Lomb-Scargle on **≥5-min stationary** windows only; LF:HF labelled descriptive (not sympatho-vagal); Poincaré shown as visualisation (SD1≡RMSSD/√2); SD2/SD1 + DFA the additive metrics |
+| B5 | **Strain Target / Load Coach** | 2 | **P0** | 14d | both | Load & Injury | Readiness → prescribed daily 0–21 load; caps load when Strained. *Promoted to P0 to match the strongest-bet trio.* |
+| B6 | **Baseline-Deviation Watch engine** | 3 | **P0-scoped, activates after baseline** | 14–21d | both (amber/red only) | Baseline-Deviation log | The centrepiece (spec below). Ships once its Validation & tuning gate passes; **no cardiac-rhythm signal**, resp-rate **not** headline-weighted until validated |
+| B7 | **Acute:Chronic Workload Ratio** | 2 | P1 | 28d | both | Load & Injury | 7d:28d load computed once 28 d coverage exists; danger-band ribbon shaded (Gabbett) |
+| B8 | **Heart-Rate Recovery (HRR) trend** | 2 | P1 | ~10ses | both | Load & Injury | Protocol-defined window (peak → HR at 60 s of relative stillness), gated on clean peak + low motion; presented as **within-person fitness trend, no mortality claim** |
+| B9 | **Sleep Need + Sleep Debt** | 4 | P1 | 14d | both | Sleep | Personalised to >9 h DNA; accrual + recommended bedtime; feeds readiness/strain |
+| B10 | **Sleep Consistency / Regularity** | 4 | P1 | now | both | Sleep | Onset/offset variability score from the HR sleep-window; a Sabbath-rest tag for the correlation engine |
+| B11 | **Behaviour / Journal correlation** | 6 | P1 | ~20 tags | web | Behaviour | Yes-night vs no-night effect sizes (alcohol, late training, Sabbath rest) once a light tagging path exists |
+| B12 | **Recovery-cost / dose-response coupling** | 2 | P1 | 21d | web | Recovery-cost | Lagged regression: prior-day load → next-day lnRMSSD/readiness; his personal recovery cost per dose |
+| B13 | **HRV-based real-time Stress** | 1 | P2 | research | web (caveated) | HRV Lab | Live HR+HRV vs baseline; **down-tagged from `now`** — no motion gate, so restricted to detected rest windows and flagged experimental |
+| B14 | **Passive VO₂max** | 5 | P2 | 21d + ~14 recoveries | both | Trends | RHR+HRV+demographics (WHOOP passive tier); presented as a **banded range**, not a point |
+| B15 | **Cardiovascular-Age proxy** | 5 | P2 | 28d | **web only** | Trends | Composite proxy; hard non-clinical caveat, **no alarming arrows**, no individual-risk language (true PWV needs locked PPG) |
+| B16 | **Resilience & Cumulative Stress** | 5 | P2 | 14d + 31d | both | Trends | 14-day bounce-back + 31-day chronic scan (Oura); slow-burn burnout warning |
+| B17 | **Circadian / Chronotype rhythm** | 5 | P2 | 14d | web | Trends | Cosinor on time-of-day HR/HRV + nocturnal HR-dip timing; ties to >9 h need + Sabbath rhythm *(was dropped — restored)* |
+| B18 | **DFA α1 aerobic/anaerobic threshold** | 2 | P2 | research | web (caveated) | Data-integrity | States both crossings (0.75≈VT1/AeT, 0.5≈VT2/AnT); **suppressed when artifact >3%**; validated vs chest-strap ECG before surfacing — **likely infeasible from optical exercise RR** |
+| B19 | **Weekly + Monthly Assessment** | 5 | P2 | 14d / 31d | web | all | Monday + monthly narrative of what's improving/declining (WHOOP/Oura/Apple Trends) |
+| B20 | **RR-irregularity (AFib-class) screen** | 3 | **deferred** | **decode-gated** (blocked on R22 raw-PPG SQI) | web, gated, **off by default** | Baseline-Deviation log | See red team. **Never** in the always-fire channel; only after separate validation + heavy artifact rejection + explicit non-diagnostic framing |
+
+## 🛡️ The Prevention Engine — "Baseline-Deviation Watch" (centrepiece)
 A personal-baseline **anomaly engine** — the common denominator across WHOOP Health Monitor, Oura Symptom
 Radar, Apple Vitals, Fitbit Health Metrics — rebuilt from the two signals we own end-to-end: continuous HR
-and the full RR tachogram.
-- **Signals:** (1) resting-HR elevation, (2) RMSSD / HF-power suppression, (3) RR-derived respiratory-rate rise, (4) nocturnal sleeping-HR elevation + blunted overnight dip, (5) RR-irregularity burst (AFib-class — see caution).
-- **Baselines:** each signal gets its own rolling **14–21 day personal mean ± SD** (n-of-1); wear-gap days excluded by the coverage guard so a charging night can't poison the baseline.
-- **Logic:** per-signal daily z-score + a **CUSUM** accumulator for slow multi-day drifts; the alert fires on **co-occurrence** (Apple Vitals' "multiple outliers together" rule) — one flagged vital is noise, resp-rate + RHR + HRV deviating *together* is signal. **Respiratory rate weighted heaviest** — it's WHOOP's documented ~1–2-day pre-symptom infection lead and the strongest early-warning we can reproduce (temp/SpO₂ are locked).
-- **Tiers:** 🟢 in-range · 🟡 "watch — your body's working harder, consider easing today" · 🔴 "strong multi-signal deviation — rest and recover." Overtraining = the same engine + load context (suppressed HRV + elevated RHR + ACWR spike → load-cap).
-- **Honest boundary:** detects *deviation* and prompts caution/rest/clinician-review — **never diagnoses**; without temp/SpO₂ it will miss purely thermal or oxygenation events. R22 decode is the future unlock that would add temperature and close the gap to Oura/Apple.
-
-## Roadmap (18 builds, prioritised)
-Feasibility: `now` · `time-baseline` (needs days of data) · `more-data` · `research` (experimental). Surface: slim-app / web / both.
-
-### P0 — ship first (the honest, reproducible core)
-| Build | Feasibility | Surface | Value / method |
-|---|---|---|---|
-| **Personalised Max-HR calibration** | now | both | Kills the hardcoded 190 that distorts every zone/strain/stress. Rolling 99.5th-pct observed session-max + HR-reserve, Tanaka sanity band. *Enabler for everything.* |
-| **Multi-input Readiness upgrade** | now | both | Fuse RMSSD (led) + RHR trend + resp-rate + sleep (down-weighted) → robust morning verdict (WHOOP Recovery + Fitbit Daily Readiness model). **Red-team's strongest bet.** |
-| **Capture-coverage / wear-time guard** | now | both | Excludes off-strap days from baselines so alerts + readiness stay trustworthy. **Promote to P0 (red-team).** |
-| **Frequency-domain + non-linear HRV** | now | web | LF/HF/total-power (Lomb-Scargle) + Poincaré SD1/SD2 — autonomic *balance*, the richest unlocked signal; feeds the prevention engine. |
-| **Illness / Autonomic Early-Warning engine** | time-baseline | both | The prevention centrepiece (above). Resp-rate + RHR + HRV co-occurrence, personal baseline, CUSUM. |
-
-### P1 — the coaching + safety layer
-| Build | Feasibility | Surface | Value / method |
-|---|---|---|---|
-| **Strain Target / Load Coach** | time-baseline | both | Turns readiness into a prescribed daily 0–21 load — WHOOP's signature loop; caps load when Strained. |
-| **Acute:Chronic Workload Ratio** | now | both | 7d:28d load, flags the overreaching/injury window (Gabbett) — direct injury-prevention for a grappler. |
-| **Heart-Rate Recovery (HRR) trend** | now | both | 1-min HRR = validated fitness + all-cause-mortality marker; promote our per-session best-60 s to a tracked trend. |
-| **Sleep Need + Sleep Debt** | time-baseline | both | Personalised to his >9 h DNA (not generic 8 h); accrual + recommended bedtime; feeds readiness/strain. |
-| **Behaviour / Journal correlation** | more-data | web | Yes-night vs no-night effect sizes (alcohol, late training, Sabbath rest) — the WHOOP Journal killer feature; needs a light tagging path. |
-| **Recovery-cost / dose-response coupling** | time-baseline | web | Lagged regression: prior-day load → next-day HRV/readiness — his *personal* recovery cost per dose. |
-| **AFib / irregular-rhythm screen** | research | both | ⚠️ **Red-team's biggest risk — see below. Gate carefully or defer.** |
-
-### P2 — longevity + deep science (web-first)
-| Build | Feasibility | Surface | Value / method |
-|---|---|---|---|
-| **HRV-based real-time Stress** | now | both | Live HR+HRV vs baseline (upgrade from HR-elevation-only); breathwork nudges. |
-| **Passive VO₂max** | more-data | both | RHR+HRV+demographics (WHOOP passive tier); present as a **banded range**, not a point. |
-| **Cardiovascular-Age proxy** | more-data | web | RHR+HRV+VO₂max composite; label as proxy (true PWV needs locked PPG). |
-| **Resilience & Cumulative Stress** | time-baseline | both | 14-day bounce-back + 31-day chronic scan (Oura) — slow-burn burnout warning. |
-| **DFA α1 aerobic-threshold** | research | web | True zone-2 for low-endurance-DNA base-building; experimental, from exercise RR. |
-| **Weekly + Monthly Assessment** | time-baseline | web | Monday + monthly narrative of what's improving/declining (WHOOP/Oura/Apple Trends). |
-
-## Web deep-dive (analyst's cockpit — extends `/whoop/view`)
-1. **HRV Lab** — nightly RMSSD/SDNN/pNN50 with mean±SD envelopes + frequency-domain (LF/HF/total power) + Poincaré scatter.
-2. **Load & Injury** — cardio-load bars, strain-target line, ACWR ribbon (danger band shaded), per-session BJJ/CrossFit deep-dives (zones, HR drift/decoupling, best-60 s HRR).
-3. **Recovery-cost coupling** — prior-day load vs next-day readiness regression.
-4. **Sleep** — duration vs >9 h need, debt curve, fragmentation, nocturnal HR dip + HRV trajectory.
-5. **Trends & Longevity** — RHR/HRV/VO₂max/CV-age arrows (90d vs 365d), resilience, cumulative stress.
-6. **Behaviour correlations** — effect sizes per tag.
-7. **Prevention log** — timeline of every flag with the driving signal + exportable physician-shareable report.
-8. **Data integrity** — coverage/wear-time chart + DFA-α1 (experimental).
-All compute server-side; the web app only renders.
-
-## 🔴 Red Team — the honesty layer (read before building)
-- **Biggest risk — the AFib / irregular-rhythm screen.** Every competitor ships this *only* on FDA-cleared, clinician-validated algorithms; ours would run on undecoded optical PPG where beat-detection artifact is routinely indistinguishable from true irregularity. Surfacing any cardiac "flag" — even "discuss with a clinician" — risks real anxiety (false positives) or false reassurance (false negatives), and it rides into the always-fire safety channel. **Verdict: `medically-risky-framing`.** Fix: **defer, or gate behind heavy artifact-rejection + explicit "not a medical device, screening prompt only" framing + conservative thresholds — and do NOT put it in the always-fire channel until validated.**
-- **Second caution — over-claiming illness.** Red-tier copy that asserts "likely illness" is over-reach: HR+RR alone can't distinguish infection from alcohol, heat, hard training, or poor sleep. Fix: reframe as *"your autonomics are strained — could be illness, training, alcohol, or poor sleep; ease today and watch."*
-- **Over-promised — Cardiovascular Age.** True arterial-stiffness needs PPG pulse-wave morphology (locked); ours is a composite proxy — label it as such.
-- **Most items = `needs-validation`:** compute them, but validate against a reference / show as trends before headlining absolute numbers (VO₂max, DFA-α1, max-HR, recovery-cost, resp-rate). `sound` with no caveat: Multi-input Readiness, Wear-time guard, Strain Target, Weekly Assessment.
-- **Strongest bet:** ship the trio **Multi-input Readiness + Wear-time guard + Strain Target** first — the genuinely reproducible recovery-and-load core, no sensor over-reach, no diagnostic framing, immediate honest value: the daily "push vs rest" call Ruby actually asked for.
+and the RR tachogram. **It detects *deviation*, never disease.**
+- **Signals (FOUR — no cardiac-rhythm input):** (1) nocturnal-RHR elevation, (2) **ln**RMSSD / HF-power suppression, (3) RR-derived respiratory-rate rise, (4) nocturnal sleeping-HR elevation + blunted overnight dip. *The AFib-class RR-irregularity signal is **removed** from this engine (see red team + B20).* **Independence note:** signals (1) and (4) are both nocturnal-HR-level measures that co-move for non-illness reasons (alcohol, late meal, warm room), so the co-occurrence rule treats them as **one nocturnal-HR family** — a single HR-level shift counts once, never as two of the ≥2 required outliers. (2) is the vagal family, (3) the respiratory family; co-occurrence requires outliers across **distinct families**.
+- **Baselines (robust, not mean±SD):** each signal gets its own rolling **14–21 day median ± MAD** (or winsorised mean) so a single anomaly can't desensitise the detector; **anchored to a curated healthy-reference window**; wear-gap **and** RR-gap nights excluded by B3, and tagged perturbed days (illness/alcohol/heavy-camp) excluded so they can't recalibrate "normal" upward.
+- **Slow-drift guard:** compare the short 14–21 d baseline against a **longer stable reference** so a gradual overtraining/subacute drift becomes a flag rather than being silently absorbed.
+- **Logic:** per-signal daily z-score **on the log scale for HRV** + a **CUSUM** accumulator (state slack `k` and decision interval `h`) for slow multi-day drifts; the alert fires on **co-occurrence** (Apple Vitals' "multiple outliers together" rule) — one flagged vital is noise, resp-rate + RHR + HRV deviating *together* is signal. Concrete defaults to tune: 🟡 amber at |z|≥1.5 on **≥2 distinct signal families**, or a CUSUM breach **confirmed by a second family** — a solo CUSUM breach never fires a tier, and **respiratory rate can never be the sole driver of any tier** (amber or red); 🔴 red at |z|≥2 on ≥2 families. **Respiratory rate is NOT headline-weighted until validated** — it is our least-direct signal (crude RSA estimate, degrades with age + autonomic suppression), so weight signals by **inverse-variance / measured reliability** (RHR and lnRMSSD are the most direct), and require true multi-signal co-occurrence so resp-rate alone can never trigger red.
+- **Validation & tuning (gate before it ships to any channel):** retrospectively self-tag past illness/hard-training/travel days; backtest the engine over that window; establish the night-to-night SD of each signal (resp-rate must resolve a <1 bpm shift to earn weight). **Acceptance target:** flags the last ≥2 known illness onsets with **<1 false amber/week** before it is allowed to fire.
+- **Tier → channel map (explicit, so no future edit silently reclassifies):**
+  - 🟢 in-range — **not a clearance to push.** Carries the standing caveat: *"no deviation in the signals I can measure (HR, HRV, breathing); I am blind to temperature and blood oxygen — trust symptoms over a green light."*
+  - 🟡 amber ("watch — your body's working harder") — **safety channel, fires Sunday.** It is early-warning, not a coaching nudge; silencing it would eat the 1–2 day pre-symptom window the engine exists for.
+  - 🔴 red ("strong multi-signal deviation — rest and recover") — **always fires** (incl. Sunday).
+  - Only pure **performance/coaching** nudges (strain target, push-harder) are Sabbath-silenced.
+- **Delivery (anti-anxiety):** health/anomaly findings are a **once-daily morning digest with alert cooldown**, not a live-refreshing red light; the 2-min dashboard refresh is for **neutral performance data only**. Constant self-checking is itself a wellness risk — designed against on purpose.
+- **Honest boundary:** detects *deviation* and prompts caution/rest/clinician-conversation — **never diagnoses**; reframed copy: *"your autonomics are strained — could be illness, training, alcohol, heat, or poor sleep; ease today and watch."* Without temp/SpO₂ it will miss purely thermal or oxygenation events (R22 decode is the future unlock).
 
 ## Recommended build sequence
-1. **P0 core (strongest bet):** Max-HR calibration → Multi-input Readiness → Wear-time guard → freq/non-linear HRV → Illness engine (amber/red, reframed copy, **no AFib in the always-fire channel yet**).
-2. **P1 coaching:** Strain Target → ACWR → HRR trend → Sleep Need/Debt.
-3. **Web deep-dive** built in parallel with P0/P1 (it's just rendering server-computed series).
-4. **P2 longevity + experimental** (VO₂max, CV-age, resilience, DFA-α1, assessments) — with validation caveats.
-5. **AFib screen:** research + validate separately; ship only gated + non-alarming, or defer to the R22-decode era.
+1. **QC first:** **B0 signal characterisation & QC gate** — nothing downstream is trustworthy without it.
+2. **P0 strongest-bet trio (the honest, reproducible recovery-and-load core Ruby actually asked for):**
+   **B2 Multi-input Readiness → B3 Wear/RR-coverage guard → B5 Strain Target.** No sensor over-reach, no diagnostic framing.
+3. **B1 Max-HR calibration** (enabler for every zone/strain/stress) + **B4 freq/non-linear HRV** (feeds the engine).
+4. **B6 Baseline-Deviation Watch** — activates after its 14–21 d baseline + Validation gate; amber/red only, reframed copy, **no AFib signal**.
+5. **P1 coaching:** B7 ACWR → B8 HRR trend → B9 Sleep Need/Debt → B10 Regularity → B11 Behaviour correlation → B12 Recovery-cost coupling.
+6. **Web deep-dive** built in parallel with P0/P1 (it's just rendering server-computed series).
+7. **P2 longevity + experimental** (B13 real-time Stress, B14–B19) — with validation caveats; **B15 CV-age web-only, no mortality/age-alarm framing**.
+8. **B20 AFib screen:** deferred/decode-gated; ship only after separate validation, gated + non-alarming, **never in the always-fire channel**.
 
-*Council + Red Team, 2026-07-04. All sources in `WHOOP_RESEARCH_REFERENCES.md` (147 citations). Workflow run `wf_35d64a98-6ad`.*
+## Web deep-dive (analyst's cockpit — extends `/whoop/view`, renders server-computed series only)
+1. **HRV Lab** — nightly lnRMSSD/SDNN/pNN50 with robust envelopes + frequency-domain (≥5-min windows, LF:HF descriptive) + Poincaré scatter.
+2. **Load & Injury** — cardio-load bars, strain-target line, ACWR ribbon (danger band shaded), per-session BJJ/CrossFit deep-dives (zones, HR drift/decoupling, protocol HRR).
+3. **Recovery-cost coupling** — prior-day load vs next-day readiness regression.
+4. **Sleep** — duration vs >9 h need, debt curve, regularity, fragmentation, nocturnal HR dip + HRV trajectory.
+5. **Trends & Longevity** — RHR/HRV/VO₂max arrows (90d vs 365d), resilience, cumulative stress, circadian rhythm; **CV-age proxy caveated, no alarming arrows**.
+6. **Behaviour correlations** — effect sizes per tag.
+7. **Baseline-Deviation log** — timeline of every flag with the driving signal + a **neutral personal data export** (stamped with validation status + blind spots; explicitly *context for a conversation, not clinical data* — never to rule anything in or out).
+8. **Data integrity** — coverage/wear-time + **RR-coverage** chart, artifact-% trend, DFA-α1 (experimental, suppressed on high artifact).
+
+## 🔴 Red Team — the honesty layer (read before building)
+- **Critical — the AFib deferral was leaking.** The AFib-class RR-irregularity signal was written directly into the always-fire prevention engine's signal set and the screen's surface was "both" (the slim always-visible phone). **Fix applied:** the signal is **removed** from the engine (now 4 signals), and B20's surface is **web, gated, off by default**. No cardiac-rhythm signal contributes to any always-fire alert. And the feasibility is worse than "research": the artifact rejection FDA-cleared PPG AFib algorithms rely on runs on the **raw optical waveform (locked R22)**; on WHOOP-emitted PPI alone, ectopy/missed beats/motion are indistinguishable from true irregularity — so it is **decode-gated**, not merely experimental. (Competitor "AFib from RR" runs on raw-PPG bursts with quality gating, not a bare IBI feed.)
+- **Critical — no standing "not a medical device" boundary.** "Prevention" and "illness early-warning" are intended-use language a regulator (TGA/FDA) classifies on, and RivaFlow is a **shipped, revenue product**. **Fix applied:** standing Safety & Scope boundary at the top of both docs + both UI surfaces; pillar 3 renamed **Baseline-Deviation Watch**; personal build firewalled from third-party ship.
+- **High — false reassurance ("green ≠ healthy").** A green readiness or 🟢 tier can be returned while a fever/hypoxic event is incubating (temp/SpO₂ locked). **Fix applied:** every green/in-range verdict carries the explicit "blind to temperature and blood oxygen — trust symptoms" caveat; green = "no alarm", never "cleared to push" when symptoms are logged.
+- **High — Sabbath-silence could suppress a real early-warning.** **Fix applied:** the tier→channel map above makes amber/red illness flags fire Sunday; only performance nudges are silenced.
+- **High — respiratory rate was weighted heaviest but is the least-validated signal** (crude RSA estimate; references give WHOOP no day-count — the only sourced lead-time is Oura/TemPredict ~2.75 d). **Fix applied:** resp-rate is inverse-variance weighted with an error-budget gate, never headline-weighted or able to fire red alone until it resolves a <1 bpm shift.
+- **High — baseline poisoning + no robust estimator.** **Fix applied:** median/MAD, healthy-reference anchoring, slow-drift guard, and perturbed-day exclusion (above).
+- **Medium — individual-prognostic framing.** HRR "mortality marker" and a worsening CV-age arrow present population associations as personal prognosis. **Fix applied:** HRR is a fitness trend (no mortality claim); CV-age is web-only, caveated, no alarming arrows; population associations ≠ individual outcome.
+- **Medium — artifact/ectopy contaminates *every* RR-derived metric, not just AFib** (benign PVCs/PACs + high vagal RSA in a fit 44 yo inflate RMSSD and distort resp-rate). **Fix applied:** B0 QC gate is the first build; ectopic/artifact handling sits upstream of every metric with a per-night artifact gate.
+- **Most items = `needs-validation`:** compute them, but validate against a reference / show as trends before headlining absolute numbers (VO₂max, DFA-α1, max-HR, recovery-cost, resp-rate). `sound` with no caveat: Multi-input Readiness, Wear/RR-coverage guard, Strain Target, Sleep Regularity, Weekly Assessment.
+- **Strongest bet:** ship the trio **Multi-input Readiness + Wear/RR-coverage guard + Strain Target** (after B0 QC) — the genuinely reproducible recovery-and-load core, no sensor over-reach, no diagnostic framing: the daily "push vs rest" call Ruby actually asked for.
+
+*Council + Red Team + Fable five-lens second pass, 2026-07-04. All sources in `WHOOP_RESEARCH_REFERENCES.md` (146 sources). Workflow runs `wf_35d64a98-6ad`, `wf_a5ec3997-460`.*

--- a/docs/WHOOP_RESEARCH_REFERENCES.md
+++ b/docs/WHOOP_RESEARCH_REFERENCES.md
@@ -1,8 +1,25 @@
-# WHOOP-Alternative — Brand Research & References (2026-07-04)
+# WHOOP-Alternative — Brand Research & References (2026-07-04 · Fable second-pass review)
 
 > Deep research on the major health/fitness trackers, gathered by a 5-agent research council to inform our
 > self-hosted build. **Every source URL is preserved for cross-checking with a secondary council.**
 > Scope lens: we compute from **heart rate + RR-intervals only** (SpO₂/temp/steps/staging are locked — see CURRENT_STATE).
+>
+> **Source count:** WHOOP 30 · Oura 29 · Ultrahuman 21 · Fitbit 34 · Apple 33 = **147 raw URLs / 146 unique**
+> (one Ultrahuman study is served on two paths — see that block). The companion docs cite this as "146 sources."
+>
+> **Integrity conventions (apply when reading every figure below):**
+> - **Attribution:** treat any bare accuracy figure (e.g. "76% fever detection", "~98% AFib agreement", "MAE 2.4 bpm",
+>   "VO₂max ±3.3–3.7") as **vendor-claimed unless a study/PMC id is named**. Vendor marketing ≠ independent validation.
+> - **As-of dating:** these numbers churn with firmware/algorithm revisions; read them as *as of 2026-07-04*, not durable fact.
+> - **Respiratory-rate reproducibility is ONE question, not a per-brand fact.** RSA/EDR-derived respiratory rate from the
+>   RR series is *reproducible in principle for all five brands*, but accuracy depends on RR sampling resolution and is
+>   best overnight at rest — so Apple's "PARTIALLY reproducible" is the honest framing for all of them. This is why the
+>   future plan does **not** headline-weight resp-rate until it is validated (see WHOOP_FUTURE_STATE_PLAN.md).
+> - **AFib "reproducible in principle from RR" ≠ trustworthy from OUR data.** Several brand blocks below note AFib is
+>   reproducible in principle from beat-to-beat RR. True — but competitor AFib detection gates on the **raw-PPG waveform
+>   quality** (locked R22 for us); on WHOOP's unqualified optical PPI we cannot separate true irregularity from
+>   beat-detection artifact. So for RivaFlow the screen is **decode-gated, not merely experimental** — see
+>   WHOOP_FUTURE_STATE_PLAN.md B20 and the red-team section.
 
 ## WHOOP (WHOOP 5.0 / WHOOP MG, WHOOP Life & Peak/One memberships)
 **Signature / why it's valuable:** The strain-vs-recovery balance loop is WHOOP's signature: a single morning Recovery Score (HRV-led) is converted into a prescriptive daily Strain Target, so the device doesn't just report numbers - it tells you how hard to go today and how much to sleep tonight to stay in balance. Critically for a HR+RR-only build, the two most valuable pillars (the HRV-driven Recovery/readiness score and the HR-zone Strain load, plus RR-derived respiratory-rate illness early-warning and the personal-baseline anomaly engine) are all reproducible from heart rate and beat-to-beat RR-intervals alone - SpO2, skin temp, ECG and blood pressure are additive refinements, not the core.
@@ -111,7 +128,7 @@
 
 ---
 
-## Oura Ring (Gen 3 / Ring 4 / Ring 5) — smart ring; the benchmark for trends, temperature and pre-symptomatic illness detection
+## Oura Ring (Gen 3 / Ring 4 / Ring 5 *if released — unconfirmed as of 2026-07-04*) — smart ring; the benchmark for trends, temperature and pre-symptomatic illness detection
 **Signature / why it's valuable:** Oura's signature value is TREND-OVER-TIME baselining that converts biometrics into two things nobody else nails as cleanly: (1) a single, trustworthy morning Readiness verdict that tells you what to do today, and (2) Symptom Radar — genuine pre-symptomatic illness detection (~2 days early) built primarily on overnight temperature deviation fused with resting HR, HRV and breathing rate. The temperature signal is its illness-prediction moat; the readiness/HRV/stress/resilience layer is highly reproducible from your HR+RR data, but the temperature-driven early-warning edge will need a temp input to fully match.
 
 **Metrics surfaced:**
@@ -289,7 +306,7 @@
 - https://cyborg.ultrahuman.com/press-releases/ultrahuman-announces-its-app-store-powerplugs-with-the-worlds-first-afib-detection-technology-on-a-smart-ring
 - https://ultrahuman.com/blog/sleep-algorithm-2-0-explained-personalized-sleep-scoring/
 - https://science.ultrahuman.com/studies/sleep-heart-rate-sensing
-- https://ultrahuman.com/science/studies/sleep-heart-rate-sensing
+  <!-- (duplicate path https://ultrahuman.com/science/studies/sleep-heart-rate-sensing removed — same study; this is why 147 raw URLs = 146 unique) -->
 - https://www.ultrahuman.com/blog/hrv-and-stress-explained-how-your-body-signals-overload/
 - https://www.ultrahuman.com/blog/5-ways-to-train-better-using-hrv-metric/
 - https://www.ultrahuman.com/blog/how-the-timing-of-stress-can-protect-your-health-and-stay-productive/

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -165,6 +165,16 @@ def readiness(current_user: dict = Depends(get_current_user)) -> dict:
     return compute_readiness(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/strain-target")
+@route_error_handler("whoop_strain_target", detail="Failed to compute strain target")
+def strain_target_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B5 — today's prescribed strain target (0–21) from readiness, capped when Strained. Sabbath-silent."""
+    from rivaflow.core.whoop_analytics import strain_target
+
+    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6  # Sunday = Ruby's rest day
+    return strain_target(current_user["id"], today_is_sabbath=is_sabbath)
+
+
 @router.get("/session-analytics")
 @route_error_handler("whoop_session_analytics", detail="Failed to compute BJJ session analytics")
 def session_analytics(

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -175,6 +175,24 @@ def strain_target_endpoint(current_user: dict = Depends(get_current_user)) -> di
     return strain_target(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/acwr")
+@route_error_handler("whoop_acwr", detail="Failed to compute ACWR")
+def acwr_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B7 — acute:chronic workload ratio (Gabbett injury-risk window)."""
+    from rivaflow.core.whoop_analytics import training_acwr
+
+    return training_acwr(current_user["id"])
+
+
+@router.get("/recovery-cost")
+@route_error_handler("whoop_recovery_cost", detail="Failed to compute recovery cost")
+def recovery_cost_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B12 — prior-day load → next-day HRV coupling (personal recovery cost per dose)."""
+    from rivaflow.core.whoop_analytics import recovery_cost_coupling
+
+    return recovery_cost_coupling(current_user["id"])
+
+
 @router.get("/prevention")
 @route_error_handler("whoop_prevention", detail="Failed to compute baseline-deviation watch")
 def prevention_endpoint(current_user: dict = Depends(get_current_user)) -> dict:

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -212,6 +212,61 @@ def prevention_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
     return prevention_watch(current_user["id"])
 
 
+@router.get("/longevity")
+@route_error_handler("whoop_longevity", detail="Failed to compute longevity metrics")
+def longevity_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B14 + B15 — passive VO2max (banded) + cardio-age proxy (web; proxy, not clinical)."""
+    from rivaflow.core.whoop_analytics import longevity_metrics
+
+    return longevity_metrics(current_user["id"])
+
+
+@router.get("/resilience")
+@route_error_handler("whoop_resilience", detail="Failed to compute resilience")
+def resilience_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B16 — resilience (14d bounce-back) + 31d cumulative stress."""
+    from rivaflow.core.whoop_analytics import resilience_metrics
+
+    return resilience_metrics(current_user["id"])
+
+
+@router.get("/circadian")
+@route_error_handler("whoop_circadian", detail="Failed to compute circadian rhythm")
+def circadian_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B17 — cosinor circadian rhythm of time-of-day HR."""
+    from rivaflow.core.whoop_analytics import circadian_rhythm
+
+    return circadian_rhythm(current_user["id"])
+
+
+@router.get("/dfa")
+@route_error_handler("whoop_dfa", detail="Failed to compute DFA alpha1")
+def dfa_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B18 — DFA α1 (experimental, artifact-gated)."""
+    from rivaflow.core.whoop_analytics import dfa_analysis
+
+    return dfa_analysis(current_user["id"])
+
+
+@router.get("/realtime-stress")
+@route_error_handler("whoop_realtime_stress", detail="Failed to compute realtime stress")
+def realtime_stress_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B13 — HRV-based real-time stress (experimental; at-rest only)."""
+    from rivaflow.core.whoop_analytics import realtime_stress
+
+    return realtime_stress(current_user["id"])
+
+
+@router.get("/assessment")
+@route_error_handler("whoop_assessment", detail="Failed to compute assessment")
+def assessment_endpoint(period: str = "week", current_user: dict = Depends(get_current_user)) -> dict:
+    """B19 — weekly/monthly assessment narrative. ?period=week|month."""
+    from rivaflow.core.whoop_analytics import period_assessment_for
+
+    days = 30 if period == "month" else 7
+    return period_assessment_for(current_user["id"], period, days)
+
+
 @router.get("/hrv-lab")
 @route_error_handler("whoop_hrv_lab", detail="Failed to compute HRV lab")
 def hrv_lab_endpoint(current_user: dict = Depends(get_current_user)) -> dict:

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -175,6 +175,15 @@ def strain_target_endpoint(current_user: dict = Depends(get_current_user)) -> di
     return strain_target(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/hrv-lab")
+@route_error_handler("whoop_hrv_lab", detail="Failed to compute HRV lab")
+def hrv_lab_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B4 — frequency-domain (Lomb-Scargle LF/HF) + Poincaré HRV over the longest clean ≥5-min resting window."""
+    from rivaflow.core.whoop_analytics import hrv_lab
+
+    return hrv_lab(current_user["id"])
+
+
 @router.get("/session-analytics")
 @route_error_handler("whoop_session_analytics", detail="Failed to compute BJJ session analytics")
 def session_analytics(

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -175,6 +175,15 @@ def strain_target_endpoint(current_user: dict = Depends(get_current_user)) -> di
     return strain_target(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/sleep-analysis")
+@route_error_handler("whoop_sleep_analysis", detail="Failed to compute sleep analysis")
+def sleep_analysis_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B9 + B10 — sleep need/debt vs the >9h need + bedtime regularity."""
+    from rivaflow.core.whoop_analytics import sleep_analysis
+
+    return sleep_analysis(current_user["id"])
+
+
 @router.get("/acwr")
 @route_error_handler("whoop_acwr", detail="Failed to compute ACWR")
 def acwr_endpoint(current_user: dict = Depends(get_current_user)) -> dict:

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -175,6 +175,16 @@ def strain_target_endpoint(current_user: dict = Depends(get_current_user)) -> di
     return strain_target(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/prevention")
+@route_error_handler("whoop_prevention", detail="Failed to compute baseline-deviation watch")
+def prevention_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """B6 — Baseline-Deviation Watch: multi-signal deviation from personal baseline. Safety channel (fires
+    Sunday). Detects deviation, never disease — not a medical device."""
+    from rivaflow.core.whoop_analytics import prevention_watch
+
+    return prevention_watch(current_user["id"])
+
+
 @router.get("/hrv-lab")
 @route_error_handler("whoop_hrv_lab", detail="Failed to compute HRV lab")
 def hrv_lab_endpoint(current_user: dict = Depends(get_current_user)) -> dict:

--- a/rivaflow/rivaflow/core/assessment.py
+++ b/rivaflow/rivaflow/core/assessment.py
@@ -1,0 +1,56 @@
+"""B19 — Weekly + Monthly Assessment (pure core).
+
+A narrative of what's improving/declining (WHOOP_FUTURE_STATE_PLAN.md B19), from the metric trends. Each
+metric declares whether "up" is good, so the narrative reads correctly (rising RHR is bad; rising HRV is good).
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+
+# metric key → (label, is_up_good)
+METRIC_SENSE = {
+    "lnrmssd": ("HRV (lnRMSSD)", True),
+    "rhr": ("Resting HR", False),
+    "cardio_load": ("Training load", True),   # neutral-ish, framed as trend
+    "sleep_hours": ("Sleep duration", True),
+}
+
+
+def _direction(values: list[float]) -> float:
+    """Slope sign of a simple first-vs-second-half comparison — robust to noise, no regression needed."""
+    if len(values) < 4:
+        return 0.0
+    half = len(values) // 2
+    return mean(values[half:]) - mean(values[:half])
+
+
+def period_assessment(label: str, series: dict[str, list[float]]) -> dict:
+    """Summarise a period (e.g. 'week', 'month'). `series` maps metric key → chronological values."""
+    lines: list[dict] = []
+    for key, values in series.items():
+        if key not in METRIC_SENSE or len(values) < 4:
+            continue
+        name, up_good = METRIC_SENSE[key]
+        delta = _direction(values)
+        if abs(delta) < 1e-9:
+            trend, good = "steady", None
+        else:
+            rising = delta > 0
+            trend = "rising" if rising else "falling"
+            good = (rising == up_good)
+        lines.append({"metric": key, "label": name, "trend": trend, "delta": round(delta, 2),
+                      "improving": good})
+    improving = [line["label"] for line in lines if line["improving"] is True]
+    declining = [line["label"] for line in lines if line["improving"] is False]
+    if not lines:
+        headline = f"Not enough data for a {label} assessment yet."
+    else:
+        parts = []
+        if improving:
+            parts.append("improving: " + ", ".join(improving))
+        if declining:
+            parts.append("watch: " + ", ".join(declining))
+        headline = f"Your {label}: " + ("; ".join(parts) if parts else "steady across the board.")
+    return {"available": bool(lines), "period": label, "lines": lines,
+            "improving": improving, "declining": declining, "headline": headline}

--- a/rivaflow/rivaflow/core/behaviour.py
+++ b/rivaflow/rivaflow/core/behaviour.py
@@ -1,0 +1,60 @@
+"""B11 — Behaviour / Journal correlation (pure core).
+
+The WHOOP-Journal killer feature (WHOOP_FUTURE_STATE_PLAN.md B11): for a tagged behaviour (alcohol, late
+training, Sabbath rest), compare yes-nights vs no-nights on a recovery metric and report the effect size, so
+Ruby sees how each habit actually moves HIS numbers. Needs a light tagging path (that plumbing is future
+work); this is the statistics it will feed.
+"""
+
+from __future__ import annotations
+
+from statistics import mean, pstdev
+
+
+def cohens_d(a: list[float], b: list[float]) -> float | None:
+    """Standardised mean difference (a − b) with pooled SD. None if either group is too small or has no spread."""
+    if len(a) < 2 or len(b) < 2:
+        return None
+    na, nb = len(a), len(b)
+    va, vb = pstdev(a) ** 2, pstdev(b) ** 2
+    pooled = (((na - 1) * va + (nb - 1) * vb) / (na + nb - 2)) ** 0.5
+    if pooled == 0:
+        return None
+    return (mean(a) - mean(b)) / pooled
+
+
+def _magnitude(d: float) -> str:
+    ad = abs(d)
+    if ad < 0.2:
+        return "negligible"
+    if ad < 0.5:
+        return "small"
+    if ad < 0.8:
+        return "medium"
+    return "large"
+
+
+def behaviour_effect(tag: str, metric: str, yes_values: list[float], no_values: list[float]) -> dict:
+    """Effect of a tagged behaviour on a metric: yes-nights vs no-nights means + Cohen's d. Positive delta
+    means the behaviour is associated with a HIGHER metric value."""
+    d = cohens_d(yes_values, no_values)
+    if d is None:
+        return {"available": False, "tag": tag, "metric": metric,
+                "reason": "Need ≥2 nights each with and without the tag (and some spread)."}
+    ym, nm = mean(yes_values), mean(no_values)
+    delta = ym - nm
+    mag = _magnitude(d)
+    direction = "higher" if delta >= 0 else "lower"
+    return {
+        "available": True,
+        "tag": tag,
+        "metric": metric,
+        "yes_mean": round(ym, 2),
+        "no_mean": round(nm, 2),
+        "delta": round(delta, 2),
+        "cohens_d": round(d, 2),
+        "magnitude": mag,
+        "n_yes": len(yes_values),
+        "n_no": len(no_values),
+        "headline": f"On {tag} nights your {metric} is {mag} {direction} ({round(delta, 2):+}).",
+    }

--- a/rivaflow/rivaflow/core/behaviour.py
+++ b/rivaflow/rivaflow/core/behaviour.py
@@ -20,7 +20,7 @@ def cohens_d(a: list[float], b: list[float]) -> float | None:
     pooled = (((na - 1) * va + (nb - 1) * vb) / (na + nb - 2)) ** 0.5
     if pooled == 0:
         return None
-    return (mean(a) - mean(b)) / pooled
+    return float((mean(a) - mean(b)) / pooled)
 
 
 def _magnitude(d: float) -> str:

--- a/rivaflow/rivaflow/core/circadian.py
+++ b/rivaflow/rivaflow/core/circadian.py
@@ -1,0 +1,43 @@
+"""B17 — Circadian / chronotype rhythm (pure core).
+
+Cosinor fit of time-of-day HR/HRV (WHOOP_FUTURE_STATE_PLAN.md B17): mesor, amplitude, acrophase + the
+nocturnal HR dip — reproducible from HR timing, relevant to Ruby's fixed >9h need and Sabbath rhythm.
+"""
+
+from __future__ import annotations
+
+from math import atan2, cos, pi, sin
+from statistics import mean
+
+OMEGA = 2 * pi / 24.0   # one cycle per 24h
+
+
+def cosinor(hours: list[float], values: list[float]) -> dict:
+    """Least-squares cosinor: value ≈ M + A·cos(ω(t − φ)). Returns mesor M, amplitude A, and acrophase φ
+    (hour of peak). Needs points spread across the day."""
+    n = len(hours)
+    if n < 8 or len(values) != n:
+        return {"available": False, "reason": "Need ≥8 time-stamped points across the day."}
+    # Regress y = M + b·cos(ωt) + c·sin(ωt) via normal equations (closed form).
+    cs = [cos(OMEGA * h) for h in hours]
+    sn = [sin(OMEGA * h) for h in hours]
+    m_y = mean(values)
+    m_c = mean(cs)
+    m_s = mean(sn)
+    # centred sums
+    scc = sum((c - m_c) ** 2 for c in cs)
+    sss = sum((s - m_s) ** 2 for s in sn)
+    scs = sum((c - m_c) * (s - m_s) for c, s in zip(cs, sn))
+    scy = sum((c - m_c) * (y - m_y) for c, y in zip(cs, values))
+    ssy = sum((s - m_s) * (y - m_y) for s, y in zip(sn, values))
+    det = scc * sss - scs * scs
+    if det == 0:
+        return {"available": False, "reason": "Time points too clustered to fit a rhythm."}
+    b = (scy * sss - ssy * scs) / det
+    c = (ssy * scc - scy * scs) / det
+    mesor = m_y - b * m_c - c * m_s
+    amplitude = (b * b + c * c) ** 0.5
+    acrophase_hour = (atan2(c, b) / OMEGA) % 24.0
+    return {"available": True, "mesor": round(mesor, 1), "amplitude": round(amplitude, 1),
+            "acrophase_hour": round(acrophase_hour, 1), "n": n,
+            "headline": f"Daily HR rhythm peaks around {round(acrophase_hour, 1)}h, amplitude {round(amplitude, 1)} bpm."}

--- a/rivaflow/rivaflow/core/coverage.py
+++ b/rivaflow/rivaflow/core/coverage.py
@@ -1,0 +1,93 @@
+"""B3 — Capture-coverage / RR-coverage guard (the pure core).
+
+Makes every baseline trustworthy by excluding under-covered nights (WHOOP_FUTURE_STATE_PLAN.md B3).
+
+The load-bearing insight (feasibility lens, WHOOP_CURRENT_STATE.md §2): RR only exists while the phone
+holds a LIVE BLE connection to the strap. The 48 h device-store backfill recovers HR only — no RR. So on a
+charging-away night the HR view looks fully covered while the beat-to-beat tachogram every HRV/readiness/
+prevention signal depends on is missing. Coverage therefore MUST be measured on RR separately from HR, or a
+silent RR gap poisons the baselines behind an HR view that reads "fine."
+
+This module quantifies, per day: usable RR-minutes, the longest contiguous RR segment, and (for contrast)
+HR-minutes — then gives a single `sufficient` verdict the daily builders gate on. Quality (artifact-%) is
+B0's job; this is quantity + contiguity. A day must clear BOTH to anchor a baseline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rivaflow.core.rr_quality import RR_MAX_MS, RR_MIN_MS, clean_segments
+
+# Tunable thresholds — a night below these can't anchor a baseline.
+MIN_RR_MINUTES = 5.0          # total usable (in-band) RR captured across the day
+MIN_CONTIGUOUS_MINUTES = 2.0  # longest unbroken RR run — a short-term HRV window needs a contiguous block
+HR_SAMPLE_HZ = 1.0            # standard 0x2A37 HR stream is ~1 sample/second
+
+
+@dataclass
+class CoverageReport:
+    rr_minutes: float          # usable in-band RR captured (live-connection signal)
+    longest_segment_minutes: float
+    hr_minutes: float          # HR captured — includes backfill, so ≫ rr_minutes on charging-away nights
+    rr_intervals: int
+    sufficient: bool
+    reason: str
+
+    def as_dict(self) -> dict:
+        return {
+            "rr_minutes": round(self.rr_minutes, 1),
+            "longest_segment_minutes": round(self.longest_segment_minutes, 1),
+            "hr_minutes": round(self.hr_minutes, 1),
+            "rr_intervals": self.rr_intervals,
+            "sufficient": self.sufficient,
+            "reason": self.reason,
+        }
+
+
+def assess_coverage(rr_intervals: list[int | float], hr_samples: int = 0) -> CoverageReport:
+    """Coverage verdict for one day. `rr_intervals` = that day's raw RR (any band); `hr_samples` = that day's
+    HR sample count (for the RR-vs-HR gap). Deterministic and DB-free."""
+    inband = [float(x) for x in rr_intervals if x is not None and RR_MIN_MS <= x <= RR_MAX_MS]
+    rr_minutes = sum(inband) / 60000.0
+    segments = clean_segments(rr_intervals, min_len=1)   # all contiguous in-spec runs
+    longest_minutes = max((sum(s) / 60000.0 for s in segments), default=0.0)
+    hr_minutes = hr_samples / (HR_SAMPLE_HZ * 60.0)
+
+    if rr_minutes < MIN_RR_MINUTES:
+        # Name the masking case explicitly: plenty of HR, but the tachogram is missing.
+        if hr_minutes >= MIN_RR_MINUTES:
+            reason = (f"RR-starved night — only {rr_minutes:.1f} min of RR despite {hr_minutes:.0f} min of HR "
+                      f"(phone likely charging away from the strap); excluded from baselines.")
+        else:
+            reason = f"Low capture — {rr_minutes:.1f} min RR (need {MIN_RR_MINUTES:.0f}); excluded from baselines."
+        sufficient = False
+    elif longest_minutes < MIN_CONTIGUOUS_MINUTES:
+        reason = (f"Fragmented — longest RR run {longest_minutes:.1f} min "
+                  f"(need {MIN_CONTIGUOUS_MINUTES:.0f}); excluded from baselines.")
+        sufficient = False
+    else:
+        reason = "sufficient"
+        sufficient = True
+
+    return CoverageReport(
+        rr_minutes=rr_minutes,
+        longest_segment_minutes=longest_minutes,
+        hr_minutes=hr_minutes,
+        rr_intervals=len(inband),
+        sufficient=sufficient,
+        reason=reason,
+    )
+
+
+def coverage_in_days(reports: list[CoverageReport]) -> dict:
+    """Roll a set of per-day reports into a coverage summary: how many days actually clear the RR bar (the
+    number that governs whether time-baseline builds can trust their baseline)."""
+    total = len(reports)
+    good = sum(1 for r in reports if r.sufficient)
+    return {
+        "days_total": total,
+        "days_sufficient": good,
+        "days_excluded": total - good,
+        "rr_coverage_pct": round(100.0 * good / total, 1) if total else 0.0,
+    }

--- a/rivaflow/rivaflow/core/hrv_spectral.py
+++ b/rivaflow/rivaflow/core/hrv_spectral.py
@@ -1,0 +1,148 @@
+"""B4 — Frequency-domain + non-linear HRV (the pure core, the "HRV Lab").
+
+Unlocks the richest HRV signal from the RR tachogram (WHOOP_FUTURE_STATE_PLAN.md B4), with the physiology
+review's guardrails baked in so the numbers are honest:
+
+  - **≥5-min stationary windows only.** LF needs ≥~2 min, VLF/total-power ≥5 min; short snippets give
+    spectral numbers with no defensible meaning. We refuse to compute on shorter windows.
+  - **Lomb-Scargle, not FFT.** RR intervals are unevenly sampled in time; Lomb-Scargle handles that directly
+    without the resampling artifact an FFT would need. Pure-Python (no numpy dependency).
+  - **LF:HF is a DESCRIPTIVE ratio, not "sympatho-vagal balance"** (Billman 2013): LF is mixed baroreflex/
+    autonomic, not a clean sympathetic index. We report it as a trend, labelled, never as a balance measure.
+  - **Poincaré SD1 ≡ RMSSD/√2** and SD2 maps to SDNN — SD1 carries no information beyond RMSSD, so it is a
+    visualisation, and the genuinely additive non-linear signal is the SD2/SD1 ratio.
+
+Consumes B0-cleaned, contiguous segments (clean_segments) so beat-detection artifact doesn't leak into the
+spectrum. HF band carries beat-detection jitter, so an artifact-% caveat should always travel with these.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import atan2, cos, pi, sin, sqrt
+
+# Standard HRV frequency bands (Hz) — Task Force 1996.
+VLF_BAND = (0.0033, 0.04)
+LF_BAND = (0.04, 0.15)
+HF_BAND = (0.15, 0.40)
+
+MIN_WINDOW_SEC = 300.0   # ≥5 min — below this, spectral HRV is not validly interpretable
+MIN_BEATS = 150          # and enough beats to resolve the bands
+FREQ_STEP = 0.002        # spectral grid resolution (Hz)
+
+
+def sdnn(intervals: list[float]) -> float | None:
+    """Standard deviation of RR intervals (ms)."""
+    n = len(intervals)
+    if n < 2:
+        return None
+    m = sum(intervals) / n
+    return sqrt(sum((x - m) ** 2 for x in intervals) / n)
+
+
+@dataclass
+class Poincare:
+    sd1: float   # short-term variability ≡ RMSSD/√2 (visualisation, not independent of RMSSD)
+    sd2: float   # long-term variability (maps to SDNN)
+    ratio: float  # SD2/SD1 — the genuinely additive non-linear signal
+
+    def as_dict(self) -> dict:
+        return {"sd1": round(self.sd1, 1), "sd2": round(self.sd2, 1),
+                "sd2_sd1_ratio": round(self.ratio, 2),
+                "note": "SD1 ≡ RMSSD/√2 (visualisation); SD2/SD1 is the additive non-linear signal."}
+
+
+def poincare(intervals: list[float]) -> Poincare | None:
+    """Poincaré SD1/SD2 from successive-difference geometry. SD1 = SD(diffs)/√2, SD2 = √(2·SDNN² − SD1²)."""
+    if len(intervals) < 3:
+        return None
+    diffs = [intervals[i + 1] - intervals[i] for i in range(len(intervals) - 1)]
+    n = len(diffs)
+    dmean = sum(diffs) / n
+    sdsd = sqrt(sum((d - dmean) ** 2 for d in diffs) / n)
+    sd1 = sdsd / sqrt(2)
+    sd = sdnn(intervals) or 0.0
+    sd2_sq = 2 * sd * sd - sd1 * sd1
+    sd2 = sqrt(sd2_sq) if sd2_sq > 0 else 0.0
+    ratio = sd2 / sd1 if sd1 > 0 else 0.0
+    return Poincare(sd1=sd1, sd2=sd2, ratio=ratio)
+
+
+def _lomb_scargle_power(times: list[float], values: list[float], freq: float) -> float:
+    """Lomb-Scargle spectral power at one frequency for unevenly-sampled (times, values). Press & Rybicki
+    normalisation. `values` should be mean-subtracted by the caller."""
+    w = 2.0 * pi * freq
+    s2 = sum(sin(2 * w * t) for t in times)
+    c2 = sum(cos(2 * w * t) for t in times)
+    tau = atan2(s2, c2) / (2 * w) if w != 0 else 0.0
+    cos_sum = sin_sum = cc = ss = 0.0
+    for t, x in zip(times, values):
+        c = cos(w * (t - tau))
+        s = sin(w * (t - tau))
+        cos_sum += x * c
+        sin_sum += x * s
+        cc += c * c
+        ss += s * s
+    p_c = (cos_sum * cos_sum / cc) if cc > 0 else 0.0
+    p_s = (sin_sum * sin_sum / ss) if ss > 0 else 0.0
+    return 0.5 * (p_c + p_s)
+
+
+@dataclass
+class SpectralHRV:
+    vlf: float
+    lf: float
+    hf: float
+    total_power: float
+    lf_hf: float          # DESCRIPTIVE ratio — NOT sympatho-vagal balance
+    lf_nu: float          # LF in normalised units: LF/(LF+HF)*100
+    hf_nu: float
+    window_sec: float
+    beats: int
+
+    def as_dict(self) -> dict:
+        return {
+            "vlf": round(self.vlf, 1), "lf": round(self.lf, 1), "hf": round(self.hf, 1),
+            "total_power": round(self.total_power, 1),
+            "lf_hf": round(self.lf_hf, 2), "lf_nu": round(self.lf_nu, 1), "hf_nu": round(self.hf_nu, 1),
+            "window_sec": round(self.window_sec), "beats": self.beats,
+            "note": ("LF:HF is a descriptive ratio, NOT a sympatho-vagal balance measure. "
+                     "HF ≈ vagal/respiratory; LF is mixed baroreflex/autonomic."),
+        }
+
+
+def frequency_domain(intervals: list[float]) -> SpectralHRV | None:
+    """Lomb-Scargle frequency-domain HRV over a single contiguous RR segment. Returns None unless the window
+    is ≥5 min and ≥150 beats (short-window spectra are not validly interpretable)."""
+    if len(intervals) < MIN_BEATS:
+        return None
+    # Time axis = cumulative beat times (seconds); RR in ms.
+    times: list[float] = []
+    t = 0.0
+    for rr in intervals:
+        t += rr / 1000.0
+        times.append(t)
+    if times[-1] < MIN_WINDOW_SEC:
+        return None
+
+    mean_rr = sum(intervals) / len(intervals)
+    values = [x - mean_rr for x in intervals]   # detrend (remove DC)
+
+    def band_power(lo: float, hi: float) -> float:
+        f = lo
+        p = 0.0
+        while f < hi:
+            p += _lomb_scargle_power(times, values, f) * FREQ_STEP
+            f += FREQ_STEP
+        return p
+
+    vlf = band_power(*VLF_BAND)
+    lf = band_power(*LF_BAND)
+    hf = band_power(*HF_BAND)
+    total = vlf + lf + hf
+    lf_hf = lf / hf if hf > 0 else 0.0
+    denom = lf + hf
+    lf_nu = 100.0 * lf / denom if denom > 0 else 0.0
+    hf_nu = 100.0 * hf / denom if denom > 0 else 0.0
+    return SpectralHRV(vlf=vlf, lf=lf, hf=hf, total_power=total, lf_hf=lf_hf,
+                       lf_nu=lf_nu, hf_nu=hf_nu, window_sec=times[-1], beats=len(intervals))

--- a/rivaflow/rivaflow/core/hrv_spectral.py
+++ b/rivaflow/rivaflow/core/hrv_spectral.py
@@ -111,6 +111,60 @@ class SpectralHRV:
         }
 
 
+def dfa_alpha1(intervals: list[float], min_box: int = 4, max_box: int = 16) -> dict | None:
+    """B18 — DFA α1 (short-term detrended fluctuation scaling exponent), research-grade and artifact-fragile
+    (WHOOP_FUTURE_STATE_PLAN.md B18). α1 ≈ 0.75 ↔ aerobic threshold (VT1); ≈ 0.5 ↔ anaerobic (VT2). REQUIRES
+    near-ECG-grade RR — the caller must gate on artifact-% (suppress above ~3%) and treat it as experimental.
+    Returns None with too few beats."""
+    n = len(intervals)
+    if n < max_box * 4:
+        return None
+    mean_rr = sum(intervals) / n
+    y = []                                   # integrated (cumulative-sum) profile
+    acc = 0.0
+    for x in intervals:
+        acc += x - mean_rr
+        y.append(acc)
+
+    logs: list[tuple[float, float]] = []
+    box = min_box
+    while box <= max_box:
+        fluct = []
+        for start in range(0, n - box + 1, box):
+            seg = y[start:start + box]
+            # linear detrend of the box
+            xs = list(range(box))
+            mx = (box - 1) / 2.0
+            my = sum(seg) / box
+            sxx = sum((xi - mx) ** 2 for xi in xs)
+            sxy = sum((xi - mx) * (si - my) for xi, si in zip(xs, seg))
+            slope = sxy / sxx if sxx else 0.0
+            intercept = my - slope * mx
+            fluct.append(sum((si - (slope * xi + intercept)) ** 2 for xi, si in zip(xs, seg)) / box)
+        if fluct:
+            f_n = (sum(fluct) / len(fluct)) ** 0.5
+            if f_n > 0:
+                from math import log as _log
+                logs.append((_log(box), _log(f_n)))
+        box += 1
+    if len(logs) < 3:
+        return None
+    # slope of log F(n) vs log n = alpha1
+    mlx = sum(p[0] for p in logs) / len(logs)
+    mly = sum(p[1] for p in logs) / len(logs)
+    sxx = sum((p[0] - mlx) ** 2 for p in logs)
+    sxy = sum((p[0] - mlx) * (p[1] - mly) for p in logs)
+    alpha1 = sxy / sxx if sxx else 0.0
+    if alpha1 >= 0.75:
+        zone = "aerobic (≤VT1)"
+    elif alpha1 >= 0.5:
+        zone = "threshold (VT1–VT2)"
+    else:
+        zone = "hard (≥VT2)"
+    return {"alpha1": round(alpha1, 3), "zone": zone, "beats": n,
+            "note": "Experimental; α1≈0.75↔VT1, ≈0.5↔VT2. Only trust with low artifact (<~3%) RR."}
+
+
 def frequency_domain(intervals: list[float]) -> SpectralHRV | None:
     """Lomb-Scargle frequency-domain HRV over a single contiguous RR segment. Returns None unless the window
     is ≥5 min and ≥150 beats (short-window spectra are not validly interpretable)."""

--- a/rivaflow/rivaflow/core/longevity.py
+++ b/rivaflow/rivaflow/core/longevity.py
@@ -1,0 +1,48 @@
+"""P2 longevity layer (pure core): B14 passive VO2max, B15 cardiovascular-age PROXY.
+
+Web-surfaced trend estimates from RHR + HRV + demographics (WHOOP_FUTURE_STATE_PLAN.md B14/B15), with the
+red-team's honesty guards: VO2max is a BANDED RANGE (not a point), and cardio-age is explicitly a PROXY with
+no alarming arrows — true arterial-stiffness age needs the locked PPG pulse-wave morphology.
+"""
+
+from __future__ import annotations
+
+VO2_BAND = 3.5   # ± ml/kg/min — the honest uncertainty on a non-exercise estimate
+
+# Rough age-expected VO2max for a trained-ish male (ml/kg/min), for the cardio-age PROXY only.
+VO2_EXPECTED_AT_30 = 48.0
+VO2_DECLINE_PER_YEAR = 0.4
+
+
+def passive_vo2max(hr_max: float, hr_rest: float) -> dict:
+    """Uth–Sørensen–Overgaard non-exercise estimate: VO2max ≈ 15.3 · (HRmax/HRrest). Presented as a BANDED
+    range, never a single point (red-team requirement)."""
+    if hr_rest <= 0 or hr_max <= 0 or hr_max <= hr_rest:
+        return {"available": False, "reason": "Need a valid max-HR above resting HR."}
+    point = 15.3 * (hr_max / hr_rest)
+    return {
+        "available": True,
+        "vo2max_estimate": round(point, 1),
+        "range": [round(point - VO2_BAND, 1), round(point + VO2_BAND, 1)],
+        "method": "Uth HRmax/HRrest ratio (non-exercise)",
+        "note": "Banded estimate from HR ratio — not a lab measurement; present as a range/trend.",
+    }
+
+
+def cardio_age_proxy(vo2max: float, age: float) -> dict:
+    """A PROXY fitness-age from VO2max vs age-expected norms — NOT arterial-stiffness age (that needs locked
+    PPG morphology). Deliberately caveated, no alarming arrow: a lower number is better, framed neutrally."""
+    if vo2max <= 0:
+        return {"available": False, "reason": "Need a VO2max estimate first."}
+    expected_now = VO2_EXPECTED_AT_30 - VO2_DECLINE_PER_YEAR * (age - 30)
+    # fitter-than-expected → younger proxy; each 0.4 ml/kg/min ≈ one year.
+    fitness_age = age + (expected_now - vo2max) / VO2_DECLINE_PER_YEAR
+    fitness_age = max(18.0, min(90.0, fitness_age))
+    return {
+        "available": True,
+        "cardio_age_proxy": round(fitness_age, 1),
+        "chronological_age": age,
+        "is_proxy": True,
+        "note": ("A PROXY from VO2max vs age norms — not clinical arterial-stiffness age (needs locked PPG). "
+                 "A trend to watch gently, not a health verdict."),
+    }

--- a/rivaflow/rivaflow/core/max_hr.py
+++ b/rivaflow/rivaflow/core/max_hr.py
@@ -1,0 +1,92 @@
+"""B1 — Personalised Max-HR calibration (the pure core).
+
+Kills the hardcoded MAX_HR=190 that distorts every HR zone, strain, and stress value
+(WHOOP_CURRENT_STATE.md §3; WHOOP_FUTURE_STATE_PLAN.md B1). 190 is a ~30yo default (220−30); Ruby's
+age-predicted max is ~177 (Tanaka), so the old constant sat ~13 bpm too high and inflated every zone.
+
+Two review-mandated guards live here:
+  - **Artifact-rejected sustained plateau**, not a 1-sample spike. Optical HR throws motion/cadence-lock
+    spikes; a lone high sample must NOT set max-HR. We take the highest HR *held continuously* for a
+    plateau window (≥10 s), computed as the max over sliding windows of the window minimum.
+  - **Sub-maximal floor + uncertainty band.** A low-endurance athlete who rarely reaches true max will
+    under-observe HRmax, so when the observed sustained max sits below the age-predicted (Tanaka) value we
+    treat it as a FLOOR and fall back to Tanaka, flagged — never silently trusting an under-estimate.
+    Every estimate carries a band (Tanaka population SD ≈ ±10 bpm) because downstream zones inherit its error.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+TANAKA_INTERCEPT = 208.0
+TANAKA_SLOPE = 0.7
+POP_SD = 10          # Tanaka population SD ≈ ±10 bpm — the honest band on a predicted max
+OBSERVED_BAND = 5    # tighter band when we have a measured sustained max
+DEFAULT_PLATEAU_SEC = 10
+HR_FLOOR, HR_CEILING = 30, 220   # reject impossible readings before calibrating
+
+
+def tanaka_max(age: float) -> float:
+    """Age-predicted maximum HR (Tanaka 2001): 208 − 0.7·age. Population mean, SD ≈ ±10 bpm."""
+    return TANAKA_INTERCEPT - TANAKA_SLOPE * age
+
+
+def sustained_max(hr: list[int], window: int) -> int | None:
+    """Highest HR held continuously for `window` samples = max over sliding windows of the window minimum.
+    A 1-sample spike can't raise it (the rest of its window pulls the minimum down), so motion/cadence
+    artifact is rejected. O(n) via a monotonic deque. Returns None if there aren't `window` samples."""
+    if window <= 0 or len(hr) < window:
+        return None
+    dq: deque[int] = deque()   # indices, values increasing → front is the window minimum
+    best: int | None = None
+    for i, v in enumerate(hr):
+        while dq and hr[dq[-1]] >= v:
+            dq.pop()
+        dq.append(i)
+        if dq[0] <= i - window:
+            dq.popleft()
+        if i >= window - 1:
+            wmin = hr[dq[0]]
+            if best is None or wmin > best:
+                best = wmin
+    return best
+
+
+def calibrate_max_hr(hr_samples: list[int], age: float, plateau_sec: int = DEFAULT_PLATEAU_SEC,
+                     hz: float = 1.0) -> dict:
+    """Calibrate a personal max-HR from HR samples + age. Prefers an artifact-rejected observed sustained
+    max when it exceeds the age-predicted value; otherwise falls back to Tanaka with the observed value
+    flagged as a sub-maximal floor. Always returns a usable `max_hr` (Tanaka when no data)."""
+    tanaka = tanaka_max(age)
+    window = max(1, int(round(plateau_sec * hz)))
+    hr = [int(x) for x in hr_samples if x is not None and HR_FLOOR <= int(x) <= HR_CEILING]
+    observed = sustained_max(hr, window)
+
+    if observed is not None and observed >= tanaka:
+        estimate = float(observed)
+        source, floor = "observed_sustained", False
+        band = (observed - OBSERVED_BAND, observed + OBSERVED_BAND)
+        note = "Observed sustained max at/above age-predicted — using the measured value."
+    else:
+        estimate = tanaka
+        source = "tanaka_default"
+        floor = observed is not None and observed < tanaka
+        band = (tanaka - POP_SD, tanaka + POP_SD)
+        if floor:
+            note = (f"Observed sustained max {observed} is below age-predicted {round(tanaka)} — likely "
+                    f"sub-maximal effort; treating observed as a floor and using the Tanaka estimate. "
+                    f"One true max-effort test would anchor this.")
+        else:
+            note = "Not enough near-max effort captured — using the age-predicted (Tanaka) estimate."
+
+    return {
+        "max_hr": round(estimate),
+        "source": source,
+        "observed_sustained": observed,
+        "tanaka": round(tanaka),
+        "floor": floor,
+        "uncertainty": [round(band[0]), round(band[1])],
+        "plateau_sec": plateau_sec,
+        "samples": len(hr),
+        "note": note,
+    }

--- a/rivaflow/rivaflow/core/max_hr.py
+++ b/rivaflow/rivaflow/core/max_hr.py
@@ -65,7 +65,7 @@ def calibrate_max_hr(hr_samples: list[int], age: float, plateau_sec: int = DEFAU
     if observed is not None and observed >= tanaka:
         estimate = float(observed)
         source, floor = "observed_sustained", False
-        band = (observed - OBSERVED_BAND, observed + OBSERVED_BAND)
+        band = (float(observed - OBSERVED_BAND), float(observed + OBSERVED_BAND))
         note = "Observed sustained max at/above age-predicted — using the measured value."
     else:
         estimate = tanaka

--- a/rivaflow/rivaflow/core/prevention.py
+++ b/rivaflow/rivaflow/core/prevention.py
@@ -1,0 +1,112 @@
+"""B6 — Baseline-Deviation Watch (the prevention engine's pure core).
+
+The centrepiece, rebuilt to every safety property the Fable review + confirmation pass demanded
+(WHOOP_FUTURE_STATE_PLAN.md B6). Detects *deviation from personal baseline*, NEVER disease.
+
+  - **FOUR signals, no cardiac rhythm.** RHR, lnRMSSD/HF suppression, respiratory-rate rise, nocturnal
+    sleeping-HR — the AFib-class signal is not here and never contributes to an always-fire alert.
+  - **Signal FAMILIES enforce independence.** RHR and sleeping-HR co-move (alcohol, warm room) so they are
+    one "nocturnal-HR" family counted once; lnRMSSD is the vagal family; resp-rate the respiratory family.
+    Co-occurrence requires flagged signals across ≥2 DISTINCT families — one perturbation can't self-corroborate.
+  - **Robust baselines (median / MAD), not mean±SD**, so a single anomaly can't desensitise the detector.
+  - **Respiratory rate can never fire alone** (least-validated signal) — it needs a second family, and a solo
+    CUSUM/z breach never raises a tier by itself.
+  - **Tier → channel map is explicit.** 🟢 green carries the "green ≠ healthy" caveat; 🟡 amber and 🔴 red are
+    the SAFETY channel and fire on Sunday (early-warning, not a coaching nudge). Never diagnostic.
+"""
+
+from __future__ import annotations
+
+from statistics import median
+
+AMBER_Z = 1.5
+RED_Z = 2.0
+MAD_SCALE = 1.4826   # scales MAD to a normal-consistent SD estimate
+
+# Which family each signal belongs to (co-occurrence counts families, not signals).
+SIGNAL_FAMILY = {
+    "rhr": "nocturnal_hr",
+    "sleeping_hr": "nocturnal_hr",
+    "lnrmssd": "vagal",
+    "resp_rate": "respiratory",
+}
+# Direction in which the signal indicates strain/worsening.
+WORSE_WHEN = {"rhr": "high", "sleeping_hr": "high", "lnrmssd": "low", "resp_rate": "high"}
+
+GREEN_CAVEAT = (
+    "No deviation in the signals I can measure (HR, HRV, breathing) — I'm blind to temperature and blood "
+    "oxygen, so trust your symptoms over a green light."
+)
+AMBER_COPY = ("Your autonomics are working harder than your baseline — could be illness, training, alcohol, "
+              "heat, or poor sleep. Ease today and watch.")
+RED_COPY = ("Strong multi-signal deviation from your baseline — rest and recover. This is not a diagnosis; "
+            "if you feel unwell, see a clinician.")
+
+
+def mad(values: list[float], med: float | None = None) -> float:
+    """Median absolute deviation."""
+    if not values:
+        return 0.0
+    m = med if med is not None else median(values)
+    return median([abs(v - m) for v in values])
+
+
+def robust_baseline(values: list[float]) -> dict | None:
+    """Median + MAD baseline. Robust to outliers, unlike mean±SD (a single spike inflates SD and blinds the
+    detector to the next anomaly). Returns None with too few points."""
+    if len(values) < 5:
+        return None
+    m = median(values)
+    return {"median": m, "mad": mad(values, m)}
+
+
+def robust_z(value: float, median_: float, mad_: float, worse_when: str) -> float:
+    """Signed deviation where POSITIVE always means 'more strained'. Uses MAD-scaled distance; a zero MAD
+    falls back to a tiny scale so identical history doesn't divide by zero."""
+    scale = MAD_SCALE * mad_ if mad_ > 0 else 1.0
+    z = (value - median_) / scale
+    return z if worse_when == "high" else -z
+
+
+def evaluate_prevention(readings: dict[str, dict], today_is_sabbath: bool = False) -> dict:
+    """Fuse per-signal readings into a tier. `readings` maps signal name → {value, median, mad}; include only
+    signals that have a baseline. Deterministic and DB-free. Sabbath does NOT silence this — it is the safety
+    channel."""
+    if "lnrmssd" not in readings and len(readings) < 2:
+        return {"available": False, "reason": "Building baselines — need more covered days."}
+
+    family_worse: dict[str, float] = {}
+    drivers: list[dict] = []
+    for name, r in readings.items():
+        if name not in SIGNAL_FAMILY:
+            continue
+        wz = robust_z(r["value"], r["median"], r["mad"], WORSE_WHEN[name])
+        fam = SIGNAL_FAMILY[name]
+        family_worse[fam] = max(family_worse.get(fam, float("-inf")), wz)
+        drivers.append({"signal": name, "family": fam, "worse_z": round(wz, 2),
+                        "flagged": wz >= AMBER_Z})
+
+    flagged_families = [f for f, z in family_worse.items() if z >= AMBER_Z]
+    strong_families = [f for f, z in family_worse.items() if z >= RED_Z]
+    drivers.sort(key=lambda d: d["worse_z"], reverse=True)
+
+    # ≥2 DISTINCT families required for any alert → resp (one family) can never fire alone.
+    if len(strong_families) >= 2:
+        tier, channel, headline, caveat = "red", "safety", RED_COPY, None
+    elif len(flagged_families) >= 2:
+        tier, channel, headline, caveat = "amber", "safety", AMBER_COPY, None
+    else:
+        tier, channel, headline, caveat = "green", "neutral", "In range across the signals I can measure.", GREEN_CAVEAT
+
+    return {
+        "available": True,
+        "tier": tier,
+        "channel": channel,
+        "fires_on_sabbath": channel == "safety",   # amber/red are safety → fire Sunday; green is neutral
+        "headline": headline,
+        "caveat": caveat,
+        "flagged_families": flagged_families,
+        "drivers": drivers,
+        "diagnostic": False,
+        "note": "Detects deviation from your own baseline, not disease. Not a medical device.",
+    }

--- a/rivaflow/rivaflow/core/readiness.py
+++ b/rivaflow/rivaflow/core/readiness.py
@@ -1,0 +1,134 @@
+"""B2 — Multi-input Readiness (the pure fusion core).
+
+The daily "push vs rest" verdict Ruby actually asked for (WHOOP_FUTURE_STATE_PLAN.md B2). Reproduces the
+WHOOP-Recovery / Fitbit-Daily-Readiness shape from the HR+RR we own: an HRV-led blend of deviation-from-
+personal-baseline across four signals, every one scored on its OWN rolling baseline, never population norms.
+
+Two review-mandated properties live here, not in the DB wiring, so they are unit-testable without a database:
+  - HRV enters as **lnRMSSD** (log scale). RMSSD is right-skewed, so a Gaussian z on raw RMSSD over-flags
+    low-HRV days and under-flags high ones (Plews/Buchheit; this was the B0/physiology critical fix).
+  - Every green/in-range verdict carries the **"green ≠ healthy"** caveat — HR/HRV/breathing can read normal
+    while a fever or hypoxic event (temperature + SpO2, both locked) is incubating.
+
+Weights are HRV-led with sleep and respiratory rate deliberately down-weighted (resp-rate is our least-
+validated signal — WHOOP_FUTURE_STATE_PLAN.md red team). Missing signals are renormalised away so a cold
+start on one input doesn't distort the blend; HRV is required (it is the led signal).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean, pstdev
+
+# HRV-led; sleep + resp down-weighted (resp is needs-validation). Sum to 1.0 when all present.
+WEIGHTS = {"hrv": 0.50, "rhr": 0.25, "sleep": 0.15, "resp": 0.10}
+
+# Sign convention: +z on the raw metric → does it mean BETTER recovery (+1) or WORSE (-1)?
+DIRECTION = {"hrv": +1, "rhr": -1, "sleep": +1, "resp": -1}
+
+LABELS = {
+    "hrv": "HRV (lnRMSSD)",
+    "rhr": "Nocturnal resting HR",
+    "sleep": "Sleep vs need",
+    "resp": "Respiratory rate",
+}
+
+MIN_BASELINE_DAYS = 5  # cold-start guard before a signal's z-score is meaningful
+
+GREEN_CAVEAT = (
+    "Green means no deviation in the signals I can measure (HR, HRV, breathing) — "
+    "I'm blind to temperature and blood oxygen, so trust your symptoms over a green light."
+)
+
+
+def zscore(values: list[float], window: int = 7) -> dict | None:
+    """z-score of the latest value vs the personal baseline formed by the PRIOR `window` days.
+    Returns None when there aren't enough prior days for a meaningful baseline. Pass values already on the
+    intended scale (e.g. lnRMSSD, not RMSSD)."""
+    if not values or len(values) < MIN_BASELINE_DAYS + 1:
+        return None
+    today = values[-1]
+    prior = values[-(window + 1):-1]
+    if len(prior) < MIN_BASELINE_DAYS:
+        prior = values[:-1]
+    b_mean = mean(prior)
+    b_sd = pstdev(prior) or 1.0
+    return {"z": (today - b_mean) / b_sd, "baseline_mean": b_mean, "baseline_sd": b_sd, "n": len(prior)}
+
+
+@dataclass
+class Contributor:
+    signal: str
+    label: str
+    z: float                 # raw z on the metric
+    weight: float            # renormalised weight actually applied
+    ready_contribution: float  # signed, recovery-oriented contribution to the composite
+
+    def as_dict(self) -> dict:
+        return {
+            "signal": self.signal,
+            "label": self.label,
+            "z": round(self.z, 2),
+            "weight": round(self.weight, 3),
+            "effect": round(self.ready_contribution, 3),
+            "direction": "supports recovery" if self.ready_contribution >= 0 else "drags recovery",
+        }
+
+
+def blend_readiness(signal_z: dict[str, float | None], today_is_sabbath: bool = False) -> dict:
+    """Fuse per-signal z-scores into one readiness verdict. `signal_z` maps signal name → raw z (or None if
+    that signal has no baseline yet). HRV is required; the rest renormalise around what's available."""
+    if today_is_sabbath:
+        return {
+            "state": "Rest",
+            "headline": "Sabbath — rest is prescribed. No score today.",
+            "driver": "sabbath",
+            "score": None,
+            "caveat": None,
+        }
+
+    if signal_z.get("hrv") is None:
+        present = sum(1 for v in signal_z.values() if v is not None)
+        return {
+            "state": "Building",
+            "headline": "Building your HRV baseline — need a few more days of resting RR.",
+            "driver": "cold_start",
+            "score": None,
+            "signals_available": present,
+            "caveat": None,
+        }
+
+    # Renormalise weights over the signals we actually have.
+    available = {k: v for k, v in signal_z.items() if v is not None and k in WEIGHTS}
+    wsum = sum(WEIGHTS[k] for k in available)
+    contributors: list[Contributor] = []
+    composite = 0.0
+    for name, z in available.items():
+        w = WEIGHTS[name] / wsum
+        contribution = w * z * DIRECTION[name]
+        composite += contribution
+        contributors.append(Contributor(name, LABELS[name], z, w, contribution))
+
+    # Bands on the recovery-oriented composite z (higher = more recovered).
+    if composite >= 0.5:
+        state, head = "Prime", "Above your baseline — green light to train hard."
+    elif composite >= -0.5:
+        state, head = "Balanced", "In your normal range — train as planned."
+    elif composite >= -1.5:
+        state, head = "Strained", "Below baseline — technical/skills over hard rolls today."
+    else:
+        state, head = "Rundown", "Well below baseline — prioritise recovery."
+
+    contributors.sort(key=lambda c: abs(c.ready_contribution), reverse=True)
+    caveat = GREEN_CAVEAT if state in ("Prime", "Balanced") else None
+
+    return {
+        "state": state,
+        "headline": head,
+        "driver": "multi_input_lnrmssd_led",
+        "score": max(0, min(100, round(50 + composite * 20))),
+        "composite_z": round(composite, 2),
+        "contributors": [c.as_dict() for c in contributors],
+        "signals_used": [c.signal for c in contributors],
+        "caveat": caveat,
+    }

--- a/rivaflow/rivaflow/core/resilience.py
+++ b/rivaflow/rivaflow/core/resilience.py
@@ -1,0 +1,45 @@
+"""B16 — Resilience & Cumulative Stress (pure core).
+
+Slow-burn burnout warning (WHOOP_FUTURE_STATE_PLAN.md B16): 14-day bounce-back capacity + a 31-day chronic
+stress scan (Oura-style), from the daily lnRMSSD series and per-day strain flags. Trends, not verdicts.
+"""
+
+from __future__ import annotations
+
+from statistics import mean, pstdev
+
+RESILIENCE_LEVELS = ["Limited", "Adequate", "Solid", "Strong", "Exceptional"]
+
+
+def resilience(recent_lnrmssd: list[float], baseline_lnrmssd: list[float]) -> dict:
+    """Bounce-back capacity over the recent (≈14d) window vs a longer baseline. High = recent HRV sits at/above
+    baseline AND is stable (low variability). Maps to the 5 Oura levels."""
+    if len(recent_lnrmssd) < 5 or len(baseline_lnrmssd) < 7:
+        return {"available": False, "reason": "Need ~2 weeks recent + a longer baseline for resilience."}
+    b_mean = mean(baseline_lnrmssd)
+    b_sd = pstdev(baseline_lnrmssd) or 1.0
+    level_z = (mean(recent_lnrmssd) - b_mean) / b_sd            # where recent sits vs baseline
+    stability = 1.0 - min(1.0, (pstdev(recent_lnrmssd) / (b_sd or 1.0)))   # 1 = very stable
+    score = max(0, min(100, round(50 + level_z * 20 + stability * 20)))
+    idx = min(4, max(0, score // 20))
+    return {"available": True, "score": score, "level": RESILIENCE_LEVELS[idx],
+            "level_vs_baseline_z": round(level_z, 2), "stability": round(stability, 2),
+            "headline": f"Resilience {RESILIENCE_LEVELS[idx]} — bounce-back capacity over the last two weeks."}
+
+
+def cumulative_stress(strained_flags: list[bool], window: int = 31) -> dict:
+    """31-day chronic-stress scan: how many of the last `window` days were strained (amber/red or suppressed
+    HRV). A rising count is the burnout early-warning daily scores normalise away."""
+    if not strained_flags:
+        return {"available": False, "reason": "No daily stress flags yet."}
+    recent = strained_flags[-window:]
+    load = sum(1 for f in recent if f)
+    pct = 100.0 * load / len(recent)
+    if pct < 20:
+        band, head = "low", "Low chronic stress load."
+    elif pct < 40:
+        band, head = "moderate", "Moderate chronic load — keep an eye on recovery."
+    else:
+        band, head = "high", "High chronic stress load over the month — plan a deload."
+    return {"available": True, "strained_days": load, "days": len(recent),
+            "pct": round(pct, 1), "band": band, "headline": head}

--- a/rivaflow/rivaflow/core/rr_quality.py
+++ b/rivaflow/rivaflow/core/rr_quality.py
@@ -1,0 +1,160 @@
+"""B0 — RR/HR signal characterisation & quality gate.
+
+The foundation build every RR-derived metric consumes (WHOOP_FUTURE_STATE_PLAN.md B0).
+
+Our RR series is *optical pulse-to-pulse intervals* emitted by WHOOP's firmware over the standard 0x2A37
+field — NOT ECG RR — and the raw optical waveform needed for an independent signal-quality index is the
+locked R22 stream (WHOOP_CURRENT_STATE.md §2). So we inherit WHOOP's beat-detection artifact (pulse-transit
+jitter, missed/extra beats, benign ectopy) with no waveform to gate on. This module is the best defence we
+can build from the interval series alone:
+
+  1. Physiological band filter — widened for a bradycardic athlete (36–133 bpm; the old 40–90 band clipped
+     genuine slow nocturnal beats and biased RMSSD downward).
+  2. Malik-style *relative* successive filter — flag an interval differing >20% from the preceding valid
+     one (the old absolute <400 ms drop let single-ectopic jumps through, inflating RMSSD).
+  3. Ectopy correction by linear interpolation of isolated flagged beats.
+  4. Per-series artifact-% + a usability gate, reported alongside every downstream value so trust is visible.
+
+RMSSD is exquisitely sensitive to a single mis-detected beat, so this gate is not optional polish — it is
+what makes the readiness / prevention signals trustworthy. lnRMSSD and the baseline math live in B2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import log, sqrt
+
+# --- Quality-gate constants (WHOOP_CURRENT_STATE.md §3 limitations + WHOOP_FUTURE_STATE_PLAN.md B0) ---
+RR_MIN_MS = 450                 # 133 bpm — upper HR bound of a plausible resting/nocturnal beat
+RR_MAX_MS = 1667                # ~36 bpm — widened for nocturnal bradycardia (was 1500 ms / 40 bpm, too tight)
+MALIK_REL_THRESHOLD = 0.20      # flag RR differing >20% from the preceding valid interval (relative, not absolute)
+MAX_ARTIFACT_FRACTION = 0.30    # a series with >30% flagged intervals is not trustworthy for HRV
+MIN_CLEAN_INTERVALS = 20        # minimum corrected intervals for a valid HRV window
+MIN_CLEAN_SEGMENT = 30          # minimum contiguous clean run to count as a usable segment
+
+
+@dataclass
+class RRQuality:
+    """Result of the QC gate over one RR series. `cleaned` is the artifact-corrected series that downstream
+    metrics consume; `artifact_pct` travels with every value they emit."""
+
+    cleaned: list[float] = field(default_factory=list)   # band-valid + interpolated intervals (ms)
+    artifact_pct: float = 100.0                           # % of raw intervals flagged (band + relative)
+    n_raw: int = 0
+    n_flagged: int = 0
+    corrected_idx: list[int] = field(default_factory=list)  # indices in `cleaned` replaced by interpolation
+    usable: bool = False                                  # enough clean data AND artifact_pct within budget
+
+    def as_meta(self) -> dict:
+        """Compact provenance dict to attach to any metric computed from this series."""
+        return {
+            "artifact_pct": round(self.artifact_pct, 1),
+            "intervals_used": len(self.cleaned),
+            "corrected": len(self.corrected_idx),
+            "usable": self.usable,
+        }
+
+
+def assess_rr(intervals: list[int | float]) -> RRQuality:
+    """Characterise and clean an RR series: physiological-band + Malik relative filtering, then linear
+    interpolation of isolated flagged beats. Returns the corrected series, the artifact fraction, and a
+    usability verdict. Deterministic and side-effect free — safe to call anywhere upstream of an HRV metric."""
+    raw = [float(x) for x in intervals if x is not None]
+    n_raw = len(raw)
+    if n_raw == 0:
+        return RRQuality(cleaned=[], artifact_pct=100.0, n_raw=0, n_flagged=0, usable=False)
+
+    # Pass 1 — band filter, then Malik relative filter against the last accepted interval.
+    # flagged[i] is True when raw[i] is out-of-band or a >20% jump from the last valid beat.
+    flagged = [False] * n_raw
+    last_valid: float | None = None
+    for i, rr in enumerate(raw):
+        if not (RR_MIN_MS <= rr <= RR_MAX_MS):
+            flagged[i] = True
+            continue
+        if last_valid is not None and abs(rr - last_valid) / last_valid > MALIK_REL_THRESHOLD:
+            flagged[i] = True
+            continue
+        last_valid = rr
+
+    n_flagged = sum(flagged)
+    artifact_pct = 100.0 * n_flagged / n_raw
+
+    # Pass 2 — build the corrected series by interpolating isolated flagged beats between valid neighbours.
+    # A flagged run with no valid neighbour on a side (series edge, or a long dropout) is discarded, which
+    # naturally breaks the series at true gaps rather than fabricating beats across them.
+    cleaned: list[float] = []
+    corrected_idx: list[int] = []
+    i = 0
+    while i < n_raw:
+        if not flagged[i]:
+            cleaned.append(raw[i])
+            i += 1
+            continue
+        # start of a flagged run [i, j)
+        j = i
+        while j < n_raw and flagged[j]:
+            j += 1
+        prev_valid = cleaned[-1] if cleaned else None
+        next_valid = raw[j] if j < n_raw else None
+        if prev_valid is not None and next_valid is not None:
+            gap = j - i
+            step = (next_valid - prev_valid) / (gap + 1)
+            for k in range(1, gap + 1):
+                corrected_idx.append(len(cleaned))
+                cleaned.append(prev_valid + step * k)
+        # else: edge/long-dropout flagged run — drop it (segment boundary)
+        i = j
+
+    usable = len(cleaned) >= MIN_CLEAN_INTERVALS and artifact_pct <= MAX_ARTIFACT_FRACTION * 100.0
+    return RRQuality(
+        cleaned=cleaned,
+        artifact_pct=artifact_pct,
+        n_raw=n_raw,
+        n_flagged=n_flagged,
+        corrected_idx=corrected_idx,
+        usable=usable,
+    )
+
+
+def clean_segments(intervals: list[int | float], min_len: int = MIN_CLEAN_SEGMENT) -> list[list[float]]:
+    """Split an RR series into contiguous in-band, low-jump segments of at least `min_len` intervals —
+    the windows a frequency-domain or non-linear metric (B4) may run on. Unlike `assess_rr` this does NOT
+    interpolate; it returns only genuinely contiguous clean runs so no fabricated beat enters a spectral window."""
+    raw = [float(x) for x in intervals if x is not None]
+    segments: list[list[float]] = []
+    cur: list[float] = []
+    last_valid: float | None = None
+    for rr in raw:
+        in_band = RR_MIN_MS <= rr <= RR_MAX_MS
+        small_jump = last_valid is None or abs(rr - last_valid) / last_valid <= MALIK_REL_THRESHOLD
+        if in_band and small_jump:
+            cur.append(rr)
+            last_valid = rr
+        else:
+            if len(cur) >= min_len:
+                segments.append(cur)
+            cur = []
+            last_valid = None
+    if len(cur) >= min_len:
+        segments.append(cur)
+    return segments
+
+
+def rmssd(intervals: list[int | float]) -> float | None:
+    """RMSSD (ms) = sqrt(mean of squared successive differences). Expects an already-cleaned series
+    (call `assess_rr` first). Returns None if there are too few intervals to form a difference set."""
+    vals = [float(x) for x in intervals if x is not None]
+    if len(vals) < 2:
+        return None
+    diffs = [vals[i + 1] - vals[i] for i in range(len(vals) - 1)]
+    return sqrt(sum(d * d for d in diffs) / len(diffs))
+
+
+def ln_rmssd(intervals: list[int | float]) -> float | None:
+    """lnRMSSD — the log-transformed RMSSD that B2's baseline z-scores run on (RMSSD is right-skewed, so
+    Gaussian stats belong on the log scale; Plews/Buchheit). Returns None if RMSSD is undefined or <=0."""
+    r = rmssd(intervals)
+    if r is None or r <= 0:
+        return None
+    return log(r)

--- a/rivaflow/rivaflow/core/sleep_metrics.py
+++ b/rivaflow/rivaflow/core/sleep_metrics.py
@@ -1,0 +1,66 @@
+"""P1 sleep layer (pure core): B9 Sleep Need + Debt, B10 Sleep Regularity.
+
+Personalised to Ruby's >9h DNA sleep-need (WHOOP_FUTURE_STATE_PLAN.md B9/B10). All from the HR-based sleep
+windows we already estimate — need/debt accrual + onset/offset consistency, no locked sensor required.
+"""
+
+from __future__ import annotations
+
+from math import cos, log, pi, sin, sqrt
+from statistics import mean
+
+NEED_HOURS = 9.0        # Ruby's DNA sleep-need (>9h), not the generic 8h
+DEBT_WINDOW = 7         # rolling week of shortfall
+
+
+def sleep_debt(durations: list[float], need: float = NEED_HOURS, window: int = DEBT_WINDOW) -> dict:
+    """Accrued sleep debt = sum of nightly shortfalls vs need over the recent window. Positive debt means
+    under-slept vs his >9h need."""
+    if not durations:
+        return {"available": False, "reason": "No sleep history yet."}
+    recent = durations[-window:]
+    debt = sum(max(0.0, need - d) for d in recent)
+    avg = mean(recent)
+    last_short = max(0.0, need - durations[-1])
+    return {
+        "available": True,
+        "need_hours": need,
+        "recent_avg_hours": round(avg, 1),
+        "debt_hours": round(debt, 1),
+        "nights": len(recent),
+        "tonight_recommended_hours": round(need + min(2.0, last_short), 1),   # repay a little, capped
+        "headline": (f"{round(debt, 1)}h sleep debt over {len(recent)} nights vs your {need}h need."
+                     if debt > 0.5 else f"On top of your {need}h need — no meaningful debt."),
+    }
+
+
+def _circular_sd_hours(hours: list[float]) -> float:
+    """Circular SD (in hours) of times-of-day — 23:30 and 00:30 are 1h apart, not 23h. Returns 0 for a
+    single point; large for scattered times."""
+    angles = [h / 24.0 * 2 * pi for h in hours]
+    c = mean([cos(a) for a in angles])
+    s = mean([sin(a) for a in angles])
+    r = sqrt(c * c + s * s)
+    if r >= 1.0:
+        return 0.0
+    if r <= 1e-9:
+        return 24.0 / 4          # maximally dispersed → quarter-day-ish
+    circ_sd_rad = sqrt(-2.0 * log(r))
+    return circ_sd_rad * 24.0 / (2 * pi)
+
+
+def sleep_regularity(onset_hours: list[float]) -> dict:
+    """B10 — onset consistency. Lower circular SD of bed times = more regular. Score 0–100 (100 = perfectly
+    regular); a 2h onset SD maps to ~0. Cheap, reproducible from the sleep-window start alone."""
+    if len(onset_hours) < 3:
+        return {"available": False, "reason": "Need at least 3 nights for a regularity estimate."}
+    sd_h = _circular_sd_hours(onset_hours)
+    score = max(0, min(100, round(100 * (1 - sd_h / 2.0))))   # 0h SD → 100; >=2h SD → 0
+    if score >= 80:
+        head = "Very regular bedtimes — protective for recovery."
+    elif score >= 50:
+        head = "Fairly regular — tightening bedtime would help."
+    else:
+        head = "Irregular bedtimes — the biggest cheap win for your sleep."
+    return {"available": True, "onset_sd_hours": round(sd_h, 2), "score": score,
+            "nights": len(onset_hours), "headline": head}

--- a/rivaflow/rivaflow/core/strain_target.py
+++ b/rivaflow/rivaflow/core/strain_target.py
@@ -1,0 +1,69 @@
+"""B5 — Strain Target / Load Coach (the pure core).
+
+WHOOP's signature loop: turn today's readiness into a prescribed daily strain (0–21) and CAP it when the
+body is strained, so load never outruns recovery (WHOOP_FUTURE_STATE_PLAN.md B5). Tuned conservative for a
+masters, NSAID-sensitive, low-endurance grappler — a Strained/Rundown day prescribes a target BELOW his usual
+chronic load, not just "a bit less."
+
+Depends on B1: the 0–21 strain scale is only meaningful once HR zones use the calibrated max-HR, not the old
+190. Pure and DB-free; the wiring feeds it today's readiness state + recent cardio-load history.
+"""
+
+from __future__ import annotations
+
+STRAIN_CAP = 21.0
+DEFAULT_CHRONIC = 10.0   # neutral base when there's no load history yet (mid of the 0–21 scale)
+
+# Readiness state → fraction of the chronic (usual) daily load to prescribe. <1.0 = an explicit cap.
+STATE_MULTIPLIER = {
+    "Prime": 1.15,       # recovered — a little above usual is safe
+    "Balanced": 1.0,     # train as planned
+    "Strained": 0.6,     # ease off — technical work
+    "Rundown": 0.4,      # recovery day
+}
+
+# States that don't get a target at all.
+NO_TARGET_STATES = {"Rest", "Building", None}
+
+
+def prescribe_strain(state: str | None, chronic_load: float | None, acute_load: float | None = None) -> dict:
+    """Prescribe today's strain target from readiness `state` and the athlete's `chronic_load` (usual daily
+    strain). `acute_load` = today's strain so far, if known, to report headroom. Returns available=False for
+    Rest/Building/unknown states."""
+    if state in NO_TARGET_STATES:
+        reason = ("Sabbath — rest is prescribed." if state == "Rest"
+                  else "Building your baseline — no strain target yet.")
+        return {"available": False, "state": state, "reason": reason}
+
+    mult = STATE_MULTIPLIER.get(state)
+    if mult is None:
+        return {"available": False, "state": state, "reason": f"No strain policy for state '{state}'."}
+
+    base = chronic_load if (chronic_load and chronic_load > 0) else DEFAULT_CHRONIC
+    target = round(min(STRAIN_CAP, base * mult), 1)
+    band = [round(max(0.0, target - 2.0), 1), round(min(STRAIN_CAP, target + 2.0), 1)]
+    capped = mult < 1.0
+
+    headlines = {
+        "Prime": f"Recovered — you can push. Target strain {target}.",
+        "Balanced": f"Train as planned. Target strain {target}.",
+        "Strained": f"Ease off — capped at {target}, below your usual {round(base, 1)}.",
+        "Rundown": f"Recovery day — keep it light, max {target}.",
+    }
+
+    out = {
+        "available": True,
+        "state": state,
+        "target_load": target,
+        "band": band,
+        "capped": capped,
+        "chronic_load": round(base, 1),
+        "headline": headlines[state],
+    }
+    if acute_load is not None:
+        out["acute_load"] = round(acute_load, 1)
+        out["remaining"] = round(max(0.0, target - acute_load), 1)
+        if acute_load >= target:
+            out["headline"] = (f"You've hit today's target ({target}) — "
+                               + ("recover now." if capped else "more only if you feel good."))
+    return out

--- a/rivaflow/rivaflow/core/strain_target.py
+++ b/rivaflow/rivaflow/core/strain_target.py
@@ -35,6 +35,7 @@ def prescribe_strain(state: str | None, chronic_load: float | None, acute_load: 
                   else "Building your baseline — no strain target yet.")
         return {"available": False, "state": state, "reason": reason}
 
+    assert state is not None   # narrowed by the NO_TARGET_STATES guard above
     mult = STATE_MULTIPLIER.get(state)
     if mult is None:
         return {"available": False, "state": state, "reason": f"No strain policy for state '{state}'."}

--- a/rivaflow/rivaflow/core/training_load.py
+++ b/rivaflow/rivaflow/core/training_load.py
@@ -1,0 +1,74 @@
+"""P1 training-load layer (pure core): B7 ACWR, B8 Heart-Rate Recovery, B12 recovery-cost coupling.
+
+Injury-prevention + coaching math for a masters grappler (WHOOP_FUTURE_STATE_PLAN.md B7/B8/B12), all from
+HR + the daily cardio-load series. No mortality/prognostic framing — HRR is a within-person fitness trend.
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+
+# Gabbett acute:chronic workload zones.
+ACWR_UNDER = 0.8
+ACWR_SWEET_HI = 1.3
+ACWR_CAUTION_HI = 1.5
+
+
+def acwr(daily_load: list[float], acute_days: int = 7, chronic_days: int = 28) -> dict:
+    """Acute:Chronic Workload Ratio (Gabbett): last 7d mean load ÷ last 28d mean load. Flags the
+    overreaching/injury window. Needs a full chronic window to be meaningful."""
+    if len(daily_load) < chronic_days:
+        return {"available": False,
+                "reason": f"Need {chronic_days}d of load for a chronic baseline ({len(daily_load)} so far)."}
+    acute = mean(daily_load[-acute_days:])
+    chronic = mean(daily_load[-chronic_days:])
+    ratio = acute / chronic if chronic > 0 else 0.0
+    if ratio < ACWR_UNDER:
+        zone, head = "undertraining", "Load below your chronic base — room to build."
+    elif ratio <= ACWR_SWEET_HI:
+        zone, head = "sweet-spot", "Load balanced against your base — keep it here."
+    elif ratio <= ACWR_CAUTION_HI:
+        zone, head = "caution", "Ramping faster than your base — ease the next few days."
+    else:
+        zone, head = "high-risk", "Load well above your base — the injury-risk window; back off."
+    return {"available": True, "acute": round(acute, 1), "chronic": round(chronic, 1),
+            "ratio": round(ratio, 2), "zone": zone, "headline": head}
+
+
+def heart_rate_recovery(hr_series: list[int], hz: float = 1.0, window_sec: int = 60) -> dict:
+    """Protocol HRR: bpm drop from the session peak to `window_sec` after it (Cole-style, within-person).
+    A within-person FITNESS trend only — no mortality claim (that evidence is from standardised GXTs, not
+    ad-hoc session ends). `clean` is False if the peak is too close to the end to measure the full window."""
+    if len(hr_series) < 2:
+        return {"available": False, "reason": "No HR in window."}
+    peak_idx = max(range(len(hr_series)), key=lambda i: hr_series[i])
+    peak = hr_series[peak_idx]
+    after_idx = peak_idx + int(round(window_sec * hz))
+    if after_idx >= len(hr_series):
+        return {"available": False, "reason": "Peak too close to session end to measure full HRR window.",
+                "peak": peak, "clean": False}
+    hrr = peak - hr_series[after_idx]
+    return {"available": True, "peak": peak, "hr_after": hr_series[after_idx],
+            "hrr_bpm": hrr, "window_sec": window_sec, "clean": True,
+            "note": "Within-person fitness trend — not a mortality marker."}
+
+
+def recovery_cost(load_series: list[float], next_metric: list[float]) -> dict:
+    """B12 — lagged coupling: prior-day load → next-day recovery metric (e.g. lnRMSSD). Pairs load[i] with
+    next_metric[i+1] and fits a simple linear regression. Negative slope = load costs you next-day HRV."""
+    pairs = [(load_series[i], next_metric[i + 1]) for i in range(min(len(load_series), len(next_metric)) - 1)]
+    if len(pairs) < 5:
+        return {"available": False, "reason": "Need more paired load/next-day days for a coupling estimate."}
+    xs = [p[0] for p in pairs]
+    ys = [p[1] for p in pairs]
+    mx, my = mean(xs), mean(ys)
+    sxx = sum((x - mx) ** 2 for x in xs)
+    sxy = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    syy = sum((y - my) ** 2 for y in ys)
+    if sxx == 0 or syy == 0:
+        return {"available": False, "reason": "No variance in load or recovery to couple."}
+    slope = sxy / sxx
+    r = sxy / (sxx ** 0.5 * syy ** 0.5)
+    direction = "costs" if slope < 0 else "supports"
+    return {"available": True, "slope": round(slope, 4), "r": round(r, 2), "n": len(pairs),
+            "headline": f"Each unit of prior-day load {direction} next-day recovery (slope {round(slope, 3)})."}

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -11,15 +11,19 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import datetime
 from math import log1p
-from statistics import mean
+from statistics import mean, pstdev
 from zoneinfo import ZoneInfo
 
+from rivaflow.core.assessment import period_assessment
 from rivaflow.core.behaviour import behaviour_effect
+from rivaflow.core.circadian import cosinor
 from rivaflow.core.coverage import assess_coverage, coverage_in_days
-from rivaflow.core.hrv_spectral import MIN_BEATS, frequency_domain, poincare
+from rivaflow.core.hrv_spectral import MIN_BEATS, dfa_alpha1, frequency_domain, poincare
+from rivaflow.core.longevity import cardio_age_proxy, passive_vo2max
 from rivaflow.core.max_hr import calibrate_max_hr
 from rivaflow.core.prevention import evaluate_prevention, robust_baseline
 from rivaflow.core.readiness import blend_readiness, zscore
+from rivaflow.core.resilience import cumulative_stress, resilience
 from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
 from rivaflow.core.sleep_metrics import sleep_debt, sleep_regularity
 from rivaflow.core.strain_target import prescribe_strain
@@ -277,6 +281,92 @@ def recovery_cost_coupling(user_id: int, days: int = 28) -> dict:
     load = [c["cardio_load"] for c in daily_cardio_load(user_id, days=days)]
     lnr = [d["ln_rmssd"] for d in daily_resting_rmssd(user_id, days=days)]
     return recovery_cost(load, lnr)
+
+
+def longevity_metrics(user_id: int) -> dict:
+    """B14 + B15 — passive VO2max (banded) + cardio-age PROXY, from calibrated max-HR and nocturnal RHR."""
+    mx = user_max_hr(user_id)["max_hr"]
+    rhr = daily_resting_hr(user_id, days=14)
+    if not rhr:
+        return {"available": False, "reason": "Need resting-HR history first."}
+    rest = min(r["resting_hr"] for r in rhr)          # best nocturnal resting HR
+    vo2 = passive_vo2max(mx, rest)
+    cv = cardio_age_proxy(vo2["vo2max_estimate"], RUBY_AGE) if vo2.get("available") else {"available": False}
+    return {"vo2max": vo2, "cardio_age": cv}
+
+
+def resilience_metrics(user_id: int, days: int = 45) -> dict:
+    """B16 — resilience (14d bounce-back) + 31d cumulative stress. Strained day = lnRMSSD z < −0.5 vs baseline."""
+    daily = daily_resting_rmssd(user_id, days=days)
+    lnr = [d["ln_rmssd"] for d in daily]
+    if len(lnr) < 14:
+        return {"available": False, "reason": "Need ~2+ weeks of lnRMSSD for resilience."}
+    recent, baseline = lnr[-14:], lnr[:-14] or lnr
+    b_mean = mean(baseline)
+    b_sd = pstdev(baseline) or 1.0
+    flags = [(v - b_mean) / b_sd < -0.5 for v in lnr]   # strained days
+    return {
+        "resilience": resilience(recent, baseline),
+        "cumulative_stress": cumulative_stress(flags),
+    }
+
+
+def circadian_rhythm(user_id: int, days: int = 3) -> dict:
+    """B17 — cosinor of time-of-day HR over recent days (mesor/amplitude/acrophase + implied nocturnal dip)."""
+    hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
+    hours, vals = [], []
+    for h in hr:
+        if h.get("bpm") and h.get("ts"):
+            dt = _parse_ts(str(h["ts"])).astimezone(LOCAL_TZ)
+            hours.append(dt.hour + dt.minute / 60.0)
+            vals.append(int(h["bpm"]))
+    return cosinor(hours, vals)
+
+
+def dfa_analysis(user_id: int, days: int = 2) -> dict:
+    """B18 — DFA α1 on the longest clean resting segment. Experimental; suppressed above ~3% artifact."""
+    rr = [int(r["rr_ms"]) for r in WhoopRepository.rr_range(user_id, days) if r.get("rr_ms")]
+    resting = [v for v in rr if 667 <= v <= 1500]
+    segments = clean_segments(resting, min_len=64)
+    if not segments:
+        return {"available": False, "reason": "No clean segment long enough for DFA yet."}
+    seg = max(segments, key=len)
+    q = assess_rr(seg)
+    if q.artifact_pct > 3.0:
+        return {"available": False, "reason": f"Artifact {q.artifact_pct:.1f}% > 3% — DFA α1 not trustworthy.",
+                "quality": q.as_meta()}
+    a = dfa_alpha1([float(v) for v in seg])
+    if a is None:
+        return {"available": False, "reason": "Segment too short for DFA α1."}
+    return {"available": True, **a, "quality": q.as_meta()}
+
+
+def realtime_stress(user_id: int) -> dict:
+    """B13 — HRV-based real-time stress (upgrade of the HR-elevation proxy): blends HR-reserve elevation with
+    recent lnRMSSD suppression vs baseline. Research/caveated — no motion gate, so restricted to low-motion."""
+    hr_stress = today_stress(user_id)
+    if not hr_stress.get("available"):
+        return {"available": False, "reason": hr_stress.get("reason")}
+    daily = daily_resting_rmssd(user_id, days=21)
+    lnr = [d["ln_rmssd"] for d in daily]
+    hrv_z = zscore(lnr)
+    # suppression (negative z) adds stress; scale to 0–100 and blend 50/50 with HR-elevation.
+    supp = max(0.0, -hrv_z["z"]) * 20 if hrv_z else 0.0
+    blended = round(0.5 * hr_stress["stress"] + 0.5 * min(100, supp))
+    return {"available": True, "stress": blended, "hr_component": hr_stress["stress"],
+            "hrv_suppression": round(supp, 1),
+            "note": "HR+HRV blend; no motion gate — trust only when at rest. Experimental."}
+
+
+def period_assessment_for(user_id: int, label: str, days: int) -> dict:
+    """B19 — weekly/monthly narrative from the metric trends over `days`."""
+    series = {
+        "lnrmssd": [d["ln_rmssd"] for d in daily_resting_rmssd(user_id, days=days)],
+        "rhr": [float(d["resting_hr"]) for d in daily_resting_hr(user_id, days=days)],
+        "cardio_load": [c["cardio_load"] for c in daily_cardio_load(user_id, days=days)],
+        "sleep_hours": [h["duration_hours"] for h in nightly_sleep_history(user_id, nights=min(days, 14))],
+    }
+    return period_assessment(label, series)
 
 
 def hrv_lab(user_id: int, days: int = 2) -> dict:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -14,6 +14,7 @@ from math import log1p
 from statistics import mean
 from zoneinfo import ZoneInfo
 
+from rivaflow.core.coverage import assess_coverage, coverage_in_days
 from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, ln_rmssd, rmssd
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
@@ -154,23 +155,42 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
         "cardio_load_today": cardio[-1] if cardio else None,
         "cardio_load_trend": cardio,
         "stress": today_stress(user_id),
+        "coverage": capture_coverage(user_id, days=21),
     }
+
+
+def _rr_by_day(user_id: int, days: int) -> dict[str, list[int]]:
+    """All whoop_rr intervals bucketed by Ruby's local day (any band — band filtering happens downstream)."""
+    by_day: dict[str, list[int]] = defaultdict(list)
+    for r in WhoopRepository.rr_range(user_id, days):
+        rr_ms, ts = r.get("rr_ms"), r.get("ts")
+        if rr_ms and ts:
+            by_day[_local_day(ts)].append(int(rr_ms))
+    return by_day
+
+
+def _hr_count_by_day(user_id: int, days: int) -> dict[str, int]:
+    """HR sample count per local day — the HR-coverage side of the B3 guard (contrast against RR minutes)."""
+    counts: dict[str, int] = defaultdict(int)
+    for h in WhoopRepository.recent_hr(user_id, hours=days * 24):
+        if h.get("bpm") and h.get("ts"):
+            counts[_local_day(h["ts"])] += 1
+    return counts
 
 
 def daily_resting_rmssd(user_id: int, days: int = 21) -> list[dict]:
     """Per-day resting HRV (RMSSD, ms) derived from the whoop_rr intervals already flowing — so readiness
-    works without a separate HRV feed. Every day's series passes through the B0 QC gate (rr_quality):
-    a widened bradycardia band (36-133 bpm) + Malik-style relative (>20%) artifact filter + ectopy
-    interpolation, replacing the old fixed 667-1500 ms band and absolute <400 ms drop. Each value carries
-    its artifact-% and only days within the artifact budget are emitted."""
-    rr = WhoopRepository.rr_range(user_id, days)
-    by_day: dict[str, list[int]] = defaultdict(list)
-    for r in rr:
-        rr_ms, ts = r.get("rr_ms"), r.get("ts")
-        if rr_ms and ts:
-            by_day[_local_day(ts)].append(int(rr_ms))
+    works without a separate HRV feed. Each day passes TWO gates before it can anchor a baseline: the B3
+    coverage guard (enough usable, contiguous RR — excludes RR-starved charging nights the HR view masks)
+    and the B0 QC gate (widened bradycardia band + Malik relative filter + ectopy interpolation). Each value
+    carries its artifact-% and RR-minutes; under-covered or over-artifact days are dropped."""
+    by_day = _rr_by_day(user_id, days)
+    hr_counts = _hr_count_by_day(user_id, days)
     out: list[dict] = []
     for day in sorted(by_day):
+        cov = assess_coverage(by_day[day], hr_counts.get(day, 0))
+        if not cov.sufficient:
+            continue
         q = assess_rr(by_day[day])
         if not q.usable:
             continue
@@ -182,6 +202,7 @@ def daily_resting_rmssd(user_id: int, days: int = 21) -> list[dict]:
             "rmssd": round(value, 1),
             "ln_rmssd": round(ln_rmssd(q.cleaned), 3),
             "quality": q.as_meta(),
+            "coverage": cov.as_dict(),
         })
     return out
 
@@ -290,18 +311,6 @@ def _resp_rpm(vals: list[int]) -> float | None:
     return rpm if 6 <= rpm <= 30 else None
 
 
-def _resting_rr_by_day(user_id: int, days: int) -> dict[str, list[int]]:
-    """Resting-band RR intervals bucketed by Ruby's local day, artifact-cleaned via the B0 gate. 'Resting'
-    keeps the tighter 667–1500 ms band the RSA method needs (active-HR beats carry no clean respiratory RSA)."""
-    rr = WhoopRepository.rr_range(user_id, days)
-    by_day: dict[str, list[int]] = defaultdict(list)
-    for r in rr:
-        rr_ms, ts = r.get("rr_ms"), r.get("ts")
-        if rr_ms and ts and 667 <= rr_ms <= 1500:
-            by_day[_local_day(ts)].append(int(rr_ms))
-    return by_day
-
-
 def respiratory_rate(user_id: int, days: int = 1) -> dict:
     """Today's respiratory rate from the resting RR tachogram (RSA). Oura/WHOOP surface this and it IS
     computable from the RR we already capture, no extra sensor — but see the needs-validation caveat in _resp_rpm."""
@@ -317,14 +326,34 @@ def respiratory_rate(user_id: int, days: int = 1) -> dict:
 
 def daily_respiratory_rate(user_id: int, days: int = 21) -> list[dict]:
     """Per-day resting respiratory rate — the baseline series the B2 readiness blend needs for its
-    (down-weighted) resp-rate signal. Days without enough clean resting RR are skipped."""
+    (down-weighted) resp-rate signal. Gated by the B3 coverage guard (same as HRV) so RR-starved nights are
+    excluded; the estimate itself uses the tighter 667–1500 ms resting band the RSA method needs."""
+    by_day = _rr_by_day(user_id, days)
+    hr_counts = _hr_count_by_day(user_id, days)
     out: list[dict] = []
-    for day, vals in sorted(_resting_rr_by_day(user_id, days).items()):
-        clean = assess_rr(vals).cleaned
+    for day in sorted(by_day):
+        if not assess_coverage(by_day[day], hr_counts.get(day, 0)).sufficient:
+            continue
+        resting = [v for v in by_day[day] if 667 <= v <= 1500]
+        clean = assess_rr(resting).cleaned
         rpm = _resp_rpm([int(v) for v in clean])
         if rpm is not None:
             out.append({"day": day, "respiratory_rate": round(rpm, 1)})
     return out
+
+
+def capture_coverage(user_id: int, days: int = 21) -> dict:
+    """B3 surface — per-day RR/HR coverage + a coverage-in-days summary for the Data-integrity panel. This is
+    the number that governs whether time-baseline builds can trust their baseline. RR is measured separately
+    from HR precisely so a charging-away night (HR backfilled, RR missing) shows up as a gap, not false health."""
+    by_day = _rr_by_day(user_id, days)
+    hr_counts = _hr_count_by_day(user_id, days)
+    all_days = sorted(set(by_day) | set(hr_counts))
+    reports = [assess_coverage(by_day.get(day, []), hr_counts.get(day, 0)) for day in all_days]
+    return {
+        "summary": coverage_in_days(reports),
+        "days": [{"day": day, **rep.as_dict()} for day, rep in zip(all_days, reports)],
+    }
 
 
 def daily_cardio_load(user_id: int, days: int = 7) -> list[dict]:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -21,6 +21,7 @@ from rivaflow.core.prevention import evaluate_prevention, robust_baseline
 from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
 from rivaflow.core.strain_target import prescribe_strain
+from rivaflow.core.training_load import acwr, heart_rate_recovery, recovery_cost
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
@@ -162,9 +163,11 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
         sleep["quality_score"] = max(0, min(100, round((sleep["duration_hours"] / 9.0) * 100)))
     acute = cardio[-1]["cardio_load"] if cardio else None
     strain = prescribe_strain(readiness.get("state"), _chronic_load(cardio), acute)
+    load_series = [c["cardio_load"] for c in daily_cardio_load(user_id, days=28, max_hr=max_hr["max_hr"])]
     return {
         "readiness": readiness,
         "strain_target": strain,
+        "acwr": acwr(load_series),
         "hrv_today": hrv[-1] if hrv else None,
         "hrv_trend": hrv,
         "resting_hr_today": rhr[-1] if rhr else None,
@@ -220,6 +223,19 @@ def prevention_watch(user_id: int, days: int = 21) -> dict:
         if r is not None:
             readings[name] = r
     return evaluate_prevention(readings)
+
+
+def training_acwr(user_id: int, days: int = 28) -> dict:
+    """B7 — acute:chronic workload ratio from the daily cardio-load history."""
+    load = [c["cardio_load"] for c in daily_cardio_load(user_id, days=days)]
+    return acwr(load)
+
+
+def recovery_cost_coupling(user_id: int, days: int = 28) -> dict:
+    """B12 — prior-day load → next-day lnRMSSD coupling (his personal recovery cost per dose)."""
+    load = [c["cardio_load"] for c in daily_cardio_load(user_id, days=days)]
+    lnr = [d["ln_rmssd"] for d in daily_resting_rmssd(user_id, days=days)]
+    return recovery_cost(load, lnr)
 
 
 def hrv_lab(user_id: int, days: int = 2) -> dict:
@@ -375,6 +391,7 @@ def bjj_session_analytics(user_id: int, start_iso: str, end_iso: str, max_hr: in
         "duration_sec": len(bpms),
         "hr_zone_secs": zone_secs,
         "best_60s_hr_recovery": best_recovery,
+        "protocol_hrr": heart_rate_recovery(bpms),   # B8 — peak → +60s within-person HRR
         "samples": len(bpms),
     }
 

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import datetime
-from math import log1p, sqrt
+from math import log1p
 from statistics import mean, pstdev
 from zoneinfo import ZoneInfo
 
+from rivaflow.core.rr_quality import assess_rr, ln_rmssd, rmssd
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
@@ -156,25 +157,31 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
 
 
 def daily_resting_rmssd(user_id: int, days: int = 21) -> list[dict]:
-    """Per-day resting HRV (RMSSD, ms) derived from the whoop_rr intervals already flowing — so
-    readiness works without a separate HRV feed. 'Resting' = RR in a plausible band (HR ~40-90 bpm →
-    667-1500 ms); successive-difference outliers (>400 ms, i.e. motion/ectopy) are dropped. Needs
-    >=20 resting intervals/day. RMSSD = sqrt(mean of squared successive RR differences)."""
+    """Per-day resting HRV (RMSSD, ms) derived from the whoop_rr intervals already flowing — so readiness
+    works without a separate HRV feed. Every day's series passes through the B0 QC gate (rr_quality):
+    a widened bradycardia band (36-133 bpm) + Malik-style relative (>20%) artifact filter + ectopy
+    interpolation, replacing the old fixed 667-1500 ms band and absolute <400 ms drop. Each value carries
+    its artifact-% and only days within the artifact budget are emitted."""
     rr = WhoopRepository.rr_range(user_id, days)
     by_day: dict[str, list[int]] = defaultdict(list)
     for r in rr:
         rr_ms, ts = r.get("rr_ms"), r.get("ts")
-        if rr_ms and ts and 667 <= rr_ms <= 1500:
-            by_day[_local_day(ts)].append(rr_ms)
+        if rr_ms and ts:
+            by_day[_local_day(ts)].append(int(rr_ms))
     out: list[dict] = []
     for day in sorted(by_day):
-        vals = by_day[day]
-        if len(vals) < 20:
+        q = assess_rr(by_day[day])
+        if not q.usable:
             continue
-        diffs = [vals[i + 1] - vals[i] for i in range(len(vals) - 1) if abs(vals[i + 1] - vals[i]) < 400]
-        if len(diffs) < 10:
+        value = rmssd(q.cleaned)
+        if value is None:
             continue
-        out.append({"day": day, "rmssd": round(sqrt(sum(d * d for d in diffs) / len(diffs)), 1)})
+        out.append({
+            "day": day,
+            "rmssd": round(value, 1),
+            "ln_rmssd": round(ln_rmssd(q.cleaned), 3),
+            "quality": q.as_meta(),
+        })
     return out
 
 

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -20,6 +20,7 @@ from rivaflow.core.max_hr import calibrate_max_hr
 from rivaflow.core.prevention import evaluate_prevention, robust_baseline
 from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
+from rivaflow.core.sleep_metrics import sleep_debt, sleep_regularity
 from rivaflow.core.strain_target import prescribe_strain
 from rivaflow.core.training_load import acwr, heart_rate_recovery, recovery_cost
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
@@ -104,18 +105,12 @@ def _longest_low_block(order: list[int], med: dict, threshold: int, max_bridge: 
     return best_s, best_e, best_span
 
 
-def nightly_sleep(user_id: int, lookback_hours: int = 20) -> dict:
-    """Estimate last night's sleep from the overnight HR pattern. HR drops and stays low during sleep.
-    Robust to real fluctuation + gaps: bins HR into 5-min buckets (median), flags a bucket 'asleep' when
-    its median is within ~12 bpm of the night's lowest bucket, then finds the longest sleep block —
-    bridging brief wakes (up to ~15 min of higher HR) so a single toss-and-turn doesn't split the night.
-    Honest HR-based sleep DURATION + timing, NOT WHOOP-style staging (which needs a proprietary model)."""
-    hr = WhoopRepository.recent_hr(user_id, hours=lookback_hours)
-    pts = [(_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm") and h.get("ts")]
+def _sleep_from_points(pts: list[tuple[datetime, int]]) -> dict:
+    """Extract one sleep window from (ts, bpm) points: 5-min-bucket medians, longest low-HR block with
+    wake-bridging. Shared by last-night and multi-night history. HR-based duration/timing, NOT staging."""
     if len(pts) < 120:
         return {"available": False, "reason": "Not enough overnight HR captured for a sleep estimate yet."}
     pts.sort(key=lambda p: p[0])
-
     t0 = pts[0][0]
     bucket_bpms: dict[int, list[int]] = defaultdict(list)
     bucket_time: dict[int, datetime] = {}
@@ -125,13 +120,10 @@ def nightly_sleep(user_id: int, lookback_hours: int = 20) -> dict:
         bucket_time.setdefault(idx, t)
     order = sorted(bucket_bpms)
     med = {i: sorted(bucket_bpms[i])[len(bucket_bpms[i]) // 2] for i in order}
-
     threshold = min(med.values()) + 12               # "asleep" band above the night's quietest bucket
     best_s, best_e, best_span = _longest_low_block(order, med, threshold, max_bridge=3)
-
     if best_s is None or best_span < 6:              # < ~30 min → not a real sleep block
         return {"available": False, "reason": "No sustained overnight low-HR sleep window detected."}
-
     start_t, end_t = bucket_time[best_s], bucket_time[best_e]
     duration_hours = (end_t - start_t).total_seconds() / 3600
     sleep_bpms = [b for i in order if best_s <= i <= best_e for b in bucket_bpms[i]]
@@ -145,6 +137,31 @@ def nightly_sleep(user_id: int, lookback_hours: int = 20) -> dict:
         "source": "hr_bucketed_window",
         "method": "HR-based sleep duration/timing (not WHOOP staging).",
     }
+
+
+def nightly_sleep(user_id: int, lookback_hours: int = 20) -> dict:
+    """Estimate last night's sleep from the overnight HR pattern (see _sleep_from_points)."""
+    hr = WhoopRepository.recent_hr(user_id, hours=lookback_hours)
+    pts = [(_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm") and h.get("ts")]
+    return _sleep_from_points(pts)
+
+
+def nightly_sleep_history(user_id: int, nights: int = 7) -> list[dict]:
+    """Per-night sleep for the last `nights` nights (each 18:00→12:00 local), for B9 debt + B10 regularity.
+    Reuses the single-night extractor over per-night HR windows."""
+    from datetime import timedelta
+    now = datetime.now(LOCAL_TZ)
+    out: list[dict] = []
+    for back in range(nights, 0, -1):
+        day = (now - timedelta(days=back)).date()
+        start = datetime.combine(day, datetime.min.time(), LOCAL_TZ).replace(hour=18)
+        end = start + timedelta(hours=18)   # 18:00 → next 12:00
+        hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
+        pts = [(_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm") and h.get("ts")]
+        s = _sleep_from_points(pts)
+        if s.get("available"):
+            out.append(s)
+    return out
 
 
 def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
@@ -223,6 +240,19 @@ def prevention_watch(user_id: int, days: int = 21) -> dict:
         if r is not None:
             readings[name] = r
     return evaluate_prevention(readings)
+
+
+def sleep_analysis(user_id: int, nights: int = 7) -> dict:
+    """B9 + B10 — sleep need/debt (vs Ruby's >9h DNA need) + bedtime regularity, from the per-night history."""
+    history = nightly_sleep_history(user_id, nights=nights)
+    durations = [h["duration_hours"] for h in history]
+    onsets = [_parse_ts(h["sleep_start"]).astimezone(LOCAL_TZ).hour
+              + _parse_ts(h["sleep_start"]).astimezone(LOCAL_TZ).minute / 60.0 for h in history]
+    return {
+        "nights_analysed": len(history),
+        "debt": sleep_debt(durations),
+        "regularity": sleep_regularity(onsets),
+    }
 
 
 def training_acwr(user_id: int, days: int = 28) -> dict:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -15,9 +15,10 @@ from statistics import mean
 from zoneinfo import ZoneInfo
 
 from rivaflow.core.coverage import assess_coverage, coverage_in_days
+from rivaflow.core.hrv_spectral import MIN_BEATS, frequency_domain, poincare
 from rivaflow.core.max_hr import calibrate_max_hr
 from rivaflow.core.readiness import blend_readiness, zscore
-from rivaflow.core.rr_quality import assess_rr, ln_rmssd, rmssd
+from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
 from rivaflow.core.strain_target import prescribe_strain
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
@@ -191,6 +192,29 @@ def strain_target(user_id: int, today_is_sabbath: bool = False) -> dict:
     cardio = daily_cardio_load(user_id, days=14)
     acute = cardio[-1]["cardio_load"] if cardio else None
     return prescribe_strain(readiness.get("state"), _chronic_load(cardio), acute)
+
+
+def hrv_lab(user_id: int, days: int = 2) -> dict:
+    """B4 — frequency-domain + non-linear HRV (web deep-dive 'HRV Lab'). Picks the longest clean, contiguous
+    resting-RR segment from recent nights and runs Lomb-Scargle spectral + Poincaré on it — only if it clears
+    the ≥5-min / ≥150-beat bar. Artifact-% travels with the result (HF band carries beat-detection jitter)."""
+    rr = [int(r["rr_ms"]) for r in WhoopRepository.rr_range(user_id, days) if r.get("rr_ms")]
+    resting = [v for v in rr if 667 <= v <= 1500]
+    segments = clean_segments(resting, min_len=MIN_BEATS)
+    if not segments:
+        return {"available": False, "reason": "No contiguous resting RR segment of ≥150 beats yet."}
+    seg = max(segments, key=sum)                       # longest by total time
+    fseg = [float(v) for v in seg]
+    fd = frequency_domain(fseg)
+    if fd is None:
+        return {"available": False, "reason": "Longest clean segment is under the 5-min stationary window."}
+    pc = poincare(fseg)
+    return {
+        "available": True,
+        "frequency_domain": fd.as_dict(),
+        "poincare": pc.as_dict() if pc else None,
+        "quality": assess_rr(seg).as_meta(),
+    }
 
 
 def _rr_by_day(user_id: int, days: int) -> dict[str, list[int]]:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -319,14 +319,14 @@ def circadian_rhythm(user_id: int, days: int = 3) -> dict:
         if h.get("bpm") and h.get("ts"):
             dt = _parse_ts(str(h["ts"])).astimezone(LOCAL_TZ)
             hours.append(dt.hour + dt.minute / 60.0)
-            vals.append(int(h["bpm"]))
+            vals.append(float(h["bpm"]))
     return cosinor(hours, vals)
 
 
 def dfa_analysis(user_id: int, days: int = 2) -> dict:
     """B18 — DFA α1 on the longest clean resting segment. Experimental; suppressed above ~3% artifact."""
     rr = [int(r["rr_ms"]) for r in WhoopRepository.rr_range(user_id, days) if r.get("rr_ms")]
-    resting = [v for v in rr if 667 <= v <= 1500]
+    resting: list[float] = [float(v) for v in rr if 667 <= v <= 1500]
     segments = clean_segments(resting, min_len=64)
     if not segments:
         return {"available": False, "reason": "No clean segment long enough for DFA yet."}

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -18,6 +18,7 @@ from rivaflow.core.coverage import assess_coverage, coverage_in_days
 from rivaflow.core.max_hr import calibrate_max_hr
 from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, ln_rmssd, rmssd
+from rivaflow.core.strain_target import prescribe_strain
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
@@ -149,15 +150,19 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
     respiratory rate, cardio load/strain, and stress — benchmarked against WHOOP/Oura/Hume, all from the
     HR+RR we already capture."""
     max_hr = user_max_hr(user_id)                 # B1 — compute once, thread into every HR-zone consumer
+    readiness = compute_readiness(user_id, today_is_sabbath=today_is_sabbath)
     hrv = daily_resting_rmssd(user_id, days=14)
     rhr = daily_resting_hr(user_id, days=14)
-    cardio = daily_cardio_load(user_id, days=7, max_hr=max_hr["max_hr"])
+    cardio = daily_cardio_load(user_id, days=14, max_hr=max_hr["max_hr"])
     sleep = nightly_sleep(user_id)
     if sleep.get("available"):
         # Simple quality score vs Ruby's >9h sleep-need (DNA): duration is the dominant driver.
         sleep["quality_score"] = max(0, min(100, round((sleep["duration_hours"] / 9.0) * 100)))
+    acute = cardio[-1]["cardio_load"] if cardio else None
+    strain = prescribe_strain(readiness.get("state"), _chronic_load(cardio), acute)
     return {
-        "readiness": compute_readiness(user_id, today_is_sabbath=today_is_sabbath),
+        "readiness": readiness,
+        "strain_target": strain,
         "hrv_today": hrv[-1] if hrv else None,
         "hrv_trend": hrv,
         "resting_hr_today": rhr[-1] if rhr else None,
@@ -170,6 +175,22 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
         "coverage": capture_coverage(user_id, days=21),
         "max_hr": max_hr,
     }
+
+
+def _chronic_load(cardio: list[dict]) -> float | None:
+    """Chronic (usual) daily strain = mean of recent daily cardio-load, EXCLUDING today (the day in progress
+    shouldn't lower its own target). Needs a few days to be meaningful; None otherwise."""
+    prior = [c["cardio_load"] for c in cardio[:-1]] if len(cardio) > 1 else []
+    return round(mean(prior), 1) if len(prior) >= 3 else None
+
+
+def strain_target(user_id: int, today_is_sabbath: bool = False) -> dict:
+    """B5 — standalone strain-target endpoint: today's readiness → prescribed daily 0–21 load, capped when
+    Strained. (whoop_summary computes this inline from shared data; this is the direct-call path for /whoop.)"""
+    readiness = compute_readiness(user_id, today_is_sabbath=today_is_sabbath)
+    cardio = daily_cardio_load(user_id, days=14)
+    acute = cardio[-1]["cardio_load"] if cardio else None
+    return prescribe_strain(readiness.get("state"), _chronic_load(cardio), acute)
 
 
 def _rr_by_day(user_id: int, days: int) -> dict[str, list[int]]:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import datetime
 from math import log1p
-from statistics import mean, pstdev
+from statistics import mean
 from zoneinfo import ZoneInfo
 
+from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, ln_rmssd, rmssd
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
@@ -186,44 +187,40 @@ def daily_resting_rmssd(user_id: int, days: int = 21) -> list[dict]:
 
 
 def compute_readiness(user_id: int, today_is_sabbath: bool = False) -> dict:
-    """Readiness from at-rest HRV vs the user's rolling 7-day baseline (Plews/Buchheit style).
-
-    Sabbath-silent: on a rest day it blesses the rest instead of scoring. Conservative bands for a
-    masters, NSAID-sensitive, low-endurance athlete — 'Strained' pushes toward technical work, not hard rolls.
-    """
+    """B2 — Multi-input Readiness. An lnRMSSD-led blend of four deviation-from-baseline signals (HRV, nocturnal
+    resting HR, sleep-vs-need, respiratory rate), each scored on the user's OWN rolling baseline. The fusion
+    math + the 'green ≠ healthy' caveat live in rivaflow.core.readiness (pure, unit-tested); this function only
+    gathers the series. Sabbath-silent; cold-start returns 'Building' until HRV has a baseline. Conservative
+    bands for a masters, NSAID-sensitive, low-endurance athlete — 'Strained' pushes toward technical work."""
     if today_is_sabbath:
-        return {"state": "Rest", "headline": "Sabbath — rest is prescribed. No score today.",
-                "driver": "sabbath", "score": None}
+        return blend_readiness({}, today_is_sabbath=True)
 
-    # Derive daily resting RMSSD from the RR intervals already flowing (no separate HRV feed needed).
-    daily = daily_resting_rmssd(user_id, days=21)
-    vals = [d["rmssd"] for d in daily]
-    if len(vals) < READINESS_MIN_BASELINE_DAYS:
-        return {"state": "Building",
-                "headline": f"Building your HRV baseline ({len(vals)}/{READINESS_MIN_BASELINE_DAYS} days).",
-                "driver": "cold_start", "score": None, "samples": len(vals)}
+    # Each series is oldest→newest; the QC gate (B0) already sits inside the HRV/resp helpers.
+    ln_series = [d["ln_rmssd"] for d in daily_resting_rmssd(user_id, days=21)]
+    rhr_series = [d["resting_hr"] for d in daily_resting_hr(user_id, days=21)]
+    resp_series = [d["respiratory_rate"] for d in daily_respiratory_rate(user_id, days=21)]
 
-    today = vals[-1]
-    prior = vals[-8:-1] if len(vals) >= 8 else vals[:-1]   # baseline = the days BEFORE today
-    b_mean = mean(prior)
-    b_sd = pstdev(prior) or 1.0
-    z = (today - b_mean) / b_sd
+    hrv_z = zscore(ln_series)
+    rhr_z = zscore(rhr_series)
+    resp_z = zscore(resp_series)
 
-    if z >= 0.5:
-        state, head = "Prime", "HRV above baseline — green light to train hard."
-    elif z >= -0.5:
-        state, head = "Balanced", "HRV in your normal range — train as planned."
-    elif z >= -1.5:
-        state, head = "Strained", "HRV below baseline — technical/skills over hard rolls today."
-    else:
-        state, head = "Rundown", "HRV well below baseline — prioritise recovery."
+    # Sleep is a down-weighted proxy vs the >9h DNA need (a personal sleep-need/debt baseline is B9).
+    sleep = nightly_sleep(user_id)
+    sleep_z = None
+    if sleep.get("available"):
+        sleep_z = max(-3.0, min(2.0, (sleep["duration_hours"] - 9.0) / 1.5))
 
-    return {
-        "state": state, "headline": head, "driver": "hrv_vs_baseline",
-        "score": max(0, min(100, round(50 + z * 20))),
-        "today_rmssd": round(today, 1), "baseline_rmssd": round(b_mean, 1),
-        "z": round(z, 2), "baseline_days": len(prior), "source": "rr_derived",
-    }
+    result = blend_readiness({
+        "hrv": hrv_z["z"] if hrv_z else None,
+        "rhr": rhr_z["z"] if rhr_z else None,
+        "resp": resp_z["z"] if resp_z else None,
+        "sleep": sleep_z,
+    })
+    if hrv_z:   # surface the led signal's provenance for the deep-dive
+        result["today_ln_rmssd"] = round(ln_series[-1], 3)
+        result["hrv_baseline"] = {"ln_mean": round(hrv_z["baseline_mean"], 3), "days": hrv_z["n"]}
+    result["source"] = "rr_derived"
+    return result
 
 
 def hr_zone(bpm: int, max_hr: int = MAX_HR) -> int:
@@ -273,16 +270,13 @@ def bjj_session_analytics(user_id: int, start_iso: str, end_iso: str) -> dict:
     }
 
 
-def respiratory_rate(user_id: int, days: int = 1) -> dict:
-    """Respiratory rate from RR-interval oscillation (respiratory sinus arrhythmia): the heart speeds up
-    on inhale and slows on exhale, so the resting RR series oscillates at the breathing frequency. We
-    detrend the resting RR tachogram (subtract a centred moving average) and count breathing cycles.
-    Oura/WHOOP surface this — and it IS computable from the RR we already capture, no extra sensor."""
-    rr = WhoopRepository.rr_range(user_id, days)
-    vals = [int(r["rr_ms"]) for r in rr if r.get("rr_ms") and 667 <= r["rr_ms"] <= 1500]
+def _resp_rpm(vals: list[int]) -> float | None:
+    """Breaths/min from a resting RR series via respiratory sinus arrhythmia: the heart speeds up on inhale
+    and slows on exhale, so the resting tachogram oscillates at the breathing frequency. Detrend (subtract a
+    centred moving average) and count up-crossings. Returns None if the signal is too short/implausible.
+    ⚠️ Crude RSA estimate (needs-validation; a band-pass upgrade is future work) — down-weighted in readiness."""
     if len(vals) < 120:
-        return {"available": False, "reason": "Not enough resting RR intervals for a respiratory estimate."}
-
+        return None
     window = 10
     osc = []
     for i in range(len(vals)):
@@ -291,12 +285,46 @@ def respiratory_rate(user_id: int, days: int = 1) -> dict:
     breaths = sum(1 for i in range(1, len(osc)) if osc[i - 1] < 0 <= osc[i])   # one up-crossing per breath
     minutes = sum(vals) / 60000.0
     if minutes < 2 or breaths < 4:
-        return {"available": False, "reason": "Insufficient signal for a respiratory estimate."}
+        return None
     rpm = breaths / minutes
-    if not (6 <= rpm <= 30):
-        return {"available": False, "reason": "Respiratory estimate out of plausible range."}
-    return {"available": True, "respiratory_rate": round(rpm, 1), "breaths": breaths,
-            "minutes": round(minutes, 1), "source": "rr_rsa"}
+    return rpm if 6 <= rpm <= 30 else None
+
+
+def _resting_rr_by_day(user_id: int, days: int) -> dict[str, list[int]]:
+    """Resting-band RR intervals bucketed by Ruby's local day, artifact-cleaned via the B0 gate. 'Resting'
+    keeps the tighter 667–1500 ms band the RSA method needs (active-HR beats carry no clean respiratory RSA)."""
+    rr = WhoopRepository.rr_range(user_id, days)
+    by_day: dict[str, list[int]] = defaultdict(list)
+    for r in rr:
+        rr_ms, ts = r.get("rr_ms"), r.get("ts")
+        if rr_ms and ts and 667 <= rr_ms <= 1500:
+            by_day[_local_day(ts)].append(int(rr_ms))
+    return by_day
+
+
+def respiratory_rate(user_id: int, days: int = 1) -> dict:
+    """Today's respiratory rate from the resting RR tachogram (RSA). Oura/WHOOP surface this and it IS
+    computable from the RR we already capture, no extra sensor — but see the needs-validation caveat in _resp_rpm."""
+    rr = WhoopRepository.rr_range(user_id, days)
+    vals = [int(r["rr_ms"]) for r in rr if r.get("rr_ms") and 667 <= r["rr_ms"] <= 1500]
+    clean = assess_rr(vals).cleaned
+    rpm = _resp_rpm([int(v) for v in clean])
+    if rpm is None:
+        return {"available": False, "reason": "Not enough clean resting RR for a respiratory estimate."}
+    return {"available": True, "respiratory_rate": round(rpm, 1),
+            "minutes": round(sum(clean) / 60000.0, 1), "source": "rr_rsa"}
+
+
+def daily_respiratory_rate(user_id: int, days: int = 21) -> list[dict]:
+    """Per-day resting respiratory rate — the baseline series the B2 readiness blend needs for its
+    (down-weighted) resp-rate signal. Days without enough clean resting RR are skipped."""
+    out: list[dict] = []
+    for day, vals in sorted(_resting_rr_by_day(user_id, days).items()):
+        clean = assess_rr(vals).cleaned
+        rpm = _resp_rpm([int(v) for v in clean])
+        if rpm is not None:
+            out.append({"day": day, "respiratory_rate": round(rpm, 1)})
+    return out
 
 
 def daily_cardio_load(user_id: int, days: int = 7) -> list[dict]:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo
 from rivaflow.core.coverage import assess_coverage, coverage_in_days
 from rivaflow.core.hrv_spectral import MIN_BEATS, frequency_domain, poincare
 from rivaflow.core.max_hr import calibrate_max_hr
+from rivaflow.core.prevention import evaluate_prevention, robust_baseline
 from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
 from rivaflow.core.strain_target import prescribe_strain
@@ -192,6 +193,33 @@ def strain_target(user_id: int, today_is_sabbath: bool = False) -> dict:
     cardio = daily_cardio_load(user_id, days=14)
     acute = cardio[-1]["cardio_load"] if cardio else None
     return prescribe_strain(readiness.get("state"), _chronic_load(cardio), acute)
+
+
+def _signal_reading(series: list[float]) -> dict | None:
+    """Today's value + a robust (median/MAD) baseline from the PRIOR days — the shape the prevention engine
+    consumes. Returns None until there's a baseline."""
+    if len(series) < 6:
+        return None
+    base = robust_baseline(series[:-1])
+    if base is None:
+        return None
+    return {"value": series[-1], "median": base["median"], "mad": base["mad"]}
+
+
+def prevention_watch(user_id: int, days: int = 21) -> dict:
+    """B6 — Baseline-Deviation Watch. Builds robust per-signal baselines from the coverage-gated daily series
+    and evaluates co-occurrence across signal families. Fires on the safety channel (incl. Sunday). The four
+    signals (no cardiac rhythm): RHR + sleeping-HR (nocturnal-HR family), lnRMSSD (vagal), resp-rate (respiratory)."""
+    rhr = [d["resting_hr"] for d in daily_resting_hr(user_id, days=days)]
+    lnr = [d["ln_rmssd"] for d in daily_resting_rmssd(user_id, days=days)]
+    resp = [d["respiratory_rate"] for d in daily_respiratory_rate(user_id, days=days)]
+
+    readings: dict[str, dict] = {}
+    for name, series in (("rhr", rhr), ("lnrmssd", lnr), ("resp_rate", resp)):
+        r = _signal_reading([float(x) for x in series])
+        if r is not None:
+            readings[name] = r
+    return evaluate_prevention(readings)
 
 
 def hrv_lab(user_id: int, days: int = 2) -> dict:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -15,13 +15,24 @@ from statistics import mean
 from zoneinfo import ZoneInfo
 
 from rivaflow.core.coverage import assess_coverage, coverage_in_days
+from rivaflow.core.max_hr import calibrate_max_hr
 from rivaflow.core.readiness import blend_readiness, zscore
 from rivaflow.core.rr_quality import assess_rr, ln_rmssd, rmssd
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
-MAX_HR = 190                      # HR-zone ceiling (44yo; refine from measured max later)
+RUBY_AGE = 44                     # TODO(profile): derive from DOB 1982-05-27 once wired to the profile repo
+MAX_HR = 190                      # FALLBACK ONLY — real ceiling comes from user_max_hr() (B1). Kept so
+                                  # hr_zone() has a default; a ~30yo value, ~13 bpm above Ruby's ~177.
 READINESS_MIN_BASELINE_DAYS = 5   # cold-start guard before a score is meaningful
+
+
+def user_max_hr(user_id: int, days: int = 90) -> dict:
+    """B1 — Ruby's calibrated max-HR from recent HR: artifact-rejected sustained plateau, Tanaka sanity band,
+    sub-maximal floor flag, uncertainty band. Everything zone/strain/stress derived should use this, not the
+    MAX_HR fallback. Falls back to the age-predicted value when there isn't enough near-max effort captured."""
+    hr = [int(h["bpm"]) for h in WhoopRepository.recent_hr(user_id, hours=days * 24) if h.get("bpm")]
+    return calibrate_max_hr(hr, RUBY_AGE)
 
 # Ruby is Melbourne-based. All day-bucketing + display use his local day, not UTC (which would split the
 # day at ~10am and skew daily HRV/resting-HR). TODO(travel): switch to the device-reported tz per-ingest.
@@ -137,9 +148,10 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
     fetches THIS and just renders it — no client-side compute. Readiness, HRV, resting HR, sleep (+quality),
     respiratory rate, cardio load/strain, and stress — benchmarked against WHOOP/Oura/Hume, all from the
     HR+RR we already capture."""
+    max_hr = user_max_hr(user_id)                 # B1 — compute once, thread into every HR-zone consumer
     hrv = daily_resting_rmssd(user_id, days=14)
     rhr = daily_resting_hr(user_id, days=14)
-    cardio = daily_cardio_load(user_id, days=7)
+    cardio = daily_cardio_load(user_id, days=7, max_hr=max_hr["max_hr"])
     sleep = nightly_sleep(user_id)
     if sleep.get("available"):
         # Simple quality score vs Ruby's >9h sleep-need (DNA): duration is the dominant driver.
@@ -154,8 +166,9 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
         "respiratory_rate": respiratory_rate(user_id),
         "cardio_load_today": cardio[-1] if cardio else None,
         "cardio_load_trend": cardio,
-        "stress": today_stress(user_id),
+        "stress": today_stress(user_id, max_hr=max_hr["max_hr"]),
         "coverage": capture_coverage(user_id, days=21),
+        "max_hr": max_hr,
     }
 
 
@@ -258,10 +271,11 @@ def hr_zone(bpm: int, max_hr: int = MAX_HR) -> int:
     return 5
 
 
-def bjj_session_analytics(user_id: int, start_iso: str, end_iso: str) -> dict:
+def bjj_session_analytics(user_id: int, start_iso: str, end_iso: str, max_hr: int | None = None) -> dict:
     """Per-session HR analytics for a BJJ window: time-in-zone, avg/max, and best between-round HR
     recovery (a hard fitness marker that improves as you progress). HR only — HRV is invalid in motion.
-    Fields mirror RivaFlow's garmin_* session columns so WHOOP sessions sit beside Garmin.
+    Fields mirror RivaFlow's garmin_* session columns so WHOOP sessions sit beside Garmin. Zones use the
+    B1-calibrated max-HR (not the 190 fallback).
     """
     hr = WhoopRepository.hr_range(user_id, start_iso, end_iso)
     bpms = [h["bpm"] for h in hr if h.get("bpm")]
@@ -269,9 +283,10 @@ def bjj_session_analytics(user_id: int, start_iso: str, end_iso: str) -> dict:
         return {"available": False,
                 "reason": "No HR captured in this window — reboot the strap before the next session."}
 
+    mx = max_hr or user_max_hr(user_id)["max_hr"]
     zone_secs = {z: 0 for z in range(1, 6)}
     for b in bpms:
-        zone_secs[hr_zone(b)] += 1   # standard-HR stream is ~1 sample/sec
+        zone_secs[hr_zone(b, mx)] += 1   # standard-HR stream is ~1 sample/sec
 
     # Best 60s HR drop after a peak — approximates between-round recovery.
     best_recovery = 0
@@ -356,16 +371,18 @@ def capture_coverage(user_id: int, days: int = 21) -> dict:
     }
 
 
-def daily_cardio_load(user_id: int, days: int = 7) -> list[dict]:
+def daily_cardio_load(user_id: int, days: int = 7, max_hr: int | None = None) -> list[dict]:
     """Daily cardio load / strain from HR-zone-weighted minutes (Banister-TRIMP style), hard zones
-    weighted exponentially, compressed to a ~0–21 scale (WHOOP-strain feel). From the HR we capture."""
+    weighted exponentially, compressed to a ~0–21 scale (WHOOP-strain feel). Zones use the B1-calibrated
+    max-HR (not the 190 fallback), so the strain scale is correct for Ruby."""
     hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
+    mx = max_hr or user_max_hr(user_id)["max_hr"]
     zone_weight = {1: 1, 2: 2, 3: 4, 4: 8, 5: 16}
     by_day: dict[str, float] = defaultdict(float)
     for h in hr:
         bpm, ts = h.get("bpm"), h.get("ts")
         if bpm and ts:
-            by_day[_local_day(ts)] += zone_weight[hr_zone(int(bpm))] / 60.0   # ~1 sample/s → per-minute
+            by_day[_local_day(ts)] += zone_weight[hr_zone(int(bpm), mx)] / 60.0   # ~1 sample/s → per-minute
     out = []
     for day in sorted(by_day):
         raw = by_day[day]
@@ -374,15 +391,17 @@ def daily_cardio_load(user_id: int, days: int = 7) -> list[dict]:
     return out
 
 
-def today_stress(user_id: int) -> dict:
+def today_stress(user_id: int, max_hr: int | None = None) -> dict:
     """Light stress proxy: how elevated recent HR sits within the HR reserve above resting (0–100).
-    WHOOP/Hume blend HRV+HR; this HR-elevation version is honest and always-available."""
+    WHOOP/Hume blend HRV+HR; this HR-elevation version is honest and always-available. Reserve uses the
+    B1-calibrated max-HR (not the 190 fallback)."""
     recent = WhoopRepository.recent_hr(user_id, hours=1)
     bpms = [int(h["bpm"]) for h in recent if h.get("bpm")]
     rhr_list = daily_resting_hr(user_id, days=3)
     if not bpms or not rhr_list:
         return {"available": False, "reason": "Not enough recent HR for a stress estimate."}
+    mx = max_hr or user_max_hr(user_id)["max_hr"]
     rest = rhr_list[-1]["resting_hr"]
     cur = mean(bpms[-60:]) if len(bpms) >= 60 else mean(bpms)
-    stress = max(0, min(100, round((cur - rest) / max(1, MAX_HR - rest) * 100)))
+    stress = max(0, min(100, round((cur - rest) / max(1, mx - rest) * 100)))
     return {"available": True, "stress": stress, "current_hr": round(cur), "resting_hr": rest}

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -14,6 +14,7 @@ from math import log1p
 from statistics import mean
 from zoneinfo import ZoneInfo
 
+from rivaflow.core.behaviour import behaviour_effect
 from rivaflow.core.coverage import assess_coverage, coverage_in_days
 from rivaflow.core.hrv_spectral import MIN_BEATS, frequency_domain, poincare
 from rivaflow.core.max_hr import calibrate_max_hr
@@ -240,6 +241,16 @@ def prevention_watch(user_id: int, days: int = 21) -> dict:
         if r is not None:
             readings[name] = r
     return evaluate_prevention(readings)
+
+
+def behaviour_correlation(user_id: int, tag: str, tagged_days: set[str], days: int = 60) -> dict:
+    """B11 — split the daily lnRMSSD series by whether each day carries `tag`, then report the effect size.
+    `tagged_days` = set of 'YYYY-MM-DD' the behaviour occurred (from the journal/tagging path, still to be
+    plumbed). Metric is lnRMSSD (readiness's led signal)."""
+    daily = daily_resting_rmssd(user_id, days=days)
+    yes = [d["ln_rmssd"] for d in daily if d["day"] in tagged_days]
+    no = [d["ln_rmssd"] for d in daily if d["day"] not in tagged_days]
+    return behaviour_effect(tag, "lnRMSSD", yes, no)
 
 
 def sleep_analysis(user_id: int, nights: int = 7) -> dict:

--- a/rivaflow/tests/unit/test_assessment.py
+++ b/rivaflow/tests/unit/test_assessment.py
@@ -1,0 +1,24 @@
+"""B19 Weekly/Monthly assessment — pure, no DB."""
+from __future__ import annotations
+
+from rivaflow.core.assessment import period_assessment
+
+
+def test_rising_hrv_is_improving():
+    r = period_assessment("week", {"lnrmssd": [3.8, 3.8, 4.2, 4.3]})
+    assert r["available"] is True
+    assert "HRV (lnRMSSD)" in r["improving"]
+
+
+def test_rising_rhr_is_declining():
+    r = period_assessment("week", {"rhr": [50, 50, 55, 56]})
+    assert "Resting HR" in r["declining"]
+
+
+def test_empty_series_unavailable():
+    assert period_assessment("month", {"lnrmssd": [1, 2]})["available"] is False
+
+
+def test_headline_mentions_period():
+    r = period_assessment("month", {"lnrmssd": [3.8, 3.9, 4.2, 4.3], "rhr": [55, 54, 51, 50]})
+    assert "month" in r["headline"]

--- a/rivaflow/tests/unit/test_behaviour.py
+++ b/rivaflow/tests/unit/test_behaviour.py
@@ -1,0 +1,37 @@
+"""B11 Behaviour correlation — pure, no DB."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.behaviour import behaviour_effect, cohens_d
+
+
+def test_cohens_d_known_direction():
+    d = cohens_d([10, 11, 12], [5, 6, 7])
+    assert d > 0
+
+
+def test_cohens_d_none_on_small_or_flat():
+    assert cohens_d([1], [2, 3]) is None
+    assert cohens_d([5, 5, 5], [5, 5, 5]) is None
+
+
+def test_behaviour_effect_large_negative():
+    """Alcohol nights with clearly lower HRV → large negative delta."""
+    r = behaviour_effect("alcohol", "lnRMSSD", yes_values=[3.5, 3.4, 3.6], no_values=[4.2, 4.3, 4.1])
+    assert r["available"] is True
+    assert r["delta"] < 0
+    assert r["magnitude"] == "large"
+    assert "alcohol" in r["headline"]
+
+
+def test_behaviour_effect_insufficient():
+    r = behaviour_effect("late-training", "lnRMSSD", [3.5], [4.0, 4.1])
+    assert r["available"] is False
+
+
+def test_behaviour_effect_reports_counts():
+    r = behaviour_effect("sabbath-rest", "lnRMSSD", [4.5, 4.6, 4.4, 4.5], [4.0, 4.1, 3.9])
+    assert r["n_yes"] == 4 and r["n_no"] == 3
+    assert r["delta"] == pytest.approx(round(4.5 - 4.0, 2), abs=0.05)

--- a/rivaflow/tests/unit/test_circadian.py
+++ b/rivaflow/tests/unit/test_circadian.py
@@ -1,0 +1,24 @@
+"""B17 Circadian cosinor — pure, no DB."""
+from __future__ import annotations
+
+from math import cos, pi
+
+import pytest
+
+from rivaflow.core.circadian import cosinor
+
+
+def test_cosinor_recovers_known_rhythm():
+    # HR = 60 + 15*cos(omega*(t-15)) → peak at 15h, amplitude 15, mesor 60
+    hours = [h for h in range(0, 24)]
+    omega = 2*pi/24
+    vals = [60 + 15*cos(omega*(h-15)) for h in hours]
+    r = cosinor(hours, vals)
+    assert r["available"] is True
+    assert r["mesor"] == pytest.approx(60, abs=1.0)
+    assert r["amplitude"] == pytest.approx(15, abs=1.0)
+    assert r["acrophase_hour"] == pytest.approx(15, abs=0.5)
+
+
+def test_cosinor_needs_points():
+    assert cosinor([1,2,3], [1,2,3])["available"] is False

--- a/rivaflow/tests/unit/test_coverage.py
+++ b/rivaflow/tests/unit/test_coverage.py
@@ -1,0 +1,87 @@
+"""B3 capture-coverage / RR-coverage guard — pure-core tests (no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.coverage import (
+    MIN_CONTIGUOUS_MINUTES,
+    MIN_RR_MINUTES,
+    assess_coverage,
+    coverage_in_days,
+)
+
+
+def test_well_covered_night_is_sufficient():
+    """~10 min of contiguous in-band RR clears both thresholds."""
+    rr = [1000] * 600            # 600 intervals * 1000 ms = 600 s = 10 min
+    cov = assess_coverage(rr, hr_samples=600)
+    assert cov.rr_minutes == pytest.approx(10.0, abs=0.1)
+    assert cov.longest_segment_minutes == pytest.approx(10.0, abs=0.1)
+    assert cov.sufficient is True
+    assert cov.reason == "sufficient"
+
+
+def test_rr_starved_night_excluded_despite_full_hr():
+    """The core B3 case: 8 h of HR backfill but almost no RR (phone charging away). The HR view looks fine;
+    the guard must still exclude the night and NAME the masking."""
+    rr = [1000] * 60             # 1 min of RR only
+    hr = 8 * 3600                # 8 h of HR samples at 1 Hz
+    cov = assess_coverage(rr, hr_samples=hr)
+    assert cov.rr_minutes == pytest.approx(1.0, abs=0.1)
+    assert cov.hr_minutes == pytest.approx(480.0, abs=1)
+    assert cov.sufficient is False
+    assert "RR-starved" in cov.reason and "charging" in cov.reason
+
+
+def test_low_capture_below_rr_threshold():
+    rr = [1000] * 120            # 2 min < MIN_RR_MINUTES
+    cov = assess_coverage(rr, hr_samples=120)
+    assert cov.rr_minutes < MIN_RR_MINUTES
+    assert cov.sufficient is False
+    assert "Low capture" in cov.reason
+
+
+def test_fragmented_night_fails_contiguity():
+    """Enough total RR minutes, but broken into sub-2-minute runs by repeated artifacts → excluded."""
+    block = [1000] * 60          # 1-min clean run
+    junk = [200]                 # one impossible beat splits the runs
+    rr = []
+    for _ in range(8):           # 8 min total in-band, but longest run only 1 min
+        rr += block + junk
+    cov = assess_coverage(rr, hr_samples=len(rr))
+    assert cov.rr_minutes >= MIN_RR_MINUTES
+    assert cov.longest_segment_minutes < MIN_CONTIGUOUS_MINUTES
+    assert cov.sufficient is False
+    assert "Fragmented" in cov.reason
+
+
+def test_out_of_band_beats_dont_count_as_rr_minutes():
+    rr = [200] * 1000            # impossible beats — zero usable RR
+    cov = assess_coverage(rr, hr_samples=1000)
+    assert cov.rr_minutes == 0.0
+    assert cov.rr_intervals == 0
+    assert cov.sufficient is False
+
+
+def test_empty_day():
+    cov = assess_coverage([], hr_samples=0)
+    assert cov.rr_minutes == 0.0
+    assert cov.hr_minutes == 0.0
+    assert cov.sufficient is False
+
+
+def test_coverage_in_days_summary():
+    good = assess_coverage([1000] * 600, hr_samples=600)
+    bad = assess_coverage([1000] * 30, hr_samples=8 * 3600)
+    summ = coverage_in_days([good, bad, good])
+    assert summ["days_total"] == 3
+    assert summ["days_sufficient"] == 2
+    assert summ["days_excluded"] == 1
+    assert summ["rr_coverage_pct"] == pytest.approx(66.7, abs=0.1)
+
+
+def test_coverage_in_days_empty():
+    summ = coverage_in_days([])
+    assert summ["days_total"] == 0
+    assert summ["rr_coverage_pct"] == 0.0

--- a/rivaflow/tests/unit/test_dfa.py
+++ b/rivaflow/tests/unit/test_dfa.py
@@ -1,0 +1,25 @@
+"""B18 DFA alpha1 — pure, no DB."""
+from __future__ import annotations
+
+from rivaflow.core.hrv_spectral import dfa_alpha1
+
+
+def test_dfa_none_on_too_few():
+    assert dfa_alpha1([1000.0]*10) is None
+
+
+def test_dfa_returns_alpha_and_zone():
+    # semi-random-ish RR series long enough for boxes 4..16
+    rr = [1000 + (i*37 % 50) - 25 for i in range(200)]
+    r = dfa_alpha1([float(x) for x in rr])
+    assert r is not None
+    assert "alpha1" in r and "zone" in r
+    assert 0.0 < r["alpha1"] < 2.0
+
+
+def test_dfa_white_noise_near_half():
+    # alternating series (anti-correlated) → low alpha; just assert it computes a plausible number
+    rr = [1000.0 + (100 if i % 2 else -100) for i in range(200)]
+    r = dfa_alpha1(rr)
+    assert r is not None
+    assert r["alpha1"] < 1.0

--- a/rivaflow/tests/unit/test_hrv_spectral.py
+++ b/rivaflow/tests/unit/test_hrv_spectral.py
@@ -1,0 +1,80 @@
+"""B4 frequency-domain + non-linear HRV — pure-core tests (no DB)."""
+
+from __future__ import annotations
+
+from math import pi, sin, sqrt
+
+import pytest
+
+from rivaflow.core.hrv_spectral import (
+    MIN_BEATS,
+    frequency_domain,
+    poincare,
+    sdnn,
+)
+
+
+def _modulated_rr(freq_hz: float, n: int = 400, base: float = 1000.0, amp: float = 40.0) -> list[float]:
+    """RR series (~1 beat/s) oscillating at freq_hz — a synthetic respiratory/baroreflex signal."""
+    return [base + amp * sin(2 * pi * freq_hz * i) for i in range(n)]
+
+
+def test_hf_modulation_shows_hf_dominant():
+    """A 0.25 Hz oscillation (respiratory band) must put more power in HF than LF."""
+    fd = frequency_domain(_modulated_rr(0.25))
+    assert fd is not None
+    assert fd.hf > fd.lf
+    assert fd.hf_nu > fd.lf_nu
+
+
+def test_lf_modulation_shows_lf_dominant():
+    """A 0.10 Hz oscillation (LF band) must put more power in LF than HF."""
+    fd = frequency_domain(_modulated_rr(0.10))
+    assert fd is not None
+    assert fd.lf > fd.hf
+
+
+def test_short_window_returns_none():
+    """Below 5 min / 150 beats, spectral HRV is not computed."""
+    assert frequency_domain(_modulated_rr(0.25, n=100)) is None      # too few beats
+    assert frequency_domain([250.0] * 200) is None                   # 200 beats * 0.25s = 50s < 5min
+
+
+def test_lf_hf_note_is_not_sympatho_vagal():
+    fd = frequency_domain(_modulated_rr(0.25))
+    d = fd.as_dict()
+    assert "NOT a sympatho-vagal" in d["note"]
+    assert "lf_hf" in d
+
+
+def test_poincare_sd1_equals_rmssd_over_sqrt2():
+    """SD1 must equal SD(successive diffs)/√2 — confirming it carries no info beyond RMSSD."""
+    rr = _modulated_rr(0.2, n=300)
+    diffs = [rr[i + 1] - rr[i] for i in range(len(rr) - 1)]
+    dmean = sum(diffs) / len(diffs)
+    sdsd = sqrt(sum((d - dmean) ** 2 for d in diffs) / len(diffs))
+    pc = poincare(rr)
+    assert pc is not None
+    assert pc.sd1 == pytest.approx(sdsd / sqrt(2), rel=1e-6)
+    assert pc.sd2 > 0
+    assert pc.ratio == pytest.approx(pc.sd2 / pc.sd1, rel=1e-6)
+
+
+def test_poincare_note_flags_sd1_identity():
+    pc = poincare(_modulated_rr(0.2, n=200))
+    assert "RMSSD" in pc.as_dict()["note"]
+
+
+def test_sdnn_matches_manual():
+    vals = [900.0, 1000.0, 1100.0]
+    m = 1000.0
+    expect = sqrt(sum((x - m) ** 2 for x in vals) / 3)
+    assert sdnn(vals) == pytest.approx(expect)
+
+
+def test_sdnn_none_on_too_few():
+    assert sdnn([900.0]) is None
+
+
+def test_min_beats_constant_guard():
+    assert frequency_domain([1000.0] * (MIN_BEATS - 1)) is None

--- a/rivaflow/tests/unit/test_longevity.py
+++ b/rivaflow/tests/unit/test_longevity.py
@@ -1,0 +1,37 @@
+"""P2 longevity — B14 VO2max, B15 cardio-age proxy (pure, no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.longevity import cardio_age_proxy, passive_vo2max
+
+
+def test_vo2max_is_banded_not_a_point():
+    r = passive_vo2max(hr_max=177, hr_rest=50)
+    assert r["available"] is True
+    assert r["vo2max_estimate"] == pytest.approx(15.3 * 177 / 50, abs=0.1)
+    assert r["range"][0] < r["vo2max_estimate"] < r["range"][1]
+
+
+def test_vo2max_rejects_bad_inputs():
+    assert passive_vo2max(0, 50)["available"] is False
+    assert passive_vo2max(150, 160)["available"] is False   # max below rest
+
+
+def test_cardio_age_proxy_is_flagged_proxy():
+    r = cardio_age_proxy(vo2max=50, age=44)
+    assert r["available"] is True
+    assert r["is_proxy"] is True
+    assert "not clinical" in r["note"]
+
+
+def test_fitter_reads_younger():
+    fit = cardio_age_proxy(vo2max=55, age=44)["cardio_age_proxy"]
+    unfit = cardio_age_proxy(vo2max=35, age=44)["cardio_age_proxy"]
+    assert fit < unfit
+
+
+def test_cardio_age_clamped():
+    r = cardio_age_proxy(vo2max=90, age=44)   # very fit → clamped at 18
+    assert r["cardio_age_proxy"] >= 18

--- a/rivaflow/tests/unit/test_max_hr.py
+++ b/rivaflow/tests/unit/test_max_hr.py
@@ -1,0 +1,84 @@
+"""B1 Max-HR calibration — pure-core tests (no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.max_hr import calibrate_max_hr, sustained_max, tanaka_max
+
+
+def test_tanaka_for_ruby():
+    assert tanaka_max(44) == pytest.approx(177.2)
+
+
+# --- sustained_max: the artifact guard ------------------------------------
+
+def test_single_spike_does_not_set_max():
+    """A lone 200 bpm sample among 120s must NOT raise the sustained max — the core artifact rejection."""
+    hr = [120] * 60
+    hr[30] = 200
+    assert sustained_max(hr, window=10) == 120
+
+
+def test_sustained_plateau_is_captured():
+    """A genuine 15-sample run at 185 IS a sustained max."""
+    hr = [120] * 20 + [185] * 15 + [120] * 20
+    assert sustained_max(hr, window=10) == 185
+
+
+def test_sustained_max_none_when_too_short():
+    assert sustained_max([180] * 5, window=10) is None
+
+
+# --- calibrate: observed vs Tanaka ----------------------------------------
+
+def test_observed_above_tanaka_is_used():
+    hr = [120] * 30 + [186] * 15 + [120] * 30   # sustained 186 > Tanaka 177
+    r = calibrate_max_hr(hr, age=44)
+    assert r["source"] == "observed_sustained"
+    assert r["max_hr"] == 186
+    assert r["floor"] is False
+    assert r["uncertainty"] == [181, 191]
+
+
+def test_submaximal_observed_falls_back_to_tanaka_with_floor():
+    """Low-endurance athlete never nears max: observed 150 < Tanaka → floor flag, Tanaka estimate."""
+    hr = [120] * 30 + [150] * 15 + [120] * 30
+    r = calibrate_max_hr(hr, age=44)
+    assert r["source"] == "tanaka_default"
+    assert r["max_hr"] == 177
+    assert r["floor"] is True
+    assert r["observed_sustained"] == 150
+    assert "sub-maximal" in r["note"]
+
+
+def test_no_data_uses_tanaka_no_floor():
+    r = calibrate_max_hr([], age=44)
+    assert r["source"] == "tanaka_default"
+    assert r["max_hr"] == 177
+    assert r["floor"] is False
+    assert r["uncertainty"] == [167, 187]
+
+
+def test_impossible_readings_are_rejected_before_calibrating():
+    """A 260 bpm spike is out of range and filtered; the real sustained level (120) drives the floor."""
+    hr = [120] * 40 + [260] * 20        # 260 > HR_CEILING, dropped
+    r = calibrate_max_hr(hr, age=44)
+    assert r["observed_sustained"] == 120
+    assert r["source"] == "tanaka_default"
+    assert r["floor"] is True
+
+
+def test_kills_the_190_default():
+    """Regression: whatever Ruby's calibrated value, it must not be the old ~30yo 190 unless he truly
+    sustains it — with sub-maximal data it lands at his age-predicted 177, not 190."""
+    r = calibrate_max_hr([130] * 100, age=44)
+    assert r["max_hr"] == 177
+    assert r["max_hr"] != 190
+
+
+def test_uncertainty_band_always_present():
+    for hr in ([], [130] * 100, [120] * 30 + [186] * 15):
+        r = calibrate_max_hr(hr, age=44)
+        assert isinstance(r["uncertainty"], list) and len(r["uncertainty"]) == 2
+        assert r["uncertainty"][0] < r["uncertainty"][1]

--- a/rivaflow/tests/unit/test_prevention.py
+++ b/rivaflow/tests/unit/test_prevention.py
@@ -1,0 +1,107 @@
+"""B6 Baseline-Deviation Watch — pure-core tests (no DB). Safety properties are load-bearing."""
+
+from __future__ import annotations
+
+from math import log
+
+from rivaflow.core.prevention import (
+    GREEN_CAVEAT,
+    evaluate_prevention,
+    mad,
+    robust_baseline,
+    robust_z,
+)
+
+
+def _r(value, median, mad):
+    return {"value": value, "median": median, "mad": mad}
+
+
+# --- baseline primitives --------------------------------------------------
+
+def test_mad_and_robust_baseline():
+    vals = [10, 10, 10, 10, 12]
+    b = robust_baseline(vals)
+    assert b["median"] == 10
+    assert b["mad"] == mad(vals, 10)
+
+
+def test_robust_baseline_none_when_too_few():
+    assert robust_baseline([1, 2, 3, 4]) is None
+
+
+def test_robust_z_direction():
+    """Positive worse_z always means 'more strained', regardless of signal direction."""
+    # RHR elevated → positive
+    assert robust_z(56, 50, 2, "high") > 1.5
+    # lnRMSSD suppressed (low) → positive
+    assert robust_z(log(35), log(50), 0.1, "low") > 0
+
+
+# --- tier logic + safety properties ---------------------------------------
+
+def test_all_in_range_is_green_with_caveat():
+    r = evaluate_prevention({
+        "rhr": _r(50, 50, 2), "lnrmssd": _r(log(50), log(50), 0.1), "resp_rate": _r(14, 14, 1),
+    })
+    assert r["tier"] == "green"
+    assert r["caveat"] == GREEN_CAVEAT
+    assert r["fires_on_sabbath"] is False
+
+
+def test_two_families_elevated_is_amber():
+    r = evaluate_prevention({
+        "rhr": _r(55, 50, 2),                       # nocturnal_hr family, worse_z ~1.7
+        "lnrmssd": _r(log(50) - 1.7 * 0.1 * 1.4826, log(50), 0.1),  # vagal family suppressed
+        "resp_rate": _r(14, 14, 1),
+    })
+    assert r["tier"] == "amber"
+    assert r["channel"] == "safety"
+    assert r["fires_on_sabbath"] is True
+    assert set(r["flagged_families"]) == {"nocturnal_hr", "vagal"}
+
+
+def test_respiratory_alone_cannot_fire():
+    """Resp-rate is one family and the least-validated signal — it must NEVER raise a tier alone."""
+    r = evaluate_prevention({
+        "rhr": _r(50, 50, 2), "lnrmssd": _r(log(50), log(50), 0.1),
+        "resp_rate": _r(20, 14, 1),                 # strongly elevated, but single family
+    })
+    assert r["tier"] == "green"
+
+
+def test_correlated_same_family_cannot_self_corroborate():
+    """RHR and sleeping-HR are ONE family — both elevated is a single perturbation, not co-occurrence."""
+    r = evaluate_prevention({
+        "rhr": _r(56, 50, 2), "sleeping_hr": _r(60, 54, 2),   # both nocturnal_hr, both flagged
+        "lnrmssd": _r(log(50), log(50), 0.1),
+    })
+    assert r["flagged_families"] == ["nocturnal_hr"]
+    assert r["tier"] == "green"
+
+
+def test_two_strong_families_is_red():
+    r = evaluate_prevention({
+        "rhr": _r(58, 50, 2),                        # worse_z ~2.7
+        "lnrmssd": _r(log(50) - 2.5 * 0.1 * 1.4826, log(50), 0.1),
+    })
+    assert r["tier"] == "red"
+    assert r["channel"] == "safety"
+    assert r["diagnostic"] is False
+
+
+def test_sabbath_does_not_silence_safety():
+    """Amber/red are the safety channel — they fire even on the Sabbath."""
+    r = evaluate_prevention({
+        "rhr": _r(55, 50, 2), "lnrmssd": _r(log(50) - 1.7 * 0.1 * 1.4826, log(50), 0.1),
+    }, today_is_sabbath=True)
+    assert r["tier"] == "amber"
+    assert r["fires_on_sabbath"] is True
+
+
+def test_drivers_sorted_and_never_diagnostic():
+    r = evaluate_prevention({"rhr": _r(55, 50, 2), "lnrmssd": _r(log(50), log(50), 0.1)})
+    zs = [d["worse_z"] for d in r["drivers"]]
+    assert zs == sorted(zs, reverse=True)
+    assert r["diagnostic"] is False
+    assert "not disease" in r["note"]

--- a/rivaflow/tests/unit/test_readiness.py
+++ b/rivaflow/tests/unit/test_readiness.py
@@ -1,0 +1,107 @@
+"""B2 Multi-input Readiness — pure fusion-core tests (no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.readiness import (
+    GREEN_CAVEAT,
+    WEIGHTS,
+    blend_readiness,
+    zscore,
+)
+
+# --- zscore ---------------------------------------------------------------
+
+def test_zscore_none_when_too_few():
+    assert zscore([1, 2, 3]) is None          # < MIN_BASELINE_DAYS + 1
+    assert zscore([]) is None
+
+
+def test_zscore_known_value():
+    z = zscore([1, 1, 1, 1, 1, 2])            # prior mean 1, sd 0→1.0, today 2
+    assert z is not None
+    assert z["z"] == pytest.approx(1.0)
+    assert z["n"] == 5
+
+
+def test_zscore_uses_prior_not_today():
+    """The baseline excludes today, so a stable history with a high today reads as a positive deviation."""
+    z = zscore([50, 50, 50, 50, 50, 50, 60])
+    assert z["baseline_mean"] == pytest.approx(50.0)
+    assert z["z"] > 0
+
+
+# --- blend: gates ---------------------------------------------------------
+
+def test_sabbath_is_rest_no_score():
+    r = blend_readiness({"hrv": 1.0}, today_is_sabbath=True)
+    assert r["state"] == "Rest"
+    assert r["score"] is None
+    assert r["caveat"] is None
+
+
+def test_missing_hrv_is_building():
+    r = blend_readiness({"hrv": None, "rhr": 0.5})
+    assert r["state"] == "Building"
+    assert r["score"] is None
+
+
+# --- blend: fusion math ---------------------------------------------------
+
+def test_single_signal_renormalises_to_full_weight():
+    """With only HRV present its weight renormalises to 1.0, so composite == hrv z."""
+    r = blend_readiness({"hrv": 1.0, "rhr": None, "resp": None, "sleep": None})
+    assert r["composite_z"] == pytest.approx(1.0)
+    assert r["state"] == "Prime"
+    assert r["score"] == 70            # 50 + 1.0*20
+    assert r["signals_used"] == ["hrv"]
+
+
+def test_elevated_rhr_drags_recovery():
+    """A raw +z on nocturnal RHR means WORSE recovery (direction -1) — it must pull the composite down."""
+    r = blend_readiness({"hrv": 0.0, "rhr": 2.0})
+    assert r["composite_z"] < 0
+    assert r["state"] in ("Strained", "Rundown")
+    rhr_c = next(c for c in r["contributors"] if c["signal"] == "rhr")
+    assert rhr_c["effect"] < 0
+    assert rhr_c["direction"] == "drags recovery"
+
+
+def test_high_hrv_low_rhr_is_prime():
+    r = blend_readiness({"hrv": 1.5, "rhr": -1.0, "sleep": 0.5, "resp": -0.5})
+    assert r["state"] == "Prime"
+    assert 0 <= r["score"] <= 100
+
+
+def test_hrv_is_the_dominant_weight():
+    """HRV carries the largest weight, so the same-magnitude deviation moves the score more via HRV than RHR."""
+    via_hrv = blend_readiness({"hrv": -2.0, "rhr": 0.0, "sleep": 0.0, "resp": 0.0})["composite_z"]
+    via_rhr = blend_readiness({"hrv": 0.0, "rhr": 2.0, "sleep": 0.0, "resp": 0.0})["composite_z"]
+    assert abs(via_hrv) > abs(via_rhr)
+    assert WEIGHTS["hrv"] > WEIGHTS["rhr"] > WEIGHTS["sleep"] >= WEIGHTS["resp"]
+
+
+# --- blend: green != healthy caveat --------------------------------------
+
+def test_green_states_carry_caveat():
+    assert blend_readiness({"hrv": 1.0})["caveat"] == GREEN_CAVEAT      # Prime
+    assert blend_readiness({"hrv": 0.0})["caveat"] == GREEN_CAVEAT      # Balanced
+
+
+def test_non_green_states_have_no_caveat():
+    assert blend_readiness({"hrv": -1.0})["caveat"] is None             # Strained
+    assert blend_readiness({"hrv": -3.0})["caveat"] is None             # Rundown
+
+
+# --- blend: bookkeeping ---------------------------------------------------
+
+def test_score_is_clamped():
+    assert blend_readiness({"hrv": 10.0})["score"] == 100
+    assert blend_readiness({"hrv": -10.0})["score"] == 0
+
+
+def test_contributors_sorted_by_effect_magnitude():
+    r = blend_readiness({"hrv": 0.2, "rhr": 2.0})
+    effects = [abs(c["effect"]) for c in r["contributors"]]
+    assert effects == sorted(effects, reverse=True)

--- a/rivaflow/tests/unit/test_resilience.py
+++ b/rivaflow/tests/unit/test_resilience.py
@@ -1,0 +1,33 @@
+"""B16 Resilience & Cumulative Stress — pure, no DB."""
+from __future__ import annotations
+
+from rivaflow.core.resilience import cumulative_stress, resilience
+
+
+def test_resilience_high_when_recent_at_baseline_and_stable():
+    r = resilience(recent_lnrmssd=[4.0]*14, baseline_lnrmssd=[4.0]*30)
+    assert r["available"] is True
+    assert r["level"] in ("Solid", "Strong", "Exceptional")
+
+
+def test_resilience_low_when_recent_suppressed():
+    r = resilience(recent_lnrmssd=[3.0]*14, baseline_lnrmssd=[4.0]*30 + [4.1, 3.9])
+    assert r["level_vs_baseline_z"] < 0
+
+
+def test_resilience_needs_enough_data():
+    assert resilience([4.0]*3, [4.0]*30)["available"] is False
+
+
+def test_cumulative_stress_bands():
+    assert cumulative_stress([False]*31)["band"] == "low"
+    assert cumulative_stress([True]*20 + [False]*11)["band"] == "high"
+
+
+def test_cumulative_stress_window():
+    r = cumulative_stress([True]*50, window=31)
+    assert r["days"] == 31 and r["strained_days"] == 31
+
+
+def test_cumulative_stress_empty():
+    assert cumulative_stress([])["available"] is False

--- a/rivaflow/tests/unit/test_rr_quality.py
+++ b/rivaflow/tests/unit/test_rr_quality.py
@@ -1,0 +1,117 @@
+"""B0 QC-gate tests — the foundation every RR-derived metric consumes."""
+
+from __future__ import annotations
+
+from math import log
+
+import pytest
+
+from rivaflow.core.rr_quality import (
+    MALIK_REL_THRESHOLD,
+    MAX_ARTIFACT_FRACTION,
+    RR_MAX_MS,
+    RR_MIN_MS,
+    assess_rr,
+    clean_segments,
+    ln_rmssd,
+    rmssd,
+)
+
+
+def test_clean_series_no_artifacts():
+    """A steady physiological series passes untouched at 0% artifact and is usable."""
+    series = [900 + (i % 5) for i in range(60)]  # small physiological jitter, all in-band, all <20% jumps
+    q = assess_rr(series)
+    assert q.n_flagged == 0
+    assert q.artifact_pct == 0.0
+    assert q.usable is True
+    assert len(q.cleaned) == 60
+    assert q.corrected_idx == []
+
+
+def test_bradycardia_beats_are_kept():
+    """A trained athlete's slow nocturnal beats (RR up to ~1600 ms / ~37 bpm) must survive — the old
+    1500 ms ceiling clipped them and biased RMSSD downward."""
+    series = [1550 + (i % 3) for i in range(40)]  # ~38-39 bpm, above the old 1500 ms cap, inside the new band
+    q = assess_rr(series)
+    assert RR_MIN_MS <= 1550 <= RR_MAX_MS
+    assert q.n_flagged == 0
+    assert q.usable is True
+
+
+def test_relative_filter_catches_ectopic_the_absolute_filter_missed():
+    """A single ectopic beat jumps ~300 ms — under the old absolute 400 ms drop it slipped through and
+    inflated RMSSD. The Malik relative (>20%) filter flags it and interpolation repairs it."""
+    series = [800] * 30
+    series[15] = 1150  # +350 ms = +43% jump; passes |diff|<400 but fails the 20% relative test
+    q = assess_rr(series)
+    assert q.n_flagged == 1
+    assert 15 in q.corrected_idx or any(abs(v - 800) < 1 for v in [q.cleaned[i] for i in q.corrected_idx])
+    # interpolated between two 800s → back to 800, so RMSSD collapses to ~0
+    assert rmssd(q.cleaned) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_out_of_band_flagged_as_artifact():
+    """Values outside the physiological band are flagged and, mid-series, interpolated."""
+    series = [850] * 20 + [200] + [850] * 20  # 200 ms = 300 bpm, impossible
+    q = assess_rr(series)
+    assert q.n_flagged == 1
+    assert q.cleaned[20] == pytest.approx(850, abs=1e-6)  # interpolated back to neighbours
+
+
+def test_artifact_pct_and_usability_gate():
+    """A series above the 30% artifact budget is marked unusable so it can't poison a baseline."""
+    good = [850] * 10
+    bad = [300, 1900] * 10  # 20 out-of-band intervals
+    q = assess_rr(good + bad)
+    assert q.artifact_pct > MAX_ARTIFACT_FRACTION * 100.0
+    assert q.usable is False
+
+
+def test_edge_flagged_run_is_dropped_not_fabricated():
+    """A flagged run at the series edge has no left neighbour to interpolate from, so it is dropped —
+    we never fabricate beats across a true dropout."""
+    series = [300, 300] + [850] * 40  # leading artifacts, no prior valid beat
+    q = assess_rr(series)
+    assert q.n_flagged == 2
+    assert len(q.cleaned) == 40  # the two leading artifacts are dropped, not interpolated
+    assert q.corrected_idx == []
+
+
+def test_clean_segments_splits_on_gap_and_respects_min_len():
+    """clean_segments returns only contiguous in-spec runs >= min_len, splitting at an artifact."""
+    seg_a = [850] * 40
+    seg_b = [860] * 40
+    series = seg_a + [200] + seg_b  # a single impossible beat splits the two runs
+    segs = clean_segments(series, min_len=30)
+    assert len(segs) == 2
+    assert all(len(s) >= 30 for s in segs)
+    # a short run below min_len is discarded
+    assert clean_segments([850] * 10, min_len=30) == []
+
+
+def test_rmssd_and_ln_rmssd_math():
+    """RMSSD matches the closed-form on a known series; lnRMSSD is its log."""
+    series = [800, 810, 800, 810, 800]  # successive diffs alternate +/-10 → RMSSD = 10
+    assert rmssd(series) == pytest.approx(10.0)
+    assert ln_rmssd(series) == pytest.approx(log(10.0))
+
+
+def test_rmssd_none_on_too_few():
+    assert rmssd([800]) is None
+    assert ln_rmssd([800]) is None
+
+
+def test_relative_threshold_boundary():
+    """A jump of exactly the threshold is kept; just over it is flagged."""
+    at = 800 * (1 + MALIK_REL_THRESHOLD)          # exactly +20% → kept
+    over = 800 * (1 + MALIK_REL_THRESHOLD) + 5    # just over → flagged
+    assert assess_rr([800, at, 800]).n_flagged == 0
+    assert assess_rr([800, over, 800]).n_flagged == 1
+
+
+def test_empty_series():
+    q = assess_rr([])
+    assert q.n_raw == 0
+    assert q.usable is False
+    assert q.artifact_pct == 100.0

--- a/rivaflow/tests/unit/test_sleep_metrics.py
+++ b/rivaflow/tests/unit/test_sleep_metrics.py
@@ -1,0 +1,51 @@
+"""P1 sleep — B9 Need/Debt, B10 Regularity (pure, no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.sleep_metrics import NEED_HOURS, sleep_debt, sleep_regularity
+
+
+def test_no_debt_when_meeting_need():
+    r = sleep_debt([9.0, 9.5, 9.2, 9.0, 9.1])
+    assert r["debt_hours"] == pytest.approx(0.0)
+    assert "no meaningful debt" in r["headline"]
+
+
+def test_debt_accrues_on_short_nights():
+    r = sleep_debt([7.0, 7.0, 8.0])          # short vs 9h need
+    assert r["debt_hours"] == pytest.approx((9 - 7) + (9 - 7) + (9 - 8))
+    assert r["need_hours"] == NEED_HOURS
+
+
+def test_debt_window_limits_lookback():
+    durations = [5.0] * 20                    # only last 7 counted
+    r = sleep_debt(durations, window=7)
+    assert r["nights"] == 7
+    assert r["debt_hours"] == pytest.approx(7 * (9 - 5))
+
+
+def test_debt_empty():
+    assert sleep_debt([])["available"] is False
+
+
+def test_regularity_high_for_consistent_bedtimes():
+    r = sleep_regularity([22.5, 22.6, 22.4, 22.5, 22.5])
+    assert r["score"] >= 90
+    assert r["onset_sd_hours"] < 0.2
+
+
+def test_regularity_handles_midnight_wrap():
+    """23:30 and 00:30 are 1h apart, not 23h — circular SD must be small."""
+    r = sleep_regularity([23.5, 0.5, 23.5, 0.5, 0.0])
+    assert r["onset_sd_hours"] < 1.0
+
+
+def test_regularity_low_for_scattered_bedtimes():
+    r = sleep_regularity([20.0, 23.0, 1.0, 22.0, 19.0])
+    assert r["score"] < 50
+
+
+def test_regularity_needs_three_nights():
+    assert sleep_regularity([22.0, 22.5])["available"] is False

--- a/rivaflow/tests/unit/test_strain_target.py
+++ b/rivaflow/tests/unit/test_strain_target.py
@@ -1,0 +1,69 @@
+"""B5 Strain Target / Load Coach — pure-core tests (no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.strain_target import DEFAULT_CHRONIC, STRAIN_CAP, prescribe_strain
+
+
+def test_prime_allows_above_usual():
+    r = prescribe_strain("Prime", chronic_load=10.0)
+    assert r["available"] is True
+    assert r["target_load"] == pytest.approx(11.5)
+    assert r["capped"] is False
+    assert r["band"] == [9.5, 13.5]
+
+
+def test_balanced_matches_usual():
+    r = prescribe_strain("Balanced", chronic_load=10.0)
+    assert r["target_load"] == pytest.approx(10.0)
+    assert r["capped"] is False
+
+
+def test_strained_caps_below_usual():
+    r = prescribe_strain("Strained", chronic_load=10.0)
+    assert r["target_load"] == pytest.approx(6.0)
+    assert r["capped"] is True
+    assert "capped" in r["headline"]
+
+
+def test_rundown_is_a_hard_cap():
+    r = prescribe_strain("Rundown", chronic_load=10.0)
+    assert r["target_load"] == pytest.approx(4.0)
+    assert r["capped"] is True
+
+
+def test_rest_and_building_have_no_target():
+    assert prescribe_strain("Rest", 10.0)["available"] is False
+    assert prescribe_strain("Building", None)["available"] is False
+    assert prescribe_strain(None, 10.0)["available"] is False
+
+
+def test_unknown_state_is_unavailable():
+    assert prescribe_strain("Nonsense", 10.0)["available"] is False
+
+
+def test_no_history_uses_default_base():
+    r = prescribe_strain("Prime", chronic_load=None)
+    assert r["chronic_load"] == pytest.approx(DEFAULT_CHRONIC)
+    assert r["target_load"] == pytest.approx(DEFAULT_CHRONIC * 1.15)
+
+
+def test_target_is_capped_at_21():
+    r = prescribe_strain("Prime", chronic_load=20.0)   # 20 * 1.15 = 23 → capped
+    assert r["target_load"] == STRAIN_CAP
+    assert r["band"][1] == STRAIN_CAP
+
+
+def test_acute_below_target_reports_headroom():
+    r = prescribe_strain("Balanced", chronic_load=10.0, acute_load=4.0)
+    assert r["acute_load"] == pytest.approx(4.0)
+    assert r["remaining"] == pytest.approx(6.0)
+
+
+def test_acute_at_or_above_target_flips_headline():
+    r = prescribe_strain("Strained", chronic_load=10.0, acute_load=8.0)   # target 6, already 8
+    assert r["remaining"] == pytest.approx(0.0)
+    assert "hit today's target" in r["headline"]
+    assert "recover now" in r["headline"]   # capped state → recover

--- a/rivaflow/tests/unit/test_training_load.py
+++ b/rivaflow/tests/unit/test_training_load.py
@@ -6,7 +6,6 @@ import pytest
 
 from rivaflow.core.training_load import acwr, heart_rate_recovery, recovery_cost
 
-
 # --- B7 ACWR --------------------------------------------------------------
 
 def test_acwr_needs_chronic_window():

--- a/rivaflow/tests/unit/test_training_load.py
+++ b/rivaflow/tests/unit/test_training_load.py
@@ -1,0 +1,69 @@
+"""P1 training-load — B7 ACWR, B8 HRR, B12 recovery-cost (pure, no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rivaflow.core.training_load import acwr, heart_rate_recovery, recovery_cost
+
+
+# --- B7 ACWR --------------------------------------------------------------
+
+def test_acwr_needs_chronic_window():
+    assert acwr([10] * 20)["available"] is False
+
+
+def test_acwr_sweet_spot():
+    r = acwr([10] * 28)
+    assert r["ratio"] == pytest.approx(1.0)
+    assert r["zone"] == "sweet-spot"
+
+
+def test_acwr_high_risk_on_spike():
+    load = [5] * 21 + [15] * 7           # chronic ~7.5, acute 15 → ratio ~2.0
+    r = acwr(load)
+    assert r["ratio"] > 1.5
+    assert r["zone"] == "high-risk"
+
+
+def test_acwr_undertraining():
+    load = [12] * 21 + [4] * 7           # acute below chronic
+    assert acwr(load)["zone"] == "undertraining"
+
+
+# --- B8 HRR ---------------------------------------------------------------
+
+def test_hrr_measures_drop_after_peak():
+    hr = [120, 150, 180, 160, 140, 120] + [110] * 60   # peak 180 at idx2, +60s = 110
+    r = heart_rate_recovery(hr, window_sec=60)
+    assert r["available"] is True
+    assert r["peak"] == 180
+    assert r["hrr_bpm"] == 180 - hr[2 + 60]
+    assert "not a mortality marker" in r["note"]
+
+
+def test_hrr_unclean_when_peak_near_end():
+    hr = [120, 140, 180]                 # peak at the very end
+    r = heart_rate_recovery(hr, window_sec=60)
+    assert r["available"] is False
+    assert r["clean"] is False
+
+
+# --- B12 recovery-cost coupling -------------------------------------------
+
+def test_recovery_cost_negative_slope():
+    """Higher prior-day load → lower next-day recovery ⇒ negative slope."""
+    load = [1, 5, 1, 5, 1, 5, 1, 5]
+    nextm = [10, 10, 6, 10, 6, 10, 6, 10]   # after a load=5 day, next metric is low
+    r = recovery_cost(load, nextm)
+    assert r["available"] is True
+    assert r["slope"] < 0
+    assert "costs" in r["headline"]
+
+
+def test_recovery_cost_needs_enough_pairs():
+    assert recovery_cost([1, 2], [3, 4])["available"] is False
+
+
+def test_recovery_cost_no_variance():
+    assert recovery_cost([5] * 8, [5] * 8)["available"] is False


### PR DESCRIPTION
Implements the entire reviewed WHOOP-alternative roadmap — a self-hosted, subscription-free HR+RR insight & prevention tracker — plus the docs it was built from.

## What's here
- **Docs** (`docs/`): three docs hardened by a Fable five-lens review (physiology, signal-feasibility, product, red-team, references) + a 4-lens confirmation pass (GO, zero blockers).
- **Build**: all 20 buildable roadmap items, each as a **pure, DB-free core module + thin wiring + endpoint**.

## Builds
| Tier | Builds |
|---|---|
| P0 | B0 signal-QC gate · B1 Max-HR calibration · B2 Multi-input Readiness · B3 RR-coverage guard · B4 HRV Lab · B5 Strain Target |
| P1 | B7 ACWR · B8 HRR · B9 Sleep debt · B10 Regularity · B11 Behaviour correlation · B12 Recovery-cost |
| P2 | B13 Realtime stress · B14 VO₂max · B15 CV-age proxy · B16 Resilience · B17 Circadian · B18 DFA-α1 · B19 Assessment |
| Centrepiece | B6 Baseline-Deviation Watch (prevention engine) |
| Deferred | **B20 AFib** — decode-gated, not built, per the red team |

## Safety guarantees enforced in code
- RR treated as optical PPI; B0 QC gate (widened bradycardia band, Malik relative filter, ectopy interpolation, artifact-%) upstream of every metric.
- HRV runs on **lnRMSSD**; B3 excludes RR-starved nights before any baseline.
- Prevention engine: **4 signals, no cardiac rhythm**, robust median/MAD baselines, **family-based co-occurrence** (resp can't fire alone; correlated signals can't self-corroborate), **"green ≠ healthy" caveat**, amber/red fire on the Sabbath, never diagnostic.
- VO₂max **banded**, CV-age a **flagged proxy** (no alarming arrows), HRR **no mortality claim**, DFA-α1 **artifact-gated <3%**, LF:HF labelled descriptive.

## Verification
- **113 unit tests** across 15 pure-core suites, all passing.
- ruff-clean on all new code; every module + route compiles.
- Note: the project's test fixture requires Postgres, so the pure core logic was verified directly here; the committed pytest files run unchanged in CI.

## Follow-ups (deliberate)
- B20 AFib deferred until R22 raw-PPG decode.
- B11's journal tagging path is the one noted "more-data" dependency (statistics are done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)