### PR TITLE
feat(whoop): P1 — Capture & Labels (journal tagging path)

### DIFF
--- a/rivaflow/docs/WHOOP_REMAINING_BUILD_PLAN.md
+++ b/rivaflow/docs/WHOOP_REMAINING_BUILD_PLAN.md
@@ -1,0 +1,126 @@
+# WHOOP-Alternative — Remaining Build Plan (Phased) · 2026-07-04
+
+The compute layer is done: all 20 buildable engines (B0–B19) are implemented, tested, and on `main`,
+with B6 (prevention) now complete to spec. B20 (AFib) is correctly deferred (decode-gated). What remains
+is **surfaces, plumbing, and validation-with-real-data — not algorithms.** This is the phased plan to finish.
+
+**Working rhythm (unchanged):** one PR per phase (or sub-phase) → CI green (Backend Tests + Code Quality +
+Dependency Scan + Frontend) → merge. Each phase is independently shippable and leaves `main` green.
+
+Companion docs: `WHOOP_CURRENT_STATE.md`, `WHOOP_FUTURE_STATE_PLAN.md`, `WHOOP_RESEARCH_REFERENCES.md`.
+
+## Phase overview
+
+| Phase | Goal | Depends on | Ships |
+|---|---|---|---|
+| **P1 — Capture & Labels** | The keystone tagging path (journal → tags) | — | B11 real output + B6 tunable |
+| **P2 — Prevention: tune & deliver** | Tune thresholds on real tags + the anti-anxiety delivery layer | P1 | B6 armed in a channel |
+| **P3 — Web deep-dive cockpit** | Render the 8 panels from existing endpoints | P1 (for prevention log) | The analyst cockpit |
+| **P4 — Slim app (iOS)** | Render the new summary fields on the phone | — | The display side |
+| **P5 — Verify & close out** | End-to-end acceptance checks + doc refresh | P1–P4 | Spec conformance proven |
+
+P3 and P4 can run in parallel with each other after P1. P2 gates on P1. P5 is last.
+
+---
+
+## P1 — Capture & Labels (the keystone)
+
+**Why first:** the one true dependency. A tagging path feeds *both* B11 behaviour correlation *and* B6's
+validation/tuning gate (illness-onset labels). Everything downstream that needs "what happened that day"
+waits on this. It's small, well-scoped plumbing.
+
+**Build:**
+- **P1.1 — Storage.** Migration `whoop_tags (user_id, day DATE, tag TEXT, created_at)` + `WhoopTagRepository`
+  (add/list/remove). ⚠️ Keep the migration comments **semicolon-free** (the 107 bug).
+- **P1.2 — Capture route.** `POST /whoop/tag {day, tag}` + `GET /whoop/tags?from&to` + `DELETE`. Tags are
+  free-text but a small suggested vocab (alcohol, late-training, ill, poor-sleep, travel, sabbath-rest).
+- **P1.3 — Wire into analytics.** `behaviour_correlation` reads `tagged_days` from the repo; a new
+  `illness_dates` helper feeds `prevention_validation`. Add `GET /whoop/behaviour?tag=alcohol`.
+
+**Acceptance:** a day can be tagged and read back; `/whoop/behaviour?tag=…` returns real effect sizes;
+`prevention_validation` runs against real `ill`-tagged onsets (not a passed-in set).
+
+---
+
+## P2 — Prevention: tune & deliver
+
+**Why:** B6's engine + validation gate are complete, but (a) thresholds need tuning on real labels and
+(b) nothing *delivers* the tiers yet, and the spec mandates an anti-anxiety **once-daily digest**, not a
+live-refreshing red light.
+
+**Build:**
+- **P2.1 — Tune.** Once P1 has accumulated ~weeks of tags, run `prevention_validation`; adjust
+  AMBER_Z/RED_Z/CUSUM/drift to hit the acceptance target (≥2 onsets caught, <1 false amber/week); record the
+  tuned values + the validation result in the PRD/doc. Until enough labels exist, the engine stays in
+  "watch-only" (compute + log, no channel fire) — state that honestly.
+- **P2.2 — Delivery layer.** A once-daily morning compile (readiness + strain target + prevention tier),
+  with **alert cooldown** (no re-alert on the same signal within N days) and **tier→channel routing**:
+  amber/red → safety notification (fires Sunday); performance nudges → Sabbath-silenced. Reuse the existing
+  notification/scheduler infra. Health flags are a digest, never a 2-min live refresh.
+
+**Acceptance:** validation passes on real data *or* reports an honest "insufficient labels — watch-only"
+state; exactly one morning digest is produced per day; no live-refresh health flag exists.
+
+---
+
+## P3 — Web deep-dive cockpit (the analyst surface)
+
+**Why:** every panel's *data* already exists as JSON endpoints; only the rendered cockpit is missing. All
+compute stays server-side — the web app only renders. Extends `/whoop/view`. Sub-phase by panel group so
+each is a shippable PR.
+
+- **P3.1 — Recovery & Load.** Readiness (+ contributors + green≠healthy caveat), strain target, ACWR ribbon
+  (danger band shaded), cardio-load bars, recovery-cost coupling. Endpoints: `/readiness`, `/strain-target`,
+  `/acwr`, `/recovery-cost`.
+- **P3.2 — HRV Lab + Data integrity.** lnRMSSD/SDNN/pNN50 envelopes, LF/HF (labelled descriptive), Poincaré,
+  DFA-α1 (experimental), coverage/RR-coverage + artifact-% chart. Endpoints: `/hrv-lab`, `/dfa`, coverage
+  block in `/summary`.
+- **P3.3 — Sleep + Trends & Longevity.** Duration vs >9h need, debt curve, regularity, nocturnal dip; RHR/HRV/
+  VO₂max arrows, CV-age *proxy* (caveated, no alarming arrows), resilience, circadian; weekly/monthly
+  assessment narrative. Endpoints: `/sleep-analysis`, `/longevity`, `/resilience`, `/circadian`, `/assessment`.
+- **P3.4 — Prevention log + Behaviour.** Tier timeline (`/prevention-backtest`) with driving signals +
+  a **neutral, validation-stamped personal data export** (not "physician-shareable"); behaviour effect sizes
+  from P1. Endpoints: `/prevention`, `/prevention-backtest`, `/behaviour`.
+
+**Acceptance:** each panel renders from live endpoints only (zero client compute); the export carries its
+validation status + blind-spot caveats.
+
+---
+
+## P4 — Slim app (iOS)
+
+**Why:** `whoop_summary` now returns the new fields (strain target, coverage, max-HR, prevention tier) but
+`SlimHomeView` still renders the old set. The phone stays slim — fetch `/whoop/summary`, render, no compute.
+
+**Build:** extend `SlimHomeView` to show: readiness state + **green≠healthy caveat**, strain target + headroom,
+an RR-coverage indicator (so a charging-night gap is visible), and the prevention tier (amber/red only, with
+the reframed copy). Repo `RubyWolff27/goose-whoop5`.
+
+**Acceptance:** the phone displays the new fields from `/summary`; the green readiness card shows the caveat;
+no client-side compute added.
+
+---
+
+## P5 — Verify & close out
+
+- **P5.1 — Acceptance harness.** For each non-deferred build, verify end-to-end against its matrix "done" bar
+  on real data (e.g. B1 "zones shift for Ruby", B2 verdict shape, B3 excludes a real charging night). A small
+  `scripts/verify_whoop_builds.py` that hits the endpoints for the real user and asserts each criterion.
+- **P5.2 — Doc refresh.** Update `WHOOP_CURRENT_STATE.md` to list the shipped builds/endpoints; mark
+  `WHOOP_FUTURE_STATE_PLAN.md` matrix rows shipped; note the standing deferrals (B20 AFib, R22/K21 decode).
+
+**Acceptance:** every non-deferred build passes its acceptance criterion on real data; the docs match reality.
+
+---
+
+## Standing deferrals (not in scope — by design)
+- **B20 — AFib / irregular-rhythm screen:** decode-gated on the locked R22 raw-PPG SQI. Never in the
+  always-fire channel; revisit only in the R22-decode era.
+- **R22 / K21 decode:** locked; a future decode retroactively unlocks SpO₂ / temperature / sleep-staging from
+  banked raw history.
+
+## Suggested order
+**P1 → P2** (sequential; P2 gates on real tags) · **P3 and P4 in parallel** after P1 · **P5** last.
+P1 is the highest-leverage single build — it unblocks B11's real output *and* B6's tuning at once.
+
+*Phased plan, 2026-07-04. Owner surfaces: `rivaflow` (backend/web), `goose-whoop5` (iOS).*

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -154,6 +154,44 @@ def capture_health(current_user: dict = Depends(get_current_user)) -> dict:
     return {"latest": latest}
 
 
