### PR TITLE
feat(whoop): short bookmarkable cockpit URL (/cockpit)

### DIFF
--- a/rivaflow/rivaflow/api/main.py
+++ b/rivaflow/rivaflow/api/main.py
@@ -297,6 +297,7 @@ app.include_router(api_keys.router, prefix="/api/v1/users/me", tags=["api-keys"]
 app.include_router(analytics.router, prefix="/api/v1/analytics", tags=["analytics"])
 app.include_router(garmin.router, prefix="/api/v1", tags=["garmin"])
 app.include_router(whoop.router, prefix="/api/v1", tags=["whoop"])
+app.include_router(whoop.short_router, tags=["whoop"])  # short bookmarkable /cockpit
 app.include_router(goals.router, prefix="/api/v1/goals", tags=["goals"])
 app.include_router(
     training_goals.router,

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -16,7 +16,7 @@ import logging
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Cookie, Depends, Query
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
@@ -27,6 +27,43 @@ from rivaflow.db.repositories.whoop_repo import WhoopRepository
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/whoop", tags=["whoop"])
+
+# Root-mounted (no /api/v1 prefix) for a short, bookmarkable cockpit URL.
+short_router = APIRouter(tags=["whoop"])
+
+
+@short_router.get("/cockpit", response_class=HTMLResponse)
+def cockpit_short(key: str = "", rf_key: str = Cookie(default="")) -> HTMLResponse:
+    """Short bookmarkable cockpit: `https://api.rivaflow.app/cockpit`. Pass ?key=YOUR_KEY once and it's
+    stored in a cookie, so you can bookmark the bare URL afterwards. Same key-auth as /api/v1/whoop/cockpit.
+    """
+    from rivaflow.core.whoop_analytics import cockpit_page
+    from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
+
+    k = key or rf_key
+    api_key = (
+        ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(k))
+        if k.startswith("rf_pk_")
+        else None
+    )
+    if not api_key:
+        return HTMLResponse(
+            "<body style='font-family:system-ui;background:#0b1120;color:#e2e8f0;padding:24px'>"
+            "<h2>WHOOP Cockpit</h2><p>Add <code>?key=YOUR_KEY</code> to this URL once "
+            "(your rf_pk_… api key), then bookmark the bare page.</p></body>",
+            status_code=401,
+        )
+    resp = HTMLResponse(cockpit_page(api_key["user_id"]))
+    if key:  # first visit carried the key → remember it so revisits can be keyless
+        resp.set_cookie(
+            "rf_key",
+            key,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=60 * 60 * 24 * 365,
+        )
+    return resp
 
 
 class RawFrame(BaseModel):

--- a/tests/test_whoop_short_cockpit.py
+++ b/tests/test_whoop_short_cockpit.py
@@ -1,0 +1,14 @@
+"""Short bookmarkable cockpit URL (root /cockpit)."""
+
+from __future__ import annotations
+
+
+class TestShortCockpit:
+    def test_root_cockpit_needs_key(self, client):
+        r = client.get("/cockpit")
+        assert r.status_code == 401
+        assert "YOUR_KEY" in r.text  # the prompt to add ?key= once
+
+    def test_root_cockpit_bad_key(self, client):
+        r = client.get("/cockpit", params={"key": "rf_pk_bogus"})
+        assert r.status_code == 401


### PR DESCRIPTION
A short root URL for the cockpit: https://api.rivaflow.app/cockpit — pass ?key= once, cookie-stored, then bookmark the bare page. Also the target for the iOS Deep Dive button. Same key-auth. Test asserts 401 without key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)