### PR TITLE
feat(whoop): P2 — prevention delivery layer (digest + cooldown)

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -374,6 +374,37 @@ def prevention_validate_endpoint(
     return prevention_validation_live(current_user["id"])
 
 
+@router.get("/digest")
+@route_error_handler("whoop_digest", detail="Failed to compile digest")
+def digest_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """P2 — once-daily digest preview (readiness + strain + prevention, tier→channel routed). Sabbath-aware."""
+    from rivaflow.core.whoop_analytics import morning_digest
+
+    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
+    return morning_digest(current_user["id"], today_is_sabbath=is_sabbath)
+
+
+@router.post("/digest/deliver")
+@route_error_handler("whoop_digest_deliver", detail="Failed to deliver digest")
+def deliver_digest_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+    """P2 — deliver today's digest: applies the cooldown and records any safety alert that fires. Called
+    once each morning by the briefing cron (idempotent per day/key)."""
+    from rivaflow.core.whoop_analytics import deliver_digest
+
+    return deliver_digest(current_user["id"])
+
+
+@router.get("/prevention-log")
+@route_error_handler("whoop_prevention_log", detail="Failed to fetch prevention log")
+def prevention_log_endpoint(
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    """P2/P3.4 — timeline of fired safety alerts (the prevention log)."""
+    from rivaflow.core.whoop_analytics import prevention_log
+
+    return prevention_log(current_user["id"])
+
+
 @router.get("/behaviour")
 @route_error_handler(
     "whoop_behaviour", detail="Failed to compute behaviour correlation"

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -36,6 +36,7 @@ from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
 from rivaflow.core.sleep_metrics import sleep_debt, sleep_regularity
 from rivaflow.core.strain_target import prescribe_strain
 from rivaflow.core.training_load import acwr, heart_rate_recovery, recovery_cost
+from rivaflow.core.whoop_digest import compile_digest
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
@@ -397,6 +398,57 @@ def behaviour_for_tag(user_id: int, tag: str, days: int = 60) -> dict:
     return behaviour_correlation(
         user_id, tag, WhoopRepository.tagged_days(user_id, tag), days=days
     )
+
+
+def morning_digest(user_id: int, today_is_sabbath: bool = False) -> dict:
+    """P2 — once-daily digest PREVIEW: readiness + strain + prevention tier, tier→channel routed (amber/red
+    = safety, fires Sunday; readiness/strain = performance nudges, Sabbath-silenced). No side effects.
+    """
+    readiness = compute_readiness(user_id, today_is_sabbath=today_is_sabbath)
+    strain = strain_target(user_id, today_is_sabbath=today_is_sabbath)
+    prevention = prevention_watch(user_id)
+    return compile_digest(
+        readiness, strain, prevention, today_is_sabbath=today_is_sabbath
+    )
+
+
+def deliver_digest(user_id: int) -> dict:
+    """P2 — compute today's digest with the cooldown applied and RECORD any safety alert that fires (the
+    delivery record + cooldown state, idempotent per (day, key)). Called once each morning by the external
+    briefing cron. Anti-anxiety: one digest per day, no live-refresh flags."""
+    now = datetime.now(LOCAL_TZ)
+    today = now.date()
+    is_sabbath = now.weekday() == 6  # Sunday = Ruby's rest day
+    readiness = compute_readiness(user_id, today_is_sabbath=is_sabbath)
+    strain = strain_target(user_id, today_is_sabbath=is_sabbath)
+    prevention = prevention_watch(user_id)
+    last_alerts = WhoopRepository.last_alert_days(user_id)
+    digest = compile_digest(
+        readiness,
+        strain,
+        prevention,
+        today_is_sabbath=is_sabbath,
+        today=today,
+        last_alerts=last_alerts,
+    )
+    alert = digest.get("safety_alert")
+    if alert:
+        WhoopRepository.record_alert(
+            user_id,
+            today.isoformat(),
+            alert["key"],
+            alert["tier"],
+            alert.get("headline"),
+        )
+        digest["delivered"] = True
+    else:
+        digest["delivered"] = False
+    return digest
+
+
+def prevention_log(user_id: int, limit: int = 60) -> list[dict]:
+    """P2/P3.4 — the fired-alert timeline (the prevention log the cockpit renders)."""
+    return WhoopRepository.recent_alerts(user_id, limit=limit)
 
 
 def behaviour_correlation(

--- a/rivaflow/rivaflow/core/whoop_digest.py
+++ b/rivaflow/rivaflow/core/whoop_digest.py
@@ -1,0 +1,108 @@
+"""P2 — Prevention & readiness delivery: the once-daily digest compiler + alert-cooldown (pure core).
+
+Anti-anxiety by design (WHOOP_FUTURE_STATE_PLAN.md B6 delivery): health/anomaly findings are a **once-daily
+morning digest with a cooldown**, never a live-refreshing red light. Tier → channel routing is explicit:
+  - prevention **amber/red** = the SAFETY channel → fires even on the Sabbath (early-warning, not a nudge);
+  - **readiness / strain** = performance nudges → Sabbath-silenced.
+A safety alert is rate-limited: the same tier won't re-alert within the cooldown window.
+
+Pure and DB-free — the wiring passes today's date + the last-alert history (from notification records).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+DEFAULT_COOLDOWN_DAYS = 3
+SAFETY_TIERS = {"amber", "red"}
+_SILENT_READINESS = {None, "Rest", "Building"}
+
+
+def route_items(
+    readiness: dict, strain: dict, prevention: dict, today_is_sabbath: bool
+) -> list[dict]:
+    """Decide what the digest surfaces and which channel each item is on. Amber/red prevention is safety
+    (fires Sunday); readiness + strain are performance nudges (Sabbath-silenced)."""
+    items: list[dict] = []
+
+    tier = prevention.get("tier") if prevention.get("available") else None
+    if tier in SAFETY_TIERS:
+        items.append(
+            {
+                "kind": "prevention",
+                "channel": "safety",
+                "tier": tier,
+                "headline": prevention.get("headline", ""),
+                "fires": True,  # safety fires regardless of Sabbath
+            }
+        )
+
+    if readiness.get("state") not in _SILENT_READINESS:
+        items.append(
+            {
+                "kind": "readiness",
+                "channel": "performance",
+                "state": readiness.get("state"),
+                "headline": readiness.get("headline", ""),
+                "caveat": readiness.get("caveat"),
+                "fires": not today_is_sabbath,
+            }
+        )
+
+    if strain.get("available"):
+        items.append(
+            {
+                "kind": "strain",
+                "channel": "performance",
+                "headline": strain.get("headline", ""),
+                "fires": not today_is_sabbath,
+            }
+        )
+
+    return items
+
+
+def should_alert(
+    last_alert_day: str | None,
+    today: date,
+    cooldown_days: int = DEFAULT_COOLDOWN_DAYS,
+) -> bool:
+    """Cooldown gate: don't re-fire the same safety signal within `cooldown_days`."""
+    if last_alert_day is None:
+        return True
+    return (
+        today.toordinal() - date.fromisoformat(last_alert_day).toordinal()
+    ) >= cooldown_days
+
+
+def compile_digest(
+    readiness: dict,
+    strain: dict,
+    prevention: dict,
+    today_is_sabbath: bool = False,
+    today: date | None = None,
+    last_alerts: dict[str, str] | None = None,
+    cooldown_days: int = DEFAULT_COOLDOWN_DAYS,
+) -> dict:
+    """The once-daily digest. Surfaces the day's items and, if a prevention amber/red is present AND not in
+    cooldown, the single `safety_alert` to actually push. `last_alerts` maps a safety key ('prevention:amber')
+    to the 'YYYY-MM-DD' it last fired; pass `today` to apply the cooldown (omit for a pure compile/preview).
+    """
+    last_alerts = last_alerts or {}
+    items = route_items(readiness, strain, prevention, today_is_sabbath)
+
+    safety_alert = None
+    for it in items:
+        if it["channel"] == "safety" and it["fires"]:
+            key = f"prevention:{it['tier']}"
+            if today is None or should_alert(
+                last_alerts.get(key), today, cooldown_days
+            ):
+                safety_alert = {**it, "key": key}
+            break
+
+    return {
+        "items": items,
+        "safety_alert": safety_alert,  # None → nothing to push (green, or in cooldown)
+        "delivery": "once-daily digest — no live-refresh health flags",
+    }

--- a/rivaflow/rivaflow/db/migrations/111_whoop_alerts.sql
+++ b/rivaflow/rivaflow/db/migrations/111_whoop_alerts.sql
@@ -1,0 +1,16 @@
+-- 111_whoop_alerts.sql
+-- SQLite local-dev variant of 111_whoop_alerts_pg.sql.
+-- (Keep these comments free of the semicolon character, which the migration runner splits on.)
+CREATE TABLE IF NOT EXISTS whoop_alerts (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    day         TEXT    NOT NULL,
+    alert_key   TEXT    NOT NULL,
+    tier        TEXT    NOT NULL,
+    headline    TEXT,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (user_id, day, alert_key),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS whoop_alerts_user_day_idx ON whoop_alerts (user_id, day);

--- a/rivaflow/rivaflow/db/migrations/111_whoop_alerts_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/111_whoop_alerts_pg.sql
@@ -1,0 +1,21 @@
+-- 111_whoop_alerts_pg.sql
+-- Delivery log + cooldown state for the WHOOP prevention digest (PostgreSQL / production).
+-- See 111_whoop_alerts.sql for the SQLite (local dev) variant.
+--
+-- One row per safety alert the once-daily digest actually fired (P2 delivery). It is the cooldown
+-- state (last-fired per key) and the delivery record the prevention-log panel reads. Anti-anxiety by
+-- design, so this is a daily digest record, never a live-refresh flag.
+-- (Keep these comments free of the semicolon character, which the migration runner treats as a
+--  statement separator even inside a comment.)
+CREATE TABLE IF NOT EXISTS whoop_alerts (
+    id          BIGSERIAL   PRIMARY KEY,
+    user_id     INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    day         DATE        NOT NULL,
+    alert_key   TEXT        NOT NULL,
+    tier        TEXT        NOT NULL,
+    headline    TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, day, alert_key)
+);
+
+CREATE INDEX IF NOT EXISTS whoop_alerts_user_day_idx ON whoop_alerts (user_id, day);

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -268,3 +268,41 @@ class WhoopRepository:
             (user_id, tag),
         )
         return {str(r["day"])[:10] for r in rows}
+
+    # ── Prevention alerts (P2 — delivery log + cooldown state) ───────────
+
+    @staticmethod
+    def record_alert(
+        user_id: int, day: str, alert_key: str, tier: str, headline: str | None
+    ) -> int:
+        """Idempotently record that a safety alert fired for a (day, key). Doubles as the cooldown state."""
+        return WhoopRepository._insert_ignore(
+            "INSERT INTO whoop_alerts (user_id, day, alert_key, tier, headline) "
+            "VALUES (?, ?, ?, ?, ?) ON CONFLICT (user_id, day, alert_key) DO NOTHING",
+            [(user_id, day, alert_key, tier, headline)],
+        )
+
+    @staticmethod
+    def last_alert_days(user_id: int) -> dict[str, str]:
+        """Most-recent fire day per alert_key — the cooldown map the digest consumes ({key: 'YYYY-MM-DD'})."""
+        rows = BaseRepository._fetchall(
+            convert_query(
+                "SELECT alert_key, MAX(day) AS last_day FROM whoop_alerts "
+                "WHERE user_id = ? GROUP BY alert_key"
+            ),
+            (user_id,),
+        )
+        return {
+            r["alert_key"]: str(r["last_day"])[:10] for r in rows if r.get("last_day")
+        }
+
+    @staticmethod
+    def recent_alerts(user_id: int, limit: int = 60) -> list[dict]:
+        """Recent fired alerts (newest first) — the prevention-log timeline (P3.4)."""
+        return BaseRepository._fetchall(
+            convert_query(
+                "SELECT day, alert_key, tier, headline, created_at FROM whoop_alerts "
+                "WHERE user_id = ? ORDER BY day DESC, created_at DESC LIMIT ?"
+            ),
+            (user_id, limit),
+        )

--- a/rivaflow/tests/unit/test_whoop_digest.py
+++ b/rivaflow/tests/unit/test_whoop_digest.py
@@ -1,0 +1,98 @@
+"""P2 delivery — once-daily digest compiler + cooldown (pure, no DB)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from rivaflow.core.whoop_digest import (
+    DEFAULT_COOLDOWN_DAYS,
+    compile_digest,
+    route_items,
+    should_alert,
+)
+
+AMBER = {"available": True, "tier": "amber", "headline": "watch"}
+GREEN = {"available": True, "tier": "green", "headline": "in range"}
+PRIME = {"state": "Prime", "headline": "push", "caveat": "green != healthy"}
+STRAIN_OK = {"available": True, "headline": "target 12"}
+
+
+def test_amber_is_safety_and_fires_even_on_sabbath():
+    items = route_items(PRIME, STRAIN_OK, AMBER, today_is_sabbath=True)
+    safety = [i for i in items if i["channel"] == "safety"]
+    assert safety and safety[0]["fires"] is True and safety[0]["tier"] == "amber"
+
+
+def test_readiness_and_strain_are_sabbath_silenced():
+    items = route_items(PRIME, STRAIN_OK, GREEN, today_is_sabbath=True)
+    perf = [i for i in items if i["channel"] == "performance"]
+    assert perf and all(i["fires"] is False for i in perf)
+
+
+def test_performance_fires_on_a_normal_day():
+    items = route_items(PRIME, STRAIN_OK, GREEN, today_is_sabbath=False)
+    perf = [i for i in items if i["channel"] == "performance"]
+    assert perf and all(i["fires"] is True for i in perf)
+
+
+def test_green_prevention_has_no_safety_item():
+    items = route_items(PRIME, STRAIN_OK, GREEN, today_is_sabbath=False)
+    assert not [i for i in items if i["channel"] == "safety"]
+
+
+def test_building_readiness_not_surfaced():
+    items = route_items({"state": "Building"}, {"available": False}, GREEN, False)
+    assert not [i for i in items if i["kind"] == "readiness"]
+
+
+# --- cooldown -------------------------------------------------------------
+
+
+def test_should_alert_no_history():
+    assert should_alert(None, date(2026, 6, 10)) is True
+
+
+def test_should_alert_within_cooldown():
+    assert should_alert("2026-06-09", date(2026, 6, 10)) is False  # 1 day < 3
+
+
+def test_should_alert_after_cooldown():
+    assert should_alert("2026-06-05", date(2026, 6, 10)) is True  # 5 days >= 3
+
+
+# --- compile_digest -------------------------------------------------------
+
+
+def test_compile_surfaces_safety_alert():
+    d = compile_digest(PRIME, STRAIN_OK, AMBER)
+    assert d["safety_alert"] is not None
+    assert d["safety_alert"]["key"] == "prevention:amber"
+    assert "no live-refresh" in d["delivery"]
+
+
+def test_compile_respects_cooldown():
+    today = date(2026, 6, 10)
+    recent = compile_digest(
+        PRIME,
+        STRAIN_OK,
+        AMBER,
+        today=today,
+        last_alerts={"prevention:amber": "2026-06-09"},
+    )
+    assert recent["safety_alert"] is None  # in cooldown
+    old = compile_digest(
+        PRIME,
+        STRAIN_OK,
+        AMBER,
+        today=today,
+        last_alerts={"prevention:amber": "2026-06-01"},
+    )
+    assert old["safety_alert"] is not None  # cooldown elapsed
+
+
+def test_compile_green_no_alert():
+    assert compile_digest(PRIME, STRAIN_OK, GREEN)["safety_alert"] is None
+
+
+def test_cooldown_default():
+    assert DEFAULT_COOLDOWN_DAYS == 3

--- a/tests/test_whoop_digest_delivery.py
+++ b/tests/test_whoop_digest_delivery.py
@@ -1,0 +1,51 @@
+"""P2 — WHOOP digest delivery: alert repo + endpoints (Postgres in CI via temp_db)."""
+
+from __future__ import annotations
+
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+
+class TestWhoopAlertRepo:
+    def test_record_and_cooldown_map(self, test_user):
+        uid = test_user["id"]
+        WhoopRepository.record_alert(
+            uid, "2026-06-01", "prevention:amber", "amber", "watch"
+        )
+        WhoopRepository.record_alert(
+            uid, "2026-06-05", "prevention:amber", "amber", "watch again"
+        )
+        WhoopRepository.record_alert(uid, "2026-06-05", "prevention:red", "red", "rest")
+        last = WhoopRepository.last_alert_days(uid)
+        assert last["prevention:amber"] == "2026-06-05"  # most recent
+        assert last["prevention:red"] == "2026-06-05"
+
+    def test_record_is_idempotent_per_day_key(self, test_user):
+        uid = test_user["id"]
+        WhoopRepository.record_alert(
+            uid, "2026-06-10", "prevention:amber", "amber", "x"
+        )
+        WhoopRepository.record_alert(
+            uid, "2026-06-10", "prevention:amber", "amber", "x"
+        )
+        rows = [
+            r
+            for r in WhoopRepository.recent_alerts(uid)
+            if r["day"] and str(r["day"]).startswith("2026-06-10")
+        ]
+        assert len(rows) == 1
+
+
+class TestWhoopDigestEndpoints:
+    def test_digest_preview_and_deliver(self, client, auth_headers):
+        # preview compiles (green/building with no data → no safety alert, but 200)
+        r = client.get("/api/v1/whoop/digest", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert "items" in r.json() and "delivery" in r.json()
+        # deliver runs the cooldown path + returns delivered flag
+        r = client.post("/api/v1/whoop/digest/deliver", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert "delivered" in r.json()
+        # prevention log is listable
+        r = client.get("/api/v1/whoop/prevention-log", headers=auth_headers)
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)


### PR DESCRIPTION
Phase 2 of the remaining-work plan. The anti-anxiety delivery layer: a once-daily digest compiler with tier→channel routing (amber/red = safety, fires Sunday; readiness/strain = Sabbath-silenced nudges) + alert cooldown, backed by a whoop_alerts table (delivery log + cooldown state). Endpoints: GET /whoop/digest, POST /whoop/digest/deliver (cron target), GET /whoop/prevention-log. Migration comments semicolon-free. +12 pure tests (138 total) + DB delivery test; Code Quality green locally. P2.1 threshold tuning stays a runtime activity pending real 'ill' tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)