+class TagCreate(BaseModel):
+    """A journal tag for one local day (P1 — Capture & Labels)."""
+
+    day: str = Field(..., description="Local day 'YYYY-MM-DD'")
+    tag: str = Field(..., min_length=1, max_length=64)
+
+
+@router.post("/tag")
+@route_error_handler("whoop_add_tag", detail="Failed to add tag")
+def add_tag_endpoint(
+    req: TagCreate, current_user: dict = Depends(get_current_user)
+) -> dict:
+    """Tag a local day (alcohol, late-training, ill, poor-sleep, travel, sabbath-rest…). Idempotent.
+    Feeds B11 behaviour correlation and the B6 validation gate (an 'ill' tag is an illness-onset label).
+    """
+    WhoopRepository.add_tag(current_user["id"], req.day, req.tag)
+    return {"added": {"day": req.day, "tag": req.tag}}
+
+
+@router.get("/tags")
+@route_error_handler("whoop_list_tags", detail="Failed to list tags")
+def list_tags_endpoint(
+    start: str = "", end: str = "", current_user: dict = Depends(get_current_user)
+) -> list[dict]:
+    """List the user's tags, optionally bounded to [start, end] local days."""
+    return WhoopRepository.list_tags(current_user["id"], start or None, end or None)
+
+
+@router.delete("/tag")
+@route_error_handler("whoop_remove_tag", detail="Failed to remove tag")
+def remove_tag_endpoint(
+    day: str, tag: str, current_user: dict = Depends(get_current_user)
+) -> dict:
+    """Remove one (day, tag)."""
+    WhoopRepository.remove_tag(current_user["id"], day, tag)
+    return {"removed": {"day": day, "tag": tag}}
+
+
 # ── Read + analytics (Phase 2 / shared access: RivaFlow UI, health dashboard, LLM/MCP) ──
 
 
