### PR TITLE
feat(whoop): P4a — expose prevention tier in whoop_summary

### DIFF
--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -264,6 +264,9 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
         "stress": today_stress(user_id, max_hr=max_hr["max_hr"]),
         "coverage": capture_coverage(user_id, days=21),
         "max_hr": max_hr,
+        "prevention": prevention_watch(
+            user_id
+        ),  # P4a — powers the slim-app safety banner (amber/red)
     }
 
 

--- a/tests/test_whoop_summary_prevention.py
+++ b/tests/test_whoop_summary_prevention.py
@@ -1,0 +1,16 @@
+"""P4a — whoop_summary exposes the prevention field the slim-app banner reads (Postgres via temp_db)."""
+
+from __future__ import annotations
+
+
+class TestSummaryPrevention:
+    def test_summary_includes_prevention(self, test_user):
+        from rivaflow.core.whoop_analytics import whoop_summary
+
+        s = whoop_summary(test_user["id"])
+        assert "prevention" in s
+        # with no data it's a building/unavailable dict, but the key must exist for the phone.
+        assert isinstance(s["prevention"], dict)
+        # and the other slim-app fields remain present
+        for k in ("readiness", "strain_target", "coverage", "max_hr"):
+            assert k in s


### PR DESCRIPTION
One-line backend change powering the iOS prevention banner (goose-whoop5 PR #1): adds prevention_watch() to whoop_summary so the phone can render amber/red safety alerts from a single /whoop/summary fetch. Green shows nothing (anti-anxiety). Test asserts the key is present. Completes P4 with the iOS side (already built + installed on-device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)