### PR TITLE
feat(whoop): P3.1 — web cockpit, Recovery & Load panel

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -505,6 +505,25 @@ def summary(current_user: dict = Depends(get_current_user)) -> dict:
     return whoop_summary(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/cockpit", response_class=HTMLResponse)
+def cockpit(key: str) -> HTMLResponse:
+    """P3 — server-rendered web deep-dive cockpit (analyst panels). Zero client compute; key-auth like /view."""
+    from rivaflow.core.whoop_analytics import cockpit_page
+    from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
+
+    api_key = (
+        ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(key))
+        if key.startswith("rf_pk_")
+        else None
+    )
+    if not api_key:
+        return HTMLResponse(
+            "<h1 style='font-family:system-ui;color:#eee;background:#111'>Unauthorized</h1>",
+            status_code=401,
+        )
+    return HTMLResponse(cockpit_page(api_key["user_id"]))
+
+
 @router.get("/view", response_class=HTMLResponse)
 def view(key: str) -> HTMLResponse:
     """Server-rendered thin-display dashboard — the phone/browser opens a URL and the VPS renders the

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -36,6 +36,7 @@ from rivaflow.core.rr_quality import assess_rr, clean_segments, ln_rmssd, rmssd
 from rivaflow.core.sleep_metrics import sleep_debt, sleep_regularity
 from rivaflow.core.strain_target import prescribe_strain
 from rivaflow.core.training_load import acwr, heart_rate_recovery, recovery_cost
+from rivaflow.core.whoop_cockpit import render_cockpit_page, render_recovery_load
 from rivaflow.core.whoop_digest import compile_digest
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
@@ -449,6 +450,21 @@ def deliver_digest(user_id: int) -> dict:
 def prevention_log(user_id: int, limit: int = 60) -> list[dict]:
     """P2/P3.4 — the fired-alert timeline (the prevention log the cockpit renders)."""
     return WhoopRepository.recent_alerts(user_id, limit=limit)
+
+
+def cockpit_page(user_id: int) -> str:
+    """P3 — server-rendered web deep-dive cockpit HTML. All series are computed here; the page only renders.
+    P3.1 ships the Recovery & Load panel; later sub-phases append more panels."""
+    now = datetime.now(LOCAL_TZ)
+    is_sabbath = now.weekday() == 6
+    mx = user_max_hr(user_id)["max_hr"]
+    readiness = compute_readiness(user_id, today_is_sabbath=is_sabbath)
+    strain = strain_target(user_id, today_is_sabbath=is_sabbath)
+    acwr_data = training_acwr(user_id)
+    cardio = daily_cardio_load(user_id, days=28, max_hr=mx)
+    rec_cost = recovery_cost_coupling(user_id)
+    panels = render_recovery_load(readiness, strain, acwr_data, cardio, rec_cost)
+    return render_cockpit_page(panels)
 
 
 def behaviour_correlation(

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -1,0 +1,182 @@
+"""P3 — Web deep-dive cockpit renderer (pure, dependency-free).
+
+The analyst's cockpit (WHOOP_FUTURE_STATE_PLAN.md web deep-dive): server-rendered HTML with inline-SVG
+charts computed from the existing endpoints — the web app only RENDERS, all compute stays server-side.
+No JS/CDN dependency: sparklines, bars, and the ACWR ribbon are plain inline SVG built from the series here.
+
+Sub-phased by panel group; P3.1 ships Recovery & Load. Every dynamic string is HTML-escaped.
+"""
+
+from __future__ import annotations
+
+import html
+
+_ACCENT = {
+    "Prime": "#34d399",
+    "Balanced": "#60a5fa",
+    "Strained": "#fbbf24",
+    "Rundown": "#f87171",
+    "Building": "#94a3b8",
+    "Rest": "#a78bfa",
+}
+_ZONE_COLOR = {
+    "undertraining": "#60a5fa",
+    "sweet-spot": "#34d399",
+    "caution": "#fbbf24",
+    "high-risk": "#f87171",
+}
+
+
+def esc(s: object) -> str:
+    return html.escape(str(s))
+
+
+def svg_sparkline(
+    values: list[float | None], w: int = 240, h: int = 44, stroke: str = "#60a5fa"
+) -> str:
+    """A dependency-free line chart from a numeric series."""
+    pts = [float(v) for v in values if v is not None]
+    if len(pts) < 2:
+        return f'<svg width="{w}" height="{h}" role="img" aria-label="no data"></svg>'
+    lo, hi = min(pts), max(pts)
+    rng = (hi - lo) or 1.0
+    step = w / (len(pts) - 1)
+    coords = " ".join(
+        f"{i * step:.1f},{h - (v - lo) / rng * (h - 4) - 2:.1f}"
+        for i, v in enumerate(pts)
+    )
+    return (
+        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" preserveAspectRatio="none">'
+        f'<polyline fill="none" stroke="{stroke}" stroke-width="2" points="{coords}"/></svg>'
+    )
+
+
+def svg_bars(
+    values: list[float | None], w: int = 240, h: int = 44, fill: str = "#34d399"
+) -> str:
+    """A dependency-free bar chart (e.g. daily cardio load)."""
+    vals = [max(0.0, float(v)) for v in values if v is not None]
+    if not vals:
+        return f'<svg width="{w}" height="{h}" role="img" aria-label="no data"></svg>'
+    hi = max(vals) or 1.0
+    n = len(vals)
+    bw = w / n
+    rects = "".join(
+        f'<rect x="{i * bw:.1f}" y="{h - (v / hi) * (h - 2):.1f}" width="{bw * 0.8:.1f}" '
+        f'height="{(v / hi) * (h - 2):.1f}" fill="{fill}"/>'
+        for i, v in enumerate(vals)
+    )
+    return f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}">{rects}</svg>'
+
+
+def svg_acwr_ribbon(ratio: float, w: int = 240, h: int = 22) -> str:
+    """ACWR gauge 0–2 with the Gabbett sweet-spot (0.8–1.3) shaded green and the danger zone (>1.5) red."""
+
+    def x(r: float) -> float:
+        return min(max(r, 0.0), 2.0) / 2.0 * w
+
+    marker = x(ratio)
+    return (
+        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}">'
+        f'<rect x="0" y="6" width="{w}" height="10" fill="#334155"/>'
+        f'<rect x="{x(0.8):.1f}" y="6" width="{x(1.3) - x(0.8):.1f}" height="10" fill="#065f46"/>'
+        f'<rect x="{x(1.5):.1f}" y="6" width="{w - x(1.5):.1f}" height="10" fill="#7f1d1d"/>'
+        f'<line x1="{marker:.1f}" y1="2" x2="{marker:.1f}" y2="20" stroke="#f8fafc" stroke-width="2"/>'
+        f"</svg>"
+    )
+
+
+def stat(label: str, value: str, sub: str = "", accent: str = "#e2e8f0") -> str:
+    return (
+        f'<div class="stat"><div class="lbl">{esc(label)}</div>'
+        f'<div class="v" style="color:{accent}">{esc(value)}</div>'
+        f'<div class="sub">{esc(sub)}</div></div>'
+    )
+
+
+def render_recovery_load(
+    readiness: dict,
+    strain: dict,
+    acwr: dict,
+    cardio_trend: list[dict],
+    recovery_cost: dict,
+) -> str:
+    """P3.1 — the Recovery & Load panel."""
+    accent = _ACCENT.get(readiness.get("state", "Building"), "#94a3b8")
+    stats = [
+        stat(
+            "Readiness",
+            str(readiness.get("state", "—")),
+            readiness.get("headline", ""),
+            accent,
+        ),
+    ]
+    if strain.get("available"):
+        band = strain.get("band", [])
+        stats.append(
+            stat(
+                "Strain target",
+                f'{strain.get("target_load", "—")}/21',
+                f'{"capped · " if strain.get("capped") else ""}band {band}',
+            )
+        )
+    if acwr.get("available"):
+        stats.append(
+            stat(
+                "ACWR",
+                str(acwr.get("ratio", "—")),
+                str(acwr.get("zone", "")),
+                _ZONE_COLOR.get(acwr.get("zone", ""), "#e2e8f0"),
+            )
+        )
+
+    caveat = readiness.get("caveat")
+    caveat_html = f'<div class="caveat">⚠️ {esc(caveat)}</div>' if caveat else ""
+
+    contributors = readiness.get("contributors") or []
+    contrib_html = "".join(
+        f'<span class="chip">{esc(c.get("label", c.get("signal")))}: '
+        f'{esc(c.get("direction", ""))}</span>'
+        for c in contributors[:4]
+    )
+
+    loads = [c.get("cardio_load") for c in cardio_trend]
+    ribbon = svg_acwr_ribbon(acwr["ratio"]) if acwr.get("available") else ""
+    rc = (
+        f'<div class="sub">{esc(recovery_cost.get("headline", ""))}</div>'
+        if recovery_cost.get("available")
+        else '<div class="sub">recovery-cost coupling: needs more paired days</div>'
+    )
+
+    return (
+        '<section class="panel"><h2>Recovery &amp; Load</h2>'
+        f'<div class="stats">{"".join(stats)}</div>'
+        f"{caveat_html}"
+        f'<div class="chips">{contrib_html}</div>'
+        f'<div class="chart"><div class="lbl">Cardio load · recent</div>{svg_bars(loads)}</div>'
+        f'<div class="chart"><div class="lbl">ACWR (7d:28d) — sweet-spot 0.8–1.3</div>{ribbon}</div>'
+        f'<div class="chart"><div class="lbl">Recovery cost</div>{rc}</div>'
+        "</section>"
+    )
+
+
+def render_cockpit_page(panels_html: str) -> str:
+    """Full server-rendered cockpit page (dark, self-contained, auto-refresh)."""
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1'>"
+        "<meta http-equiv='refresh' content='120'><title>WHOOP Cockpit</title><style>"
+        "body{font-family:system-ui,-apple-system,sans-serif;background:#0b1120;color:#e2e8f0;margin:0;padding:16px}"
+        "h1{font-size:18px;margin:0 0 12px}h2{font-size:14px;color:#94a3b8;margin:0 0 10px;text-transform:uppercase;letter-spacing:.05em}"
+        ".panel{background:#111827;border:1px solid #1f2937;border-radius:12px;padding:16px;margin-bottom:14px}"
+        ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:10px}"
+        ".stat .lbl,.chart .lbl{font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:.05em}"
+        ".stat .v{font-size:22px;font-weight:600;margin:2px 0}.sub{font-size:12px;color:#94a3b8}"
+        ".caveat{background:#422006;border:1px solid #a16207;border-radius:8px;padding:8px;font-size:12px;margin:8px 0}"
+        ".chips{margin:8px 0}.chip{display:inline-block;background:#1e293b;border-radius:12px;padding:2px 8px;font-size:11px;margin:2px}"
+        ".chart{margin-top:10px}.foot{color:#475569;font-size:11px;margin-top:8px}"
+        "</style></head><body><h1>WHOOP Cockpit · analyst deep-dive</h1>"
+        f"{panels_html}"
+        "<div class='foot'>RivaFlow · self-hosted · renders server-computed series · auto-refresh 2 min</div>"
+        "</body></html>"
+    )

--- a/rivaflow/tests/unit/test_whoop_cockpit.py
+++ b/rivaflow/tests/unit/test_whoop_cockpit.py
@@ -1,0 +1,85 @@
+"""P3.1 — cockpit renderer (pure string/SVG generation, no DB)."""
+
+from __future__ import annotations
+
+from rivaflow.core.whoop_cockpit import (
+    esc,
+    render_cockpit_page,
+    render_recovery_load,
+    svg_acwr_ribbon,
+    svg_bars,
+    svg_sparkline,
+)
+
+READY = {
+    "state": "Prime",
+    "headline": "push",
+    "caveat": "green != healthy",
+    "contributors": [
+        {"label": "HRV", "signal": "hrv", "direction": "supports recovery"}
+    ],
+}
+STRAIN = {"available": True, "target_load": 12.0, "band": [10.0, 14.0], "capped": False}
+ACWR = {"available": True, "ratio": 1.1, "zone": "sweet-spot"}
+CARDIO = [{"cardio_load": 8.0}, {"cardio_load": 11.0}, {"cardio_load": 9.5}]
+RC = {"available": True, "headline": "each unit of load costs next-day recovery"}
+
+
+def test_esc_escapes_html():
+    assert esc("<script>") == "&lt;script&gt;"
+
+
+def test_sparkline_valid_svg():
+    s = svg_sparkline([1, 2, 3, 2, 4])
+    assert s.startswith("<svg") and "polyline" in s and s.endswith("</svg>")
+
+
+def test_sparkline_handles_short_series():
+    assert "<svg" in svg_sparkline([])
+    assert "<svg" in svg_sparkline([5])
+
+
+def test_bars_valid_svg():
+    s = svg_bars([1, 4, 2])
+    assert s.count("<rect") == 3
+
+
+def test_acwr_ribbon_has_marker_and_bands():
+    s = svg_acwr_ribbon(1.6)  # high-risk zone
+    assert "<line" in s and s.count("<rect") >= 3  # base + sweet + danger
+
+
+def test_render_recovery_load_includes_key_pieces():
+    html = render_recovery_load(READY, STRAIN, ACWR, CARDIO, RC)
+    assert "Recovery &amp; Load" in html
+    assert "Prime" in html
+    assert "12.0/21" in html  # strain target
+    assert "sweet-spot" in html  # acwr zone
+    assert "green != healthy" in html or "green" in html  # caveat surfaced
+    assert "<svg" in html  # charts rendered
+
+
+def test_caveat_only_when_present():
+    no_caveat = render_recovery_load(
+        {"state": "Strained", "headline": "ease"}, STRAIN, ACWR, CARDIO, RC
+    )
+    assert "caveat" not in no_caveat.lower() or "⚠️" not in no_caveat
+
+
+def test_recovery_cost_fallback_when_unavailable():
+    html = render_recovery_load(READY, STRAIN, ACWR, CARDIO, {"available": False})
+    assert "needs more paired days" in html
+
+
+def test_page_wraps_panels_and_refreshes():
+    page = render_cockpit_page("<section>x</section>")
+    assert page.startswith("<!doctype html>")
+    assert "refresh" in page and "<section>x</section>" in page
+
+
+def test_render_escapes_dynamic_headline():
+    evil = {"state": "Prime", "headline": "<img src=x onerror=alert(1)>"}
+    html = render_recovery_load(
+        evil, {"available": False}, {"available": False}, [], {"available": False}
+    )
+    assert "<img src=x" not in html and "&lt;img" in html

--- a/tests/test_whoop_cockpit_render.py
+++ b/tests/test_whoop_cockpit_render.py
@@ -1,0 +1,18 @@
+"""P3.1 — cockpit page renders end-to-end against Postgres (temp_db)."""
+
+from __future__ import annotations
+
+
+class TestCockpitRender:
+    def test_cockpit_page_renders_html(self, test_user):
+        from rivaflow.core.whoop_analytics import cockpit_page
+
+        html = cockpit_page(test_user["id"])
+        assert html.startswith("<!doctype html>")
+        assert "WHOOP Cockpit" in html
+        assert "Recovery &amp; Load" in html  # P3.1 panel present
+        assert "auto-refresh" in html
+
+    def test_cockpit_endpoint_requires_key(self, client):
+        r = client.get("/api/v1/whoop/cockpit", params={"key": "not-a-key"})
+        assert r.status_code == 401


### PR DESCRIPTION
First panel of the web deep-dive cockpit. Server-rendered, dependency-free inline-SVG (sparklines, bars, ACWR ribbon) — the web app only renders. Recovery & Load panel: readiness + contributors + green≠healthy caveat, strain target, ACWR ribbon, cardio-load bars, recovery-cost. GET /whoop/cockpit?key= (key-auth like /view). XSS-safe (all dynamic strings escaped). +11 pure tests (148 total) + DB render test; Code Quality green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)