@@ -324,10 +362,29 @@ def prevention_validate_endpoint(
     """B6 validation & tuning gate — backtest the engine against retrospectively-tagged illness onsets and
     score it vs the acceptance target. ?onsets=YYYY-MM-DD,YYYY-MM-DD (from the journal/tagging path).
     """
-    from rivaflow.core.whoop_analytics import prevention_validation
+    from rivaflow.core.whoop_analytics import (
+        prevention_validation,
+        prevention_validation_live,
+    )
 
     dates = {d.strip() for d in onsets.split(",") if d.strip()}
-    return prevention_validation(current_user["id"], dates)
+    if dates:
+        return prevention_validation(current_user["id"], dates)
+    # No explicit onsets → use the real 'ill' journal tags (P1).
+    return prevention_validation_live(current_user["id"])
+
+
+@router.get("/behaviour")
+@route_error_handler(
+    "whoop_behaviour", detail="Failed to compute behaviour correlation"
+)
+def behaviour_endpoint(
+    tag: str, current_user: dict = Depends(get_current_user)
+) -> dict:
+    """B11 — effect of a tagged behaviour on lnRMSSD (tagged nights vs untagged), from the journal tags."""
+    from rivaflow.core.whoop_analytics import behaviour_for_tag
+
+    return behaviour_for_tag(current_user["id"], tag)
 
 
 @router.get("/hrv-lab")

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -380,6 +380,25 @@ def prevention_validation(
     }
 
 
+def illness_dates(user_id: int) -> set[str]:
+    """The user's 'ill' journal tags — the illness-onset labels the B6 validation gate scores against (P1)."""
+    return WhoopRepository.tagged_days(user_id, "ill")
+
+
+def prevention_validation_live(user_id: int, days: int = 45) -> dict:
+    """B6 validation using the real 'ill' tags from the journal (P1). With nothing tagged yet the gate
+    reports that honestly (no onsets → fails → engine stays watch-only)."""
+    return prevention_validation(user_id, illness_dates(user_id), days=days)
+
+
+def behaviour_for_tag(user_id: int, tag: str, days: int = 60) -> dict:
+    """B11 — behaviour correlation using the real journal tags (P1): tagged nights vs untagged nights on
+    lnRMSSD, now that the tagging path exists to feed WhoopRepository.tagged_days."""
+    return behaviour_correlation(
+        user_id, tag, WhoopRepository.tagged_days(user_id, tag), days=days
+    )
+
+
 def behaviour_correlation(
     user_id: int, tag: str, tagged_days: set[str], days: int = 60
 ) -> dict:

--- a/rivaflow/rivaflow/db/migrations/110_whoop_tags.sql
+++ b/rivaflow/rivaflow/db/migrations/110_whoop_tags.sql
@@ -1,0 +1,15 @@
+-- 110_whoop_tags.sql
+-- SQLite local-dev variant of 110_whoop_tags_pg.sql.
+-- (Keep these comments free of the semicolon character, which the migration runner splits on.)
+CREATE TABLE IF NOT EXISTS whoop_tags (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    day         TEXT    NOT NULL,
+    tag         TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (user_id, day, tag),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS whoop_tags_user_day_idx ON whoop_tags (user_id, day);
+CREATE INDEX IF NOT EXISTS whoop_tags_user_tag_idx ON whoop_tags (user_id, tag);

--- a/rivaflow/rivaflow/db/migrations/110_whoop_tags_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/110_whoop_tags_pg.sql
@@ -1,0 +1,20 @@
+-- 110_whoop_tags_pg.sql
+-- Journal tags for the WHOOP data platform (PostgreSQL / production).
+-- See 110_whoop_tags.sql for the SQLite (local dev) variant.
+--
+-- A tag records that something happened on a given LOCAL day (alcohol, late-training, ill,
+-- poor-sleep, travel, sabbath-rest). Tags feed B11 behaviour correlation and the B6 prevention
+-- validation gate, where an "ill" tag is an illness-onset label. One row per (user, day, tag).
+-- (Keep these comments free of the semicolon character, which the migration runner treats as a
+--  statement separator even inside a comment.)
+CREATE TABLE IF NOT EXISTS whoop_tags (
+    id          BIGSERIAL   PRIMARY KEY,
+    user_id     INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    day         DATE        NOT NULL,
+    tag         TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, day, tag)
+);
+
+CREATE INDEX IF NOT EXISTS whoop_tags_user_day_idx ON whoop_tags (user_id, day);
+CREATE INDEX IF NOT EXISTS whoop_tags_user_tag_idx ON whoop_tags (user_id, tag);

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -220,3 +220,51 @@ class WhoopRepository:
             ),
             (user_id,),
         )
+
+    # ── Journal tags (P1 — Capture & Labels) ─────────────────────────────
+    # A tag marks that something happened on a local day (alcohol, late-training, ill, poor-sleep,
+    # travel, sabbath-rest). Feeds B11 behaviour correlation + the B6 validation gate ("ill" = onset).
+
+    @staticmethod
+    def add_tag(user_id: int, day: str, tag: str) -> int:
+        """Idempotent add of one (day, tag) for a user."""
+        return WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_tags (user_id, day, tag) VALUES (?, ?, ?) "
+            "ON CONFLICT (user_id, day, tag) DO NOTHING",
+            [(user_id, day, tag)],
+        )
+
+    @staticmethod
+    def list_tags(
+        user_id: int, start: str | None = None, end: str | None = None
+    ) -> list[dict]:
+        """Tags for a user, optionally bounded to [start, end] local days (newest first)."""
+        query = "SELECT day, tag, created_at FROM whoop_tags WHERE user_id = ?"
+        params: list = [user_id]
+        if start:
+            query += " AND day >= ?"
+            params.append(start)
+        if end:
+            query += " AND day <= ?"
+            params.append(end)
+        query += " ORDER BY day DESC, tag"
+        return BaseRepository._fetchall(convert_query(query), tuple(params))
+
+    @staticmethod
+    def remove_tag(user_id: int, day: str, tag: str) -> None:
+        """Delete one (day, tag) for a user."""
+        BaseRepository._execute(
+            convert_query(
+                "DELETE FROM whoop_tags WHERE user_id = ? AND day = ? AND tag = ?"
+            ),
+            (user_id, day, tag),
+        )
+
+    @staticmethod
+    def tagged_days(user_id: int, tag: str) -> set[str]:
+        """The set of 'YYYY-MM-DD' local days carrying `tag` — the shape analytics consume."""
+        rows = BaseRepository._fetchall(
+            convert_query("SELECT day FROM whoop_tags WHERE user_id = ? AND tag = ?"),
+            (user_id, tag),
+        )
+        return {str(r["day"])[:10] for r in rows}

--- a/tests/test_whoop_tags.py
+++ b/tests/test_whoop_tags.py
@@ -1,0 +1,65 @@
+"""P1 — WHOOP journal tags: capture route + repo (runs against Postgres in CI via temp_db)."""
+
+from __future__ import annotations
+
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+
+class TestWhoopTagRepo:
+    def test_add_and_tagged_days(self, test_user):
+        uid = test_user["id"]
+        WhoopRepository.add_tag(uid, "2026-06-01", "ill")
+        WhoopRepository.add_tag(uid, "2026-06-05", "ill")
+        WhoopRepository.add_tag(uid, "2026-06-05", "alcohol")
+        assert WhoopRepository.tagged_days(uid, "ill") == {"2026-06-01", "2026-06-05"}
+        assert WhoopRepository.tagged_days(uid, "alcohol") == {"2026-06-05"}
+
+    def test_add_is_idempotent(self, test_user):
+        uid = test_user["id"]
+        WhoopRepository.add_tag(uid, "2026-06-10", "poor-sleep")
+        WhoopRepository.add_tag(uid, "2026-06-10", "poor-sleep")
+        rows = [r for r in WhoopRepository.list_tags(uid) if r["tag"] == "poor-sleep"]
+        assert len(rows) == 1
+
+    def test_remove_tag(self, test_user):
+        uid = test_user["id"]
+        WhoopRepository.add_tag(uid, "2026-06-12", "travel")
+        assert "2026-06-12" in WhoopRepository.tagged_days(uid, "travel")
+        WhoopRepository.remove_tag(uid, "2026-06-12", "travel")
+        assert "2026-06-12" not in WhoopRepository.tagged_days(uid, "travel")
+
+    def test_list_tags_bounded(self, test_user):
+        uid = test_user["id"]
+        for d in ("2026-05-01", "2026-06-01", "2026-07-01"):
+            WhoopRepository.add_tag(uid, d, "late-training")
+        days = {
+            r["day"] if isinstance(r["day"], str) else r["day"].isoformat()
+            for r in WhoopRepository.list_tags(
+                uid, start="2026-06-01", end="2026-06-30"
+            )
+        }
+        assert "2026-06-01" in days
+        assert "2026-05-01" not in days and "2026-07-01" not in days
+
+
+class TestWhoopTagEndpoints:
+    def test_post_get_delete_flow(self, client, auth_headers):
+        # create
+        r = client.post(
+            "/api/v1/whoop/tag",
+            headers=auth_headers,
+            json={"day": "2026-06-20", "tag": "ill"},
+        )
+        assert r.status_code == 200, r.text
+        # list
+        r = client.get("/api/v1/whoop/tags", headers=auth_headers)
+        assert r.status_code == 200
+        assert any(row["tag"] == "ill" for row in r.json())
+        # delete
+        r = client.request(
+            "DELETE",
+            "/api/v1/whoop/tag",
+            headers=auth_headers,
+            params={"day": "2026-06-20", "tag": "ill"},
+        )
+        assert r.status_code == 200


### PR DESCRIPTION
First phase of the remaining-work plan (docs/WHOOP_REMAINING_BUILD_PLAN.md). The keystone tagging path: whoop_tags table + repo + POST/GET/DELETE /whoop/tag, wired into B11 behaviour correlation and the B6 validation gate (real 'ill' onset labels). Migration comments semicolon-free (107 lesson). DB-backed tests run in CI; 126 pure tests + Code Quality green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)