### PR TITLE
WHOOP cockpit: intraday HR/HRV, sleep, respiratory, stress + session deep-dives

### DIFF
--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -9,7 +9,7 @@ HRV only, and BJJ session analytics use HR (not HRV) because motion corrupts bea
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from math import log1p
 from statistics import mean, median, pstdev
 from zoneinfo import ZoneInfo
@@ -40,13 +40,21 @@ from rivaflow.core.whoop_cockpit import (
     render_behaviour,
     render_cockpit_page,
     render_data_integrity,
+    render_hr_ribbon,
     render_hrv_lab,
+    render_overnight_hrv,
     render_prevention_log,
     render_recovery_load,
+    render_respiratory,
+    render_rr_hrv_detail,
+    render_session_deepdives,
     render_sleep,
+    render_sleep_hr_dip,
+    render_stress_ribbon,
     render_trends,
 )
 from rivaflow.core.whoop_digest import compile_digest
+from rivaflow.db.repositories.session_repo import SessionRepository
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
@@ -464,9 +472,273 @@ def prevention_log(user_id: int, limit: int = 60) -> list[dict]:
     return WhoopRepository.recent_alerts(user_id, limit=limit)
 
 
+def _downsample_xy(
+    xs: list[float], ys: list[float], max_points: int = 600
+) -> tuple[list[float], list[float]]:
+    """Bucket-average a dense series to at most `max_points` — keeps SVG paths cheap over ~150k HR rows."""
+    n = len(xs)
+    if n <= max_points:
+        return xs, ys
+    bucket = n / max_points
+    out_x: list[float] = []
+    out_y: list[float] = []
+    for i in range(max_points):
+        lo, hi = int(i * bucket), max(int(i * bucket) + 1, int((i + 1) * bucket))
+        chunk = ys[lo:hi]
+        if not chunk:
+            continue
+        out_x.append(xs[lo])
+        out_y.append(mean(chunk))
+    return out_x, out_y
+
+
+def today_hr_ribbon(user_id: int) -> dict:
+    """P3.5 — today's full local-day HR (downsampled) + zone edges, for the intraday HR-ribbon panel."""
+    now = datetime.now(LOCAL_TZ)
+    start = datetime.combine(now.date(), datetime.min.time(), LOCAL_TZ)
+    hr = WhoopRepository.hr_range(user_id, start.isoformat(), now.isoformat())
+    pts = [
+        (_parse_ts(str(h["ts"])).astimezone(LOCAL_TZ), int(h["bpm"]))
+        for h in hr
+        if h.get("bpm") and h.get("ts")
+    ]
+    if len(pts) < 30:
+        return {"available": False, "reason": "Not enough HR captured today yet."}
+    hours = [(t - start).total_seconds() / 3600.0 for t, _ in pts]
+    bpms = [float(b) for _, b in pts]
+    xs, ys = _downsample_xy(hours, bpms)
+    return {
+        "available": True,
+        "times": xs,
+        "values": ys,
+        "avg_hr": round(mean(bpms)),
+        "max_bpm": max(int(b) for b in bpms),
+        "max_hr": user_max_hr(user_id)["max_hr"],
+    }
+
+
+def rr_hrv_detail(user_id: int, days: int = 1) -> dict:
+    """P3.5 — MUST-HAVE HRV-nerd view: RR tachogram + Poincaré scatter (SD1/SD2), over recent clean RR."""
+    rr = WhoopRepository.rr_range(user_id, days)
+    pts = [
+        (_parse_ts(str(r["ts"])), int(r["rr_ms"]))
+        for r in rr
+        if r.get("rr_ms") and 300 <= r["rr_ms"] <= 2000
+    ]
+    if len(pts) < 30:
+        return {"available": False, "reason": "Not enough clean RR captured yet."}
+    pts.sort(key=lambda p: p[0])
+    t0 = pts[0][0]
+    times = [(t - t0).total_seconds() / 60.0 for t, _ in pts]
+    vals = [float(v) for _, v in pts]
+    pc = poincare(vals)
+    if pc is None:
+        return {"available": False, "reason": "Segment too short for Poincaré geometry."}
+    xs, ys = _downsample_xy(times, vals)
+    pairs = list(zip(vals[:-1], vals[1:]))
+    stride = max(1, len(pairs) // 500)
+    return {
+        "available": True,
+        "times": xs,
+        "rr_values": ys,
+        "pairs": pairs[::stride],
+        "sd1": pc.sd1,
+        "sd2": pc.sd2,
+        "mean_hr": round(60000.0 / mean(vals)),
+    }
+
+
+def overnight_hrv_curve(user_id: int) -> dict:
+    """P3.5 — lnRMSSD in 5-min buckets across the last detected sleep window (reuses nightly_sleep)."""
+    night = nightly_sleep(user_id)
+    if not night.get("available"):
+        return {"available": False, "reason": night.get("reason", "no sleep window detected yet")}
+    start, end = _parse_ts(night["sleep_start"]), _parse_ts(night["sleep_end"])
+    rr = WhoopRepository.rr_range(user_id, days=2)
+    pts = [
+        (_parse_ts(str(r["ts"])), int(r["rr_ms"]))
+        for r in rr
+        if r.get("rr_ms")
+        and 667 <= r["rr_ms"] <= 1500
+        and start <= _parse_ts(str(r["ts"])) <= end
+    ]
+    if len(pts) < 40:
+        return {"available": False, "reason": "Not enough clean overnight RR for an HRV curve."}
+    pts.sort(key=lambda p: p[0])
+    buckets: dict[int, list[int]] = defaultdict(list)
+    for t, v in pts:
+        buckets[int((t - start).total_seconds() // 300)].append(v)
+    times: list[float] = []
+    values: list[float] = []
+    for idx in sorted(buckets):
+        vals = buckets[idx]
+        if len(vals) < 5:
+            continue
+        times.append(idx * 5 / 60.0)
+        values.append(round(ln_rmssd([float(v) for v in vals]), 3))
+    if len(values) < 3:
+        return {"available": False, "reason": "Too few clean 5-min buckets overnight."}
+    return {"available": True, "times": times, "values": values}
+
+
+def sleep_hr_dip(user_id: int) -> dict:
+    """P3.5 — HR across the detected sleep window with onset/offset + the nocturnal dip vs waking baseline."""
+    night = nightly_sleep(user_id)
+    if not night.get("available"):
+        return {"available": False, "reason": night.get("reason", "no sleep window detected yet")}
+    start, end = _parse_ts(night["sleep_start"]), _parse_ts(night["sleep_end"])
+    hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
+    pts = [
+        (_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm") and h.get("ts")
+    ]
+    if len(pts) < 30:
+        return {"available": False, "reason": "Not enough HR across the sleep window."}
+    pts.sort(key=lambda p: p[0])
+    times = [(t - start).total_seconds() / 3600.0 for t, _ in pts]
+    vals = [float(b) for _, b in pts]
+    xs, ys = _downsample_xy(times, vals)
+    waking = daily_resting_hr(user_id, days=7)
+    waking_avg = mean(r["resting_hr"] for r in waking) if waking else None
+    dip_pct = (
+        round((1 - night["avg_sleeping_hr"] / waking_avg) * 100, 1) if waking_avg else "—"
+    )
+    return {
+        "available": True,
+        "times": xs,
+        "values": ys,
+        "onset": start.astimezone(LOCAL_TZ).strftime("%H:%M"),
+        "offset": end.astimezone(LOCAL_TZ).strftime("%H:%M"),
+        "dip_pct": dip_pct,
+    }
+
+
+def respiratory_trace(user_id: int, days: int = 1) -> dict:
+    """P3.5 — breaths/min across rolling 10-min resting windows through the day (RSA-derived)."""
+    rr = WhoopRepository.rr_range(user_id, days)
+    pts = [
+        (_parse_ts(str(r["ts"])), int(r["rr_ms"]))
+        for r in rr
+        if r.get("rr_ms") and 667 <= r["rr_ms"] <= 1500
+    ]
+    if len(pts) < 200:
+        return {"available": False, "reason": "Not enough clean resting RR for a respiratory trace."}
+    pts.sort(key=lambda p: p[0])
+    t0 = pts[0][0]
+    buckets: dict[int, list[int]] = defaultdict(list)
+    for t, v in pts:
+        buckets[int((t - t0).total_seconds() // 600)].append(v)
+    times: list[float] = []
+    values: list[float] = []
+    for idx in sorted(buckets):
+        rpm = _resp_rpm(buckets[idx])
+        if rpm is not None:
+            times.append(idx * 10 / 60.0)
+            values.append(rpm)
+    if len(values) < 3:
+        return {"available": False, "reason": "Too few clean resting windows for a trace."}
+    return {"available": True, "times": times, "values": values}
+
+
+def stress_ribbon_series(user_id: int) -> dict:
+    """P3.5 — hourly stress-vs-baseline across today, from HR-reserve elevation over resting baseline."""
+    now = datetime.now(LOCAL_TZ)
+    start = datetime.combine(now.date(), datetime.min.time(), LOCAL_TZ)
+    hr = WhoopRepository.hr_range(user_id, start.isoformat(), now.isoformat())
+    rhr_list = daily_resting_hr(user_id, days=3)
+    if not hr or not rhr_list:
+        return {"available": False, "reason": "Not enough HR/baseline history for a stress ribbon."}
+    mx = user_max_hr(user_id)["max_hr"]
+    rest = rhr_list[-1]["resting_hr"]
+    by_hour: dict[int, list[int]] = defaultdict(list)
+    for h in hr:
+        if h.get("bpm") and h.get("ts"):
+            dt = _parse_ts(str(h["ts"])).astimezone(LOCAL_TZ)
+            by_hour[dt.hour].append(int(h["bpm"]))
+    times: list[float] = []
+    values: list[float] = []
+    for hour in sorted(by_hour):
+        avg = mean(by_hour[hour])
+        stress = max(0, min(100, round((avg - rest) / max(1, mx - rest) * 100)))
+        times.append(float(hour))
+        values.append(float(stress))
+    if len(values) < 2:
+        return {"available": False, "reason": "Need more hours of HR today for a ribbon."}
+    return {"available": True, "times": times, "values": values}
+
+
+def _session_window(s: dict) -> tuple[datetime, datetime] | None:
+    """Best-effort session start/end from `sessions` row fields, for windowing the WHOOP HR query."""
+    day = s.get("session_date")
+    if not day:
+        return None
+    day_str = day.isoformat() if hasattr(day, "isoformat") else str(day)[:10]
+    time_str = str(s.get("class_time") or "18:00")[:5]
+    try:
+        start = datetime.fromisoformat(f"{day_str}T{time_str}").replace(tzinfo=LOCAL_TZ)
+    except ValueError:
+        return None
+    duration = int(s.get("duration_mins") or 60)
+    return start, start + timedelta(minutes=duration)
+
+
+def _session_label(s: dict) -> str:
+    """Human label for a session card: CrossFit (via Garmin activity type) or BJJ gi/no-gi, else generic."""
+    garmin_type = (s.get("garmin_activity_type") or "").lower()
+    class_type = (s.get("class_type") or "").lower()
+    if "crossfit" in garmin_type or "cross" in garmin_type:
+        return "CrossFit"
+    if class_type in {"gi", "nogi", "no-gi", "open-mat", "openmat"}:
+        return f"BJJ ({class_type})"
+    return (s.get("garmin_activity_type") or s.get("class_type") or "Session").title()
+
+
+def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
+    """P3.5 — MUST-HAVE: per-session HR analytics (BJJ + CrossFit) for the deep-dive cards — reuses
+    bjj_session_analytics's zone/HRR compute over each recent session's class-time window."""
+    mx = user_max_hr(user_id)["max_hr"]
+    out: list[dict] = []
+    for s in SessionRepository.get_recent(user_id, limit=limit):
+        window = _session_window(s)
+        if window is None:
+            continue
+        start, end = window
+        a = bjj_session_analytics(user_id, start.isoformat(), end.isoformat(), max_hr=mx)
+        if a.get("available"):
+            hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
+            pts = sorted(
+                ((_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm")),
+                key=lambda p: p[0],
+            )
+            times = [(t - start).total_seconds() / 60.0 for t, _ in pts]
+            vals = [float(b) for _, b in pts]
+            xs, ys = _downsample_xy(times, vals, max_points=200)
+            a["times"], a["values"] = xs, ys
+            hrr = a.get("protocol_hrr") or {}
+            a["hrr"] = hrr.get("hrr_bpm") if hrr.get("available") else None
+        out.append(
+            {"label": _session_label(s), "day": str(s.get("session_date", "")), "analytics": a}
+        )
+    return out
+
+
+def _history_progress(user_id: int) -> dict:
+    """P3.5 — days-so-far for each longitudinal panel's cold-start progress ring (HRV/readiness ~5d,
+    ACWR 28d, sleep-debt 14n, resilience/trends ~14d)."""
+    coverage = capture_coverage(user_id, days=28)
+    return {
+        "hrv": {"have": coverage["summary"].get("days_sufficient", 0), "need": 5},
+        "acwr": {"have": len(daily_cardio_load(user_id, days=28)), "need": 28},
+        "sleep_debt": {"have": len(nightly_sleep_history(user_id, nights=14)), "need": 14},
+        "resilience": {
+            "have": min(len(daily_resting_rmssd(user_id, days=45)), 14),
+            "need": 14,
+        },
+    }
+
+
 def cockpit_page(user_id: int) -> str:
     """P3 — server-rendered web deep-dive cockpit HTML. All series are computed here; the page only renders.
-    P3.1 ships the Recovery & Load panel; later sub-phases append more panels."""
+    P3.1 shipped Recovery & Load; P3.2-3.4 followed; P3.5 adds the intraday/session deep-dive panels."""
     now = datetime.now(LOCAL_TZ)
     is_sabbath = now.weekday() == 6
     mx = user_max_hr(user_id)["max_hr"]
@@ -475,6 +747,7 @@ def cockpit_page(user_id: int) -> str:
     acwr_data = training_acwr(user_id)
     cardio = daily_cardio_load(user_id, days=28, max_hr=mx)
     rec_cost = recovery_cost_coupling(user_id)
+    progress = _history_progress(user_id)
 
     # Behaviour effects for each distinct tag the user has journalled (P3.4).
     tags = sorted({t["tag"] for t in WhoopRepository.list_tags(user_id)})
@@ -483,17 +756,25 @@ def cockpit_page(user_id: int) -> str:
     panels = "".join(
         [
             render_recovery_load(
-                readiness, strain, acwr_data, cardio, rec_cost
+                readiness, strain, acwr_data, cardio, rec_cost, acwr_progress=progress["acwr"]
             ),  # P3.1
-            render_hrv_lab(hrv_lab(user_id), dfa_analysis(user_id)),  # P3.2
+            render_hr_ribbon(today_hr_ribbon(user_id)),  # P3.5
+            render_rr_hrv_detail(rr_hrv_detail(user_id)),  # P3.5 MUST-HAVE
+            render_hrv_lab(hrv_lab(user_id), dfa_analysis(user_id), progress=progress["hrv"]),  # P3.2
+            render_overnight_hrv(overnight_hrv_curve(user_id)),  # P3.5
             render_data_integrity(capture_coverage(user_id)),  # P3.2
-            render_sleep(sleep_analysis(user_id)),  # P3.3
+            render_sleep_hr_dip(sleep_hr_dip(user_id)),  # P3.5
+            render_respiratory(respiratory_trace(user_id)),  # P3.5
+            render_stress_ribbon(stress_ribbon_series(user_id)),  # P3.5
+            render_sleep(sleep_analysis(user_id), debt_progress=progress["sleep_debt"]),  # P3.3
             render_trends(  # P3.3
                 longevity_metrics(user_id),
                 resilience_metrics(user_id),
                 circadian_rhythm(user_id),
                 period_assessment_for(user_id, "week", 7),
+                resilience_progress=progress["resilience"],
             ),
+            render_session_deepdives(session_deepdives(user_id)),  # P3.5 MUST-HAVE
             render_prevention_log(  # P3.4
                 prevention_log(user_id), prevention_watch(user_id)
             ),

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -533,7 +533,10 @@ def rr_hrv_detail(user_id: int, days: int = 1) -> dict:
     vals = [float(v) for _, v in pts]
     pc = poincare(vals)
     if pc is None:
-        return {"available": False, "reason": "Segment too short for Poincaré geometry."}
+        return {
+            "available": False,
+            "reason": "Segment too short for Poincaré geometry.",
+        }
     xs, ys = _downsample_xy(times, vals)
     pairs = list(zip(vals[:-1], vals[1:]))
     stride = max(1, len(pairs) // 500)
@@ -552,7 +555,10 @@ def overnight_hrv_curve(user_id: int) -> dict:
     """P3.5 — lnRMSSD in 5-min buckets across the last detected sleep window (reuses nightly_sleep)."""
     night = nightly_sleep(user_id)
     if not night.get("available"):
-        return {"available": False, "reason": night.get("reason", "no sleep window detected yet")}
+        return {
+            "available": False,
+            "reason": night.get("reason", "no sleep window detected yet"),
+        }
     start, end = _parse_ts(night["sleep_start"]), _parse_ts(night["sleep_end"])
     rr = WhoopRepository.rr_range(user_id, days=2)
     pts = [
@@ -563,7 +569,10 @@ def overnight_hrv_curve(user_id: int) -> dict:
         and start <= _parse_ts(str(r["ts"])) <= end
     ]
     if len(pts) < 40:
-        return {"available": False, "reason": "Not enough clean overnight RR for an HRV curve."}
+        return {
+            "available": False,
+            "reason": "Not enough clean overnight RR for an HRV curve.",
+        }
     pts.sort(key=lambda p: p[0])
     buckets: dict[int, list[int]] = defaultdict(list)
     for t, v in pts:
@@ -585,11 +594,16 @@ def sleep_hr_dip(user_id: int) -> dict:
     """P3.5 — HR across the detected sleep window with onset/offset + the nocturnal dip vs waking baseline."""
     night = nightly_sleep(user_id)
     if not night.get("available"):
-        return {"available": False, "reason": night.get("reason", "no sleep window detected yet")}
+        return {
+            "available": False,
+            "reason": night.get("reason", "no sleep window detected yet"),
+        }
     start, end = _parse_ts(night["sleep_start"]), _parse_ts(night["sleep_end"])
     hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
     pts = [
-        (_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm") and h.get("ts")
+        (_parse_ts(str(h["ts"])), int(h["bpm"]))
+        for h in hr
+        if h.get("bpm") and h.get("ts")
     ]
     if len(pts) < 30:
         return {"available": False, "reason": "Not enough HR across the sleep window."}
@@ -600,7 +614,9 @@ def sleep_hr_dip(user_id: int) -> dict:
     waking = daily_resting_hr(user_id, days=7)
     waking_avg = mean(r["resting_hr"] for r in waking) if waking else None
     dip_pct = (
-        round((1 - night["avg_sleeping_hr"] / waking_avg) * 100, 1) if waking_avg else "—"
+        round((1 - night["avg_sleeping_hr"] / waking_avg) * 100, 1)
+        if waking_avg
+        else "—"
     )
     return {
         "available": True,
@@ -621,7 +637,10 @@ def respiratory_trace(user_id: int, days: int = 1) -> dict:
         if r.get("rr_ms") and 667 <= r["rr_ms"] <= 1500
     ]
     if len(pts) < 200:
-        return {"available": False, "reason": "Not enough clean resting RR for a respiratory trace."}
+        return {
+            "available": False,
+            "reason": "Not enough clean resting RR for a respiratory trace.",
+        }
     pts.sort(key=lambda p: p[0])
     t0 = pts[0][0]
     buckets: dict[int, list[int]] = defaultdict(list)
@@ -635,7 +654,10 @@ def respiratory_trace(user_id: int, days: int = 1) -> dict:
             times.append(idx * 10 / 60.0)
             values.append(rpm)
     if len(values) < 3:
-        return {"available": False, "reason": "Too few clean resting windows for a trace."}
+        return {
+            "available": False,
+            "reason": "Too few clean resting windows for a trace.",
+        }
     return {"available": True, "times": times, "values": values}
 
 
@@ -646,7 +668,10 @@ def stress_ribbon_series(user_id: int) -> dict:
     hr = WhoopRepository.hr_range(user_id, start.isoformat(), now.isoformat())
     rhr_list = daily_resting_hr(user_id, days=3)
     if not hr or not rhr_list:
-        return {"available": False, "reason": "Not enough HR/baseline history for a stress ribbon."}
+        return {
+            "available": False,
+            "reason": "Not enough HR/baseline history for a stress ribbon.",
+        }
     mx = user_max_hr(user_id)["max_hr"]
     rest = rhr_list[-1]["resting_hr"]
     by_hour: dict[int, list[int]] = defaultdict(list)
@@ -662,7 +687,10 @@ def stress_ribbon_series(user_id: int) -> dict:
         times.append(float(hour))
         values.append(float(stress))
     if len(values) < 2:
-        return {"available": False, "reason": "Need more hours of HR today for a ribbon."}
+        return {
+            "available": False,
+            "reason": "Need more hours of HR today for a ribbon.",
+        }
     return {"available": True, "times": times, "values": values}
 
 
@@ -694,7 +722,8 @@ def _session_label(s: dict) -> str:
 
 def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
     """P3.5 — MUST-HAVE: per-session HR analytics (BJJ + CrossFit) for the deep-dive cards — reuses
-    bjj_session_analytics's zone/HRR compute over each recent session's class-time window."""
+    bjj_session_analytics's zone/HRR compute over each recent session's class-time window.
+    """
     mx = user_max_hr(user_id)["max_hr"]
     out: list[dict] = []
     for s in SessionRepository.get_recent(user_id, limit=limit):
@@ -702,7 +731,9 @@ def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
         if window is None:
             continue
         start, end = window
-        a = bjj_session_analytics(user_id, start.isoformat(), end.isoformat(), max_hr=mx)
+        a = bjj_session_analytics(
+            user_id, start.isoformat(), end.isoformat(), max_hr=mx
+        )
         if a.get("available"):
             hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
             pts = sorted(
@@ -716,7 +747,11 @@ def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
             hrr = a.get("protocol_hrr") or {}
             a["hrr"] = hrr.get("hrr_bpm") if hrr.get("available") else None
         out.append(
-            {"label": _session_label(s), "day": str(s.get("session_date", "")), "analytics": a}
+            {
+                "label": _session_label(s),
+                "day": str(s.get("session_date", "")),
+                "analytics": a,
+            }
         )
     return out
 
@@ -728,7 +763,10 @@ def _history_progress(user_id: int) -> dict:
     return {
         "hrv": {"have": coverage["summary"].get("days_sufficient", 0), "need": 5},
         "acwr": {"have": len(daily_cardio_load(user_id, days=28)), "need": 28},
-        "sleep_debt": {"have": len(nightly_sleep_history(user_id, nights=14)), "need": 14},
+        "sleep_debt": {
+            "have": len(nightly_sleep_history(user_id, nights=14)),
+            "need": 14,
+        },
         "resilience": {
             "have": min(len(daily_resting_rmssd(user_id, days=45)), 14),
             "need": 14,
@@ -738,7 +776,8 @@ def _history_progress(user_id: int) -> dict:
 
 def cockpit_page(user_id: int) -> str:
     """P3 — server-rendered web deep-dive cockpit HTML. All series are computed here; the page only renders.
-    P3.1 shipped Recovery & Load; P3.2-3.4 followed; P3.5 adds the intraday/session deep-dive panels."""
+    P3.1 shipped Recovery & Load; P3.2-3.4 followed; P3.5 adds the intraday/session deep-dive panels.
+    """
     now = datetime.now(LOCAL_TZ)
     is_sabbath = now.weekday() == 6
     mx = user_max_hr(user_id)["max_hr"]
@@ -756,17 +795,26 @@ def cockpit_page(user_id: int) -> str:
     panels = "".join(
         [
             render_recovery_load(
-                readiness, strain, acwr_data, cardio, rec_cost, acwr_progress=progress["acwr"]
+                readiness,
+                strain,
+                acwr_data,
+                cardio,
+                rec_cost,
+                acwr_progress=progress["acwr"],
             ),  # P3.1
             render_hr_ribbon(today_hr_ribbon(user_id)),  # P3.5
             render_rr_hrv_detail(rr_hrv_detail(user_id)),  # P3.5 MUST-HAVE
-            render_hrv_lab(hrv_lab(user_id), dfa_analysis(user_id), progress=progress["hrv"]),  # P3.2
+            render_hrv_lab(
+                hrv_lab(user_id), dfa_analysis(user_id), progress=progress["hrv"]
+            ),  # P3.2
             render_overnight_hrv(overnight_hrv_curve(user_id)),  # P3.5
             render_data_integrity(capture_coverage(user_id)),  # P3.2
             render_sleep_hr_dip(sleep_hr_dip(user_id)),  # P3.5
             render_respiratory(respiratory_trace(user_id)),  # P3.5
             render_stress_ribbon(stress_ribbon_series(user_id)),  # P3.5
-            render_sleep(sleep_analysis(user_id), debt_progress=progress["sleep_debt"]),  # P3.3
+            render_sleep(
+                sleep_analysis(user_id), debt_progress=progress["sleep_debt"]
+            ),  # P3.3
             render_trends(  # P3.3
                 longevity_metrics(user_id),
                 resilience_metrics(user_id),

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -69,6 +69,135 @@ def svg_bars(
     return f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}">{rects}</svg>'
 
 
+def svg_progress_ring(
+    have: float, need: float, label: str = "", size: int = 64, accent: str = "#60a5fa"
+) -> str:
+    """A donut 'building baseline' ring for panels that need N days of history — shown INSTEAD of an
+    empty/needs-more-days card so cold-start panels still feel alive."""
+    need = max(need, 1e-9)
+    pct = max(0.0, min(1.0, have / need))
+    r = size / 2 - 6
+    circ = 2 * 3.14159265 * r
+    dash = circ * pct
+    cx = cy = size / 2
+    return (
+        f'<svg width="{size}" height="{size}" viewBox="0 0 {size} {size}" role="img" '
+        f'aria-label="{esc(label)} progress {have} of {need} days">'
+        f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="#1e293b" stroke-width="6"/>'
+        f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="{accent}" stroke-width="6" '
+        f'stroke-linecap="round" stroke-dasharray="{dash:.1f} {circ:.1f}" '
+        f'transform="rotate(-90 {cx} {cy})"/>'
+        f'<text x="{cx}" y="{cy + 4}" text-anchor="middle" font-size="12" fill="#e2e8f0">'
+        f"{int(min(have, need))}/{int(need)}</text></svg>"
+    )
+
+
+def progress_or_text(
+    available: bool, progress: dict | None, fallback: str, label: str = "building"
+) -> str:
+    """Shared cold-start pattern: a longitudinal panel either has enough days (renders normally, caller's
+    job) or shows a progress ring toward the threshold instead of bare 'needs more days' text."""
+    if available or not progress:
+        return fallback
+    have, need = progress.get("have", 0), progress.get("need", 1)
+    return (
+        '<div class="ring-row">'
+        f"{svg_progress_ring(have, need, label)}"
+        f'<div class="sub">{esc(label)} baseline — {int(have)} of {int(need)} days</div>'
+        "</div>"
+    )
+
+
+def svg_area_line(
+    times: list[float],
+    values: list[float | None],
+    w: int = 560,
+    h: int = 110,
+    stroke: str = "#60a5fa",
+    fill: str = "rgba(96,165,250,0.18)",
+    bands: list[tuple[float, float, str]] | None = None,
+) -> str:
+    """A filled area line for dense intraday series (HR ribbon, overnight HRV, sleep HR, respiratory,
+    stress). `bands` are (lo, hi, color) horizontal zone bands drawn behind the line, in data units."""
+    pts = [(t, v) for t, v in zip(times, values) if v is not None]
+    if len(pts) < 2:
+        return f'<svg width="{w}" height="{h}" role="img" aria-label="no data"></svg>'
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    x_lo, x_hi = min(xs), max(xs)
+    y_lo, y_hi = min(ys), max(ys)
+    if bands:
+        y_lo = min([y_lo, *(b[0] for b in bands)])
+        y_hi = max([y_hi, *(b[1] for b in bands)])
+    x_rng = (x_hi - x_lo) or 1.0
+    y_rng = (y_hi - y_lo) or 1.0
+    pad = 4
+
+    def px(x: float) -> float:
+        return (x - x_lo) / x_rng * w
+
+    def py(y: float) -> float:
+        return h - pad - (y - y_lo) / y_rng * (h - 2 * pad)
+
+    band_rects = "".join(
+        f'<rect x="0" y="{py(hi):.1f}" width="{w}" height="{max(0.0, py(lo) - py(hi)):.1f}" '
+        f'fill="{color}" opacity="0.25"/>'
+        for lo, hi, color in (bands or [])
+    )
+    coords = " ".join(f"{px(t):.1f},{py(v):.1f}" for t, v in pts)
+    area = (
+        f"{px(pts[0][0]):.1f},{py(y_lo):.1f} {coords} {px(pts[-1][0]):.1f},{py(y_lo):.1f}"
+    )
+    return (
+        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" preserveAspectRatio="none">'
+        f"{band_rects}"
+        f'<polygon points="{area}" fill="{fill}"/>'
+        f'<polyline fill="none" stroke="{stroke}" stroke-width="2" points="{coords}"/>'
+        f'<text x="2" y="10" font-size="9" fill="#64748b">{esc(round(y_hi))}</text>'
+        f'<text x="2" y="{h - 2}" font-size="9" fill="#64748b">{esc(round(y_lo))}</text>'
+        "</svg>"
+    )
+
+
+def svg_poincare(
+    pairs: list[tuple[float, float]],
+    sd1: float,
+    sd2: float,
+    w: int = 220,
+    h: int = 220,
+) -> str:
+    """Poincaré scatter (RR[n] vs RR[n+1]) with the SD1/SD2 ellipse along/across the identity line."""
+    if len(pairs) < 3:
+        return f'<svg width="{w}" height="{h}" role="img" aria-label="no data"></svg>'
+    xs = [p[0] for p in pairs]
+    ys = [p[1] for p in pairs]
+    lo, hi = min(xs + ys), max(xs + ys)
+    rng = (hi - lo) or 1.0
+    pad = 12
+    scale = (min(w, h) - 2 * pad) / rng
+
+    def sx(x: float) -> float:
+        return pad + (x - lo) * scale
+
+    def sy(y: float) -> float:
+        return h - pad - (y - lo) * scale
+
+    mean_rr = sum(xs) / len(xs)
+    dots = "".join(
+        f'<circle cx="{sx(x):.1f}" cy="{sy(y):.1f}" r="1.6" fill="#60a5fa" opacity="0.55"/>'
+        for x, y in pairs[:600]
+    )
+    cx, cy = sx(mean_rr), sy(mean_rr)
+    return (
+        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}">'
+        f'<line x1="{pad}" y1="{h - pad}" x2="{w - pad}" y2="{pad}" stroke="#334155" stroke-dasharray="3 3"/>'
+        f"{dots}"
+        f'<ellipse cx="{cx:.1f}" cy="{cy:.1f}" rx="{sd2 * scale:.1f}" ry="{sd1 * scale:.1f}" '
+        f'transform="rotate(-45 {cx:.1f} {cy:.1f})" fill="none" stroke="#34d399" stroke-width="1.5"/>'
+        "</svg>"
+    )
+
+
 def svg_acwr_ribbon(ratio: float, w: int = 240, h: int = 22) -> str:
     """ACWR gauge 0–2 with the Gabbett sweet-spot (0.8–1.3) shaded green and the danger zone (>1.5) red."""
 
@@ -100,6 +229,8 @@ def render_recovery_load(
     acwr: dict,
     cardio_trend: list[dict],
     recovery_cost: dict,
+    *,
+    acwr_progress: dict | None = None,
 ) -> str:
     """P3.1 — the Recovery & Load panel."""
     accent = _ACCENT.get(readiness.get("state", "Building"), "#94a3b8")
@@ -141,7 +272,11 @@ def render_recovery_load(
     )
 
     loads = [c.get("cardio_load") for c in cardio_trend]
-    ribbon = svg_acwr_ribbon(acwr["ratio"]) if acwr.get("available") else ""
+    ribbon = (
+        svg_acwr_ribbon(acwr["ratio"])
+        if acwr.get("available")
+        else progress_or_text(False, acwr_progress, "", "ACWR (28d)")
+    )
     rc = (
         f'<div class="sub">{esc(recovery_cost.get("headline", ""))}</div>'
         if recovery_cost.get("available")
@@ -175,6 +310,13 @@ def render_cockpit_page(panels_html: str) -> str:
         ".caveat{background:#422006;border:1px solid #a16207;border-radius:8px;padding:8px;font-size:12px;margin:8px 0}"
         ".chips{margin:8px 0}.chip{display:inline-block;background:#1e293b;border-radius:12px;padding:2px 8px;font-size:11px;margin:2px}"
         ".chart{margin-top:10px}.foot{color:#475569;font-size:11px;margin-top:8px}"
+        ".ring-row{display:flex;align-items:center;gap:10px;margin:6px 0}"
+        ".dual{display:grid;grid-template-columns:1fr 1fr;gap:14px;align-items:start}"
+        ".zbars{display:flex;gap:4px;align-items:flex-end;height:36px;margin-top:6px}"
+        ".zbars .zb{flex:1;border-radius:2px 2px 0 0}"
+        ".session-card{border-top:1px solid #1f2937;padding-top:10px;margin-top:10px}"
+        ".session-card:first-of-type{border-top:none;padding-top:0;margin-top:0}"
+        "@media (max-width:640px){.dual{grid-template-columns:1fr}}"
         "</style></head><body><h1>WHOOP Cockpit · analyst deep-dive</h1>"
         f"{panels_html}"
         "<div class='foot'>RivaFlow · self-hosted · renders server-computed series · auto-refresh 2 min</div>"
@@ -182,10 +324,15 @@ def render_cockpit_page(panels_html: str) -> str:
     )
 
 
-def render_hrv_lab(hrv_lab: dict, dfa: dict) -> str:
+def render_hrv_lab(hrv_lab: dict, dfa: dict, *, progress: dict | None = None) -> str:
     """P3.2 — HRV Lab: frequency-domain (LF:HF descriptive) + Poincaré + DFA-α1 (experimental)."""
     if not hrv_lab.get("available"):
-        body = f'<div class="sub">{esc(hrv_lab.get("reason", "no clean 5-min window yet"))}</div>'
+        body = progress_or_text(
+            False,
+            progress,
+            f'<div class="sub">{esc(hrv_lab.get("reason", "no clean 5-min window yet"))}</div>',
+            "HRV Lab",
+        )
     else:
         fd = hrv_lab.get("frequency_domain", {})
         pc = hrv_lab.get("poincare", {})
@@ -237,7 +384,7 @@ def render_data_integrity(coverage: dict) -> str:
     )
 
 
-def render_sleep(sleep: dict) -> str:
+def render_sleep(sleep: dict, *, debt_progress: dict | None = None) -> str:
     """P3.3 — Sleep: need/debt vs the >9h need + bedtime regularity."""
     debt = sleep.get("debt", {})
     reg = sleep.get("regularity", {})
@@ -260,11 +407,19 @@ def render_sleep(sleep: dict) -> str:
             ),
         ]
     )
-    return f'<section class="panel"><h2>Sleep</h2><div class="stats">{stats}</div></section>'
+    ring = progress_or_text(bool(debt.get("available")), debt_progress, "", "Sleep debt (14n)")
+    return (
+        f'<section class="panel"><h2>Sleep</h2><div class="stats">{stats}</div>{ring}</section>'
+    )
 
 
 def render_trends(
-    longevity: dict, resilience: dict, circadian: dict, assessment: dict
+    longevity: dict,
+    resilience: dict,
+    circadian: dict,
+    assessment: dict,
+    *,
+    resilience_progress: dict | None = None,
 ) -> str:
     """P3.3 — Trends & Longevity: VO2max (banded), CV-age proxy (caveated), resilience, circadian, assessment."""
     vo2 = longevity.get("vo2max", {})
@@ -307,10 +462,13 @@ def render_trends(
         if assessment.get("available")
         else ""
     )
+    ring = progress_or_text(
+        bool(res.get("available")), resilience_progress, "", "Resilience (14d)"
+    )
     return (
         f'<section class="panel"><h2>Trends &amp; Longevity</h2><div class="stats">{stats}</div>'
         f'<div class="caveat">Cardio age is a PROXY vs VO₂max norms — a gentle trend, not a health verdict.</div>'
-        f"{narr}</section>"
+        f"{narr}{ring}</section>"
     )
 
 
@@ -356,3 +514,165 @@ def render_behaviour(effects: list[dict]) -> str:
         or '<div class="sub">not enough tagged vs untagged nights yet</div>'
     )
     return f'<section class="panel"><h2>Behaviour correlations</h2>{rows}</section>'
+
+
+_HR_ZONE_BANDS = [
+    (0.60, 0.70, "#60a5fa"),
+    (0.70, 0.80, "#34d399"),
+    (0.80, 0.90, "#fbbf24"),
+    (0.90, 1.00, "#f87171"),
+]
+
+
+def render_hr_ribbon(series: dict) -> str:
+    """P3.5 — Today's full-day HR ribbon with HR-zone bands shaded behind it."""
+    if not series.get("available"):
+        body = f'<div class="sub">{esc(series.get("reason", "no HR captured today yet"))}</div>'
+    else:
+        mx = series.get("max_hr", 190)
+        bands = [(lo * mx, hi * mx, color) for lo, hi, color in _HR_ZONE_BANDS]
+        chart = svg_area_line(
+            series["times"], series["values"], bands=bands, stroke="#e2e8f0"
+        )
+        body = (
+            f'<div class="stats">{stat("Avg HR", str(series.get("avg_hr", "—")), "today")}'
+            f'{stat("Peak HR", str(series.get("max_bpm", "—")), f"of {mx} max")}</div>'
+            f'<div class="chart"><div class="lbl">HR · zone-shaded (Z1–Z5)</div>{chart}</div>'
+        )
+    return f'<section class="panel"><h2>Today · HR ribbon</h2>{body}</section>'
+
+
+def render_rr_hrv_detail(detail: dict) -> str:
+    """P3.5 — MUST-HAVE HRV-nerd view: RR tachogram + Poincaré scatter with the SD1/SD2 ellipse."""
+    if not detail.get("available"):
+        body = f'<div class="sub">{esc(detail.get("reason", "not enough clean RR yet"))}</div>'
+    else:
+        tacho = svg_area_line(
+            detail["times"], detail["rr_values"], stroke="#a78bfa", fill="rgba(167,139,250,0.15)"
+        )
+        scatter = svg_poincare(detail["pairs"], detail["sd1"], detail["sd2"])
+        stats = "".join(
+            [
+                stat("SD1", f'{detail["sd1"]:.0f}ms', "short-term (≈RMSSD/√2)"),
+                stat("SD2", f'{detail["sd2"]:.0f}ms', "long-term variability"),
+                stat("Mean HR", f'{detail.get("mean_hr", "—")}', "over window"),
+            ]
+        )
+        body = (
+            f'<div class="stats">{stats}</div>'
+            '<div class="dual">'
+            f'<div class="chart"><div class="lbl">RR tachogram</div>{tacho}</div>'
+            f'<div class="chart"><div class="lbl">Poincaré (RR[n] vs RR[n+1])</div>{scatter}</div>'
+            "</div>"
+        )
+    return f'<section class="panel"><h2>RR &amp; HRV detail</h2>{body}</section>'
+
+
+def render_overnight_hrv(curve: dict) -> str:
+    """P3.5 — lnRMSSD in 5-min buckets across the detected sleep window."""
+    if not curve.get("available"):
+        body = f'<div class="sub">{esc(curve.get("reason", "no overnight window detected yet"))}</div>'
+    else:
+        chart = svg_area_line(
+            curve["times"], curve["values"], stroke="#34d399", fill="rgba(52,211,153,0.18)"
+        )
+        body = f'<div class="chart"><div class="lbl">lnRMSSD · overnight (5-min buckets)</div>{chart}</div>'
+    return f'<section class="panel"><h2>Overnight HRV curve</h2>{body}</section>'
+
+
+def render_sleep_hr_dip(curve: dict) -> str:
+    """P3.5 — HR across the detected sleep window, showing the nocturnal dip vs waking baseline."""
+    if not curve.get("available"):
+        body = f'<div class="sub">{esc(curve.get("reason", "no overnight sleep window detected yet"))}</div>'
+    else:
+        chart = svg_area_line(
+            curve["times"], curve["values"], stroke="#818cf8", fill="rgba(129,140,248,0.15)"
+        )
+        stats = "".join(
+            [
+                stat("Sleep onset", str(curve.get("onset", "—"))),
+                stat("Sleep offset", str(curve.get("offset", "—"))),
+                stat("Nocturnal dip", f'{curve.get("dip_pct", "—")}%', "vs waking HR"),
+            ]
+        )
+        body = (
+            f'<div class="stats">{stats}</div>'
+            f'<div class="chart"><div class="lbl">HR across sleep window</div>{chart}</div>'
+        )
+    return f'<section class="panel"><h2>Sleep HR &amp; nocturnal dip</h2>{body}</section>'
+
+
+def render_respiratory(trace: dict) -> str:
+    """P3.5 — Respiratory rate (breaths/min) across rest windows through the day."""
+    if not trace.get("available"):
+        body = f'<div class="sub">{esc(trace.get("reason", "not enough clean resting RR yet"))}</div>'
+    else:
+        chart = svg_area_line(
+            trace["times"], trace["values"], stroke="#f472b6", fill="rgba(244,114,182,0.15)"
+        )
+        body = f'<div class="chart"><div class="lbl">Breaths/min · resting windows</div>{chart}</div>'
+    return f'<section class="panel"><h2>Respiratory trace</h2>{body}</section>'
+
+
+def render_stress_ribbon(ribbon: dict) -> str:
+    """P3.5 — HRV-vs-baseline stress across the day as a colored band."""
+    if not ribbon.get("available"):
+        body = f'<div class="sub">{esc(ribbon.get("reason", "not enough HR history for a baseline yet"))}</div>'
+    else:
+        bands = [(0, 34, "#34d399"), (34, 67, "#fbbf24"), (67, 100, "#f87171")]
+        chart = svg_area_line(
+            ribbon["times"], ribbon["values"], bands=bands, stroke="#e2e8f0"
+        )
+        body = f'<div class="chart"><div class="lbl">Stress vs baseline (0–100)</div>{chart}</div>'
+    return f'<section class="panel"><h2>Stress ribbon</h2>{body}</section>'
+
+
+def _zone_bar_html(zone_secs: dict) -> str:
+    total = sum(zone_secs.values()) or 1
+    colors = {1: "#60a5fa", 2: "#34d399", 3: "#a3e635", 4: "#fbbf24", 5: "#f87171"}
+    bars = "".join(
+        f'<div class="zb" style="height:{max(4, zone_secs.get(z, 0) / total * 36):.0f}px;'
+        f'background:{colors[z]}" title="Z{z}: {zone_secs.get(z, 0)}s"></div>'
+        for z in range(1, 6)
+    )
+    return f'<div class="zbars">{bars}</div>'
+
+
+def _session_card_html(s: dict) -> str:
+    a = s.get("analytics", {})
+    if not a.get("available"):
+        return (
+            '<div class="session-card">'
+            f'<div class="sub">{esc(s.get("label", "Session"))} · {esc(s.get("day", ""))} — '
+            f'{esc(a.get("reason", "no HR captured"))}</div></div>'
+        )
+    curve = svg_area_line(
+        a.get("times", []), a.get("values", []), w=420, h=70, stroke="#60a5fa"
+    )
+    drift = a.get("hrr")
+    drift_html = (
+        f'<span class="chip">HRR: {esc(drift)} bpm/60s</span>' if drift is not None else ""
+    )
+    peak_sub = f'peak {a.get("max_hr", "—")}'
+    duration_min = a.get("duration_sec", 0) // 60
+    stats_html = (
+        stat("Session", str(s.get("label", "Session")), str(s.get("day", "")))
+        + stat("Avg HR", str(a.get("avg_hr", "—")), peak_sub)
+        + stat("Duration", f"{duration_min}min", "")
+    )
+    return (
+        '<div class="session-card">'
+        f'<div class="stats">{stats_html}</div>'
+        f'<div class="dual"><div class="chart"><div class="lbl">HR curve</div>{curve}</div>'
+        f'<div class="chart"><div class="lbl">Time in zones</div>{_zone_bar_html(a.get("hr_zone_secs", {}))}'
+        f"{drift_html}</div></div></div>"
+    )
+
+
+def render_session_deepdives(sessions: list[dict]) -> str:
+    """P3.5 — MUST-HAVE: per-session (BJJ + CrossFit) HR curve, time-in-zones, and HR-drift/decoupling."""
+    if not sessions:
+        body = '<div class="sub">No recent sessions with WHOOP HR coverage yet.</div>'
+    else:
+        body = "".join(_session_card_html(s) for s in sessions[:5])
+    return f'<section class="panel"><h2>Session deep-dives</h2>{body}</section>'

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -96,7 +96,8 @@ def progress_or_text(
     available: bool, progress: dict | None, fallback: str, label: str = "building"
 ) -> str:
     """Shared cold-start pattern: a longitudinal panel either has enough days (renders normally, caller's
-    job) or shows a progress ring toward the threshold instead of bare 'needs more days' text."""
+    job) or shows a progress ring toward the threshold instead of bare 'needs more days' text.
+    """
     if available or not progress:
         return fallback
     have, need = progress.get("have", 0), progress.get("need", 1)
@@ -118,7 +119,8 @@ def svg_area_line(
     bands: list[tuple[float, float, str]] | None = None,
 ) -> str:
     """A filled area line for dense intraday series (HR ribbon, overnight HRV, sleep HR, respiratory,
-    stress). `bands` are (lo, hi, color) horizontal zone bands drawn behind the line, in data units."""
+    stress). `bands` are (lo, hi, color) horizontal zone bands drawn behind the line, in data units.
+    """
     pts = [(t, v) for t, v in zip(times, values) if v is not None]
     if len(pts) < 2:
         return f'<svg width="{w}" height="{h}" role="img" aria-label="no data"></svg>'
@@ -145,9 +147,7 @@ def svg_area_line(
         for lo, hi, color in (bands or [])
     )
     coords = " ".join(f"{px(t):.1f},{py(v):.1f}" for t, v in pts)
-    area = (
-        f"{px(pts[0][0]):.1f},{py(y_lo):.1f} {coords} {px(pts[-1][0]):.1f},{py(y_lo):.1f}"
-    )
+    area = f"{px(pts[0][0]):.1f},{py(y_lo):.1f} {coords} {px(pts[-1][0]):.1f},{py(y_lo):.1f}"
     return (
         f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" preserveAspectRatio="none">'
         f"{band_rects}"
@@ -407,10 +407,10 @@ def render_sleep(sleep: dict, *, debt_progress: dict | None = None) -> str:
             ),
         ]
     )
-    ring = progress_or_text(bool(debt.get("available")), debt_progress, "", "Sleep debt (14n)")
-    return (
-        f'<section class="panel"><h2>Sleep</h2><div class="stats">{stats}</div>{ring}</section>'
+    ring = progress_or_text(
+        bool(debt.get("available")), debt_progress, "", "Sleep debt (14n)"
     )
+    return f'<section class="panel"><h2>Sleep</h2><div class="stats">{stats}</div>{ring}</section>'
 
 
 def render_trends(
@@ -548,7 +548,10 @@ def render_rr_hrv_detail(detail: dict) -> str:
         body = f'<div class="sub">{esc(detail.get("reason", "not enough clean RR yet"))}</div>'
     else:
         tacho = svg_area_line(
-            detail["times"], detail["rr_values"], stroke="#a78bfa", fill="rgba(167,139,250,0.15)"
+            detail["times"],
+            detail["rr_values"],
+            stroke="#a78bfa",
+            fill="rgba(167,139,250,0.15)",
         )
         scatter = svg_poincare(detail["pairs"], detail["sd1"], detail["sd2"])
         stats = "".join(
@@ -574,7 +577,10 @@ def render_overnight_hrv(curve: dict) -> str:
         body = f'<div class="sub">{esc(curve.get("reason", "no overnight window detected yet"))}</div>'
     else:
         chart = svg_area_line(
-            curve["times"], curve["values"], stroke="#34d399", fill="rgba(52,211,153,0.18)"
+            curve["times"],
+            curve["values"],
+            stroke="#34d399",
+            fill="rgba(52,211,153,0.18)",
         )
         body = f'<div class="chart"><div class="lbl">lnRMSSD · overnight (5-min buckets)</div>{chart}</div>'
     return f'<section class="panel"><h2>Overnight HRV curve</h2>{body}</section>'
@@ -586,7 +592,10 @@ def render_sleep_hr_dip(curve: dict) -> str:
         body = f'<div class="sub">{esc(curve.get("reason", "no overnight sleep window detected yet"))}</div>'
     else:
         chart = svg_area_line(
-            curve["times"], curve["values"], stroke="#818cf8", fill="rgba(129,140,248,0.15)"
+            curve["times"],
+            curve["values"],
+            stroke="#818cf8",
+            fill="rgba(129,140,248,0.15)",
         )
         stats = "".join(
             [
@@ -599,7 +608,9 @@ def render_sleep_hr_dip(curve: dict) -> str:
             f'<div class="stats">{stats}</div>'
             f'<div class="chart"><div class="lbl">HR across sleep window</div>{chart}</div>'
         )
-    return f'<section class="panel"><h2>Sleep HR &amp; nocturnal dip</h2>{body}</section>'
+    return (
+        f'<section class="panel"><h2>Sleep HR &amp; nocturnal dip</h2>{body}</section>'
+    )
 
 
 def render_respiratory(trace: dict) -> str:
@@ -608,7 +619,10 @@ def render_respiratory(trace: dict) -> str:
         body = f'<div class="sub">{esc(trace.get("reason", "not enough clean resting RR yet"))}</div>'
     else:
         chart = svg_area_line(
-            trace["times"], trace["values"], stroke="#f472b6", fill="rgba(244,114,182,0.15)"
+            trace["times"],
+            trace["values"],
+            stroke="#f472b6",
+            fill="rgba(244,114,182,0.15)",
         )
         body = f'<div class="chart"><div class="lbl">Breaths/min · resting windows</div>{chart}</div>'
     return f'<section class="panel"><h2>Respiratory trace</h2>{body}</section>'
@@ -651,7 +665,9 @@ def _session_card_html(s: dict) -> str:
     )
     drift = a.get("hrr")
     drift_html = (
-        f'<span class="chip">HRR: {esc(drift)} bpm/60s</span>' if drift is not None else ""
+        f'<span class="chip">HRR: {esc(drift)} bpm/60s</span>'
+        if drift is not None
+        else ""
     )
     peak_sub = f'peak {a.get("max_hr", "—")}'
     duration_min = a.get("duration_sec", 0) // 60

--- a/tests/test_whoop_cockpit_intraday.py
+++ b/tests/test_whoop_cockpit_intraday.py
@@ -98,7 +98,13 @@ class TestPanelRendersEmptyState:
         from rivaflow.core.whoop_cockpit import render_session_deepdives
 
         out = render_session_deepdives(
-            [{"label": "BJJ (gi)", "day": "2026-07-01", "analytics": {"available": False, "reason": "no HR"}}]
+            [
+                {
+                    "label": "BJJ (gi)",
+                    "day": "2026-07-01",
+                    "analytics": {"available": False, "reason": "no HR"},
+                }
+            ]
         )
         assert "BJJ (gi)" in out
 

--- a/tests/test_whoop_cockpit_intraday.py
+++ b/tests/test_whoop_cockpit_intraday.py
@@ -1,0 +1,279 @@
+"""P3.5 — intraday/session deep-dive panels: HR ribbon, RR+Poincaré, overnight HRV, sleep HR dip,
+respiratory trace, stress ribbon, session deep-dives, and the cold-start progress rings.
+
+Render functions are pure (HTML in, HTML out) so most cases run without Postgres. The data-series
+functions (today_hr_ribbon, rr_hrv_detail, ...) need Postgres (temp_db/test_user) — on a fresh user with
+no WHOOP rows they must degrade to a clean "building" state, never raise.
+"""
+
+from __future__ import annotations
+
+
+class TestSvgHelpers:
+    def test_progress_ring_renders_svg_with_fraction(self):
+        from rivaflow.core.whoop_cockpit import svg_progress_ring
+
+        out = svg_progress_ring(3, 14, "Sleep debt")
+        assert out.startswith("<svg")
+        assert "3/14" in out
+
+    def test_area_line_empty_data_does_not_crash(self):
+        from rivaflow.core.whoop_cockpit import svg_area_line
+
+        out = svg_area_line([], [])
+        assert out.startswith("<svg")
+        assert "no data" in out
+
+    def test_area_line_with_bands(self):
+        from rivaflow.core.whoop_cockpit import svg_area_line
+
+        out = svg_area_line([0, 1, 2], [60, 90, 70], bands=[(60, 100, "#34d399")])
+        assert "<polyline" in out
+        assert "<rect" in out
+
+    def test_poincare_empty_pairs_does_not_crash(self):
+        from rivaflow.core.whoop_cockpit import svg_poincare
+
+        out = svg_poincare([], 0.0, 0.0)
+        assert out.startswith("<svg")
+
+    def test_poincare_with_pairs_draws_ellipse(self):
+        from rivaflow.core.whoop_cockpit import svg_poincare
+
+        pairs = [(800.0 + i, 810.0 + i) for i in range(20)]
+        out = svg_poincare(pairs, sd1=20.0, sd2=60.0)
+        assert "<ellipse" in out
+        assert "<circle" in out
+
+
+class TestPanelRendersEmptyState:
+    """Every new panel must render a clean 'building' state on empty/unavailable data — never crash."""
+
+    def test_hr_ribbon_empty(self):
+        from rivaflow.core.whoop_cockpit import render_hr_ribbon
+
+        out = render_hr_ribbon({"available": False, "reason": "no HR yet"})
+        assert '<section class="panel">' in out
+        assert "Today · HR ribbon" in out
+        assert "no HR yet" in out
+
+    def test_rr_hrv_detail_empty(self):
+        from rivaflow.core.whoop_cockpit import render_rr_hrv_detail
+
+        out = render_rr_hrv_detail({"available": False, "reason": "not enough RR"})
+        assert "RR &amp; HRV detail" in out
+
+    def test_overnight_hrv_empty(self):
+        from rivaflow.core.whoop_cockpit import render_overnight_hrv
+
+        out = render_overnight_hrv({"available": False, "reason": "no window"})
+        assert "Overnight HRV curve" in out
+
+    def test_sleep_hr_dip_empty(self):
+        from rivaflow.core.whoop_cockpit import render_sleep_hr_dip
+
+        out = render_sleep_hr_dip({"available": False, "reason": "no window"})
+        assert "Sleep HR &amp; nocturnal dip" in out
+
+    def test_respiratory_empty(self):
+        from rivaflow.core.whoop_cockpit import render_respiratory
+
+        out = render_respiratory({"available": False, "reason": "no RR"})
+        assert "Respiratory trace" in out
+
+    def test_stress_ribbon_empty(self):
+        from rivaflow.core.whoop_cockpit import render_stress_ribbon
+
+        out = render_stress_ribbon({"available": False, "reason": "no baseline"})
+        assert "Stress ribbon" in out
+
+    def test_session_deepdives_empty_list(self):
+        from rivaflow.core.whoop_cockpit import render_session_deepdives
+
+        out = render_session_deepdives([])
+        assert '<section class="panel">' in out
+        assert "Session deep-dives" in out
+
+    def test_session_deepdives_unavailable_session_does_not_crash(self):
+        from rivaflow.core.whoop_cockpit import render_session_deepdives
+
+        out = render_session_deepdives(
+            [{"label": "BJJ (gi)", "day": "2026-07-01", "analytics": {"available": False, "reason": "no HR"}}]
+        )
+        assert "BJJ (gi)" in out
+
+
+class TestPanelRendersPopulatedState:
+    def test_hr_ribbon_populated(self):
+        from rivaflow.core.whoop_cockpit import render_hr_ribbon
+
+        out = render_hr_ribbon(
+            {
+                "available": True,
+                "times": [0, 1, 2],
+                "values": [60, 90, 70],
+                "avg_hr": 73,
+                "max_bpm": 150,
+                "max_hr": 190,
+            }
+        )
+        assert "<svg" in out and "<polyline" in out
+
+    def test_rr_hrv_detail_populated(self):
+        from rivaflow.core.whoop_cockpit import render_rr_hrv_detail
+
+        pairs = [(800.0 + i, 810.0 + i) for i in range(10)]
+        out = render_rr_hrv_detail(
+            {
+                "available": True,
+                "times": [0, 1, 2],
+                "rr_values": [800, 820, 810],
+                "pairs": pairs,
+                "sd1": 22.0,
+                "sd2": 55.0,
+                "mean_hr": 68,
+            }
+        )
+        assert "<ellipse" in out
+
+    def test_session_deepdives_populated(self):
+        from rivaflow.core.whoop_cockpit import render_session_deepdives
+
+        sessions = [
+            {
+                "label": "BJJ (gi)",
+                "day": "2026-07-01",
+                "analytics": {
+                    "available": True,
+                    "avg_hr": 150,
+                    "max_hr": 180,
+                    "duration_sec": 3600,
+                    "hr_zone_secs": {1: 100, 2: 200, 3: 1000, 4: 1800, 5: 500},
+                    "times": [0, 1, 2],
+                    "values": [140, 160, 150],
+                    "hrr": 22,
+                },
+            }
+        ]
+        out = render_session_deepdives(sessions)
+        assert "BJJ (gi)" in out
+        assert "HRR: 22 bpm/60s" in out
+
+
+class TestProgressWiring:
+    """Existing longitudinal panels show a progress ring — not bare text — when cold-starting."""
+
+    def test_recovery_load_shows_acwr_ring_when_not_available(self):
+        from rivaflow.core.whoop_cockpit import render_recovery_load
+
+        out = render_recovery_load(
+            readiness={"state": "Building"},
+            strain={"available": False},
+            acwr={"available": False},
+            cardio_trend=[],
+            recovery_cost={"available": False},
+            acwr_progress={"have": 5, "need": 28},
+        )
+        assert "5/28" in out
+
+    def test_hrv_lab_shows_ring_when_not_available(self):
+        from rivaflow.core.whoop_cockpit import render_hrv_lab
+
+        out = render_hrv_lab(
+            {"available": False, "reason": "no window"},
+            {"available": False, "reason": "no segment"},
+            progress={"have": 2, "need": 5},
+        )
+        assert "2/5" in out
+
+    def test_sleep_shows_ring_when_debt_not_available(self):
+        from rivaflow.core.whoop_cockpit import render_sleep
+
+        out = render_sleep(
+            {"debt": {"available": False}, "regularity": {"available": False}},
+            debt_progress={"have": 4, "need": 14},
+        )
+        assert "4/14" in out
+
+    def test_trends_shows_ring_when_resilience_not_available(self):
+        from rivaflow.core.whoop_cockpit import render_trends
+
+        out = render_trends(
+            longevity={},
+            resilience={"resilience": {"available": False}},
+            circadian={},
+            assessment={},
+            resilience_progress={"have": 6, "need": 14},
+        )
+        assert "6/14" in out
+
+
+class TestDataSeriesGracefulOnFreshUser:
+    """No WHOOP rows at all for a brand-new user — every new series fn must degrade cleanly, never raise."""
+
+    def test_today_hr_ribbon_unavailable(self, test_user):
+        from rivaflow.core.whoop_analytics import today_hr_ribbon
+
+        out = today_hr_ribbon(test_user["id"])
+        assert out["available"] is False
+
+    def test_rr_hrv_detail_unavailable(self, test_user):
+        from rivaflow.core.whoop_analytics import rr_hrv_detail
+
+        out = rr_hrv_detail(test_user["id"])
+        assert out["available"] is False
+
+    def test_overnight_hrv_curve_unavailable(self, test_user):
+        from rivaflow.core.whoop_analytics import overnight_hrv_curve
+
+        out = overnight_hrv_curve(test_user["id"])
+        assert out["available"] is False
+
+    def test_sleep_hr_dip_unavailable(self, test_user):
+        from rivaflow.core.whoop_analytics import sleep_hr_dip
+
+        out = sleep_hr_dip(test_user["id"])
+        assert out["available"] is False
+
+    def test_respiratory_trace_unavailable(self, test_user):
+        from rivaflow.core.whoop_analytics import respiratory_trace
+
+        out = respiratory_trace(test_user["id"])
+        assert out["available"] is False
+
+    def test_stress_ribbon_series_unavailable(self, test_user):
+        from rivaflow.core.whoop_analytics import stress_ribbon_series
+
+        out = stress_ribbon_series(test_user["id"])
+        assert out["available"] is False
+
+    def test_session_deepdives_empty(self, test_user):
+        from rivaflow.core.whoop_analytics import session_deepdives
+
+        assert session_deepdives(test_user["id"]) == []
+
+    def test_history_progress_all_zero(self, test_user):
+        from rivaflow.core.whoop_analytics import _history_progress
+
+        progress = _history_progress(test_user["id"])
+        assert progress["hrv"]["have"] == 0
+        assert progress["acwr"]["have"] == 0
+        assert progress["sleep_debt"]["have"] == 0
+        assert progress["resilience"]["have"] == 0
+
+    def test_cockpit_page_end_to_end_on_fresh_user(self, test_user):
+        """Full assembly with zero data: every P3.5 panel present, no traceback."""
+        from rivaflow.core.whoop_analytics import cockpit_page
+
+        html = cockpit_page(test_user["id"])
+        assert html.startswith("<!doctype html>")
+        for panel in (
+            "Today · HR ribbon",
+            "RR &amp; HRV detail",
+            "Overnight HRV curve",
+            "Sleep HR &amp; nocturnal dip",
+            "Respiratory trace",
+            "Stress ribbon",
+            "Session deep-dives",
+        ):
+            assert panel in html, f"missing panel: {panel}"

--- a/tests/test_whoop_cockpit_render.py
+++ b/tests/test_whoop_cockpit_render.py
@@ -12,10 +12,17 @@ class TestCockpitRender:
         assert "WHOOP Cockpit" in html
         for panel in (
             "Recovery &amp; Load",  # P3.1
+            "Today · HR ribbon",  # P3.5
+            "RR &amp; HRV detail",  # P3.5 MUST-HAVE
             "HRV Lab",  # P3.2
+            "Overnight HRV curve",  # P3.5
             "Data integrity",  # P3.2
+            "Sleep HR &amp; nocturnal dip",  # P3.5
+            "Respiratory trace",  # P3.5
+            "Stress ribbon",  # P3.5
             "Sleep",  # P3.3
             "Trends &amp; Longevity",  # P3.3
+            "Session deep-dives",  # P3.5 MUST-HAVE
             "Baseline-Deviation log",  # P3.4
             "Behaviour correlations",  # P3.4
         ):


### PR DESCRIPTION
## Summary

The WHOOP cockpit's data is intraday-dense (~155k HR rows, ~40k RR rows) but longitudinally thin (~2-3 days), so most existing panels (readiness, ACWR, trends) render "needs more days" right now. This adds the panels that ARE meaningful on day one, plus cold-start progress rings for the ones that aren't yet.

**New panels (all self-contained inline SVG, no CDN/client JS, server-downsampled to <=600 points):**

1. **Today · HR ribbon** — full-day HR line with HR-zone bands shaded behind it (`today_hr_ribbon`, `render_hr_ribbon`)
2. **RR & HRV detail** (MUST-HAVE) — RR tachogram + Poincaré scatter with the SD1/SD2 ellipse drawn (`rr_hrv_detail`, `render_rr_hrv_detail`, `svg_poincare`)
3. **Overnight HRV curve** — lnRMSSD in 5-min buckets across the detected sleep window (`overnight_hrv_curve`, `render_overnight_hrv`)
4. **Sleep HR & nocturnal dip** — HR across the sleep window with onset/offset + dip % (`sleep_hr_dip`, `render_sleep_hr_dip`)
5. **Respiratory trace** — breaths/min across resting windows via RSA (`respiratory_trace`, `render_respiratory`)
6. **Stress ribbon** — hourly HR-reserve-vs-baseline stress across the day (`stress_ribbon_series`, `render_stress_ribbon`)
7. **Session deep-dives** (MUST-HAVE) — per-session (BJJ + CrossFit) HR curve, time-in-zones, and HR-recovery card, from `sessions` + `bjj_session_analytics` (`session_deepdives`, `render_session_deepdives`)
8. **Progress-unlock rings** — `svg_progress_ring` + `progress_or_text` helper, wired into `render_recovery_load` (ACWR/28d), `render_hrv_lab` (5d), `render_sleep` (debt/14n), `render_trends` (resilience/14d) via new keyword-only params (existing call sites/tests unaffected)

**New helpers in `whoop_cockpit.py`:** `svg_progress_ring`, `progress_or_text`, `svg_area_line` (filled zone-banded line chart), `svg_poincare`.

**New series functions in `whoop_analytics.py`:** `_downsample_xy`, `today_hr_ribbon`, `rr_hrv_detail`, `overnight_hrv_curve`, `sleep_hr_dip`, `respiratory_trace`, `stress_ribbon_series`, `_session_window`, `_session_label`, `session_deepdives`, `_history_progress`. `cockpit_page` now assembles all panels.

Every panel degrades to a clean "building" state (or a progress ring) on thin/no data — verified by manual smoke test exercising all render paths with both empty and populated synthetic data (no crashes, no stack traces).

## Test plan

- [x] `ruff check` on both changed core files and both test files — all clean (complexity, style)
- [x] `python -m py_compile` / AST parse — no syntax errors
- [x] Manual smoke test: imported `whoop_analytics`/`whoop_cockpit`, exercised every new `render_*` and `svg_*` function with empty-state and populated synthetic data — all render valid HTML/SVG, no exceptions
- [ ] `python -m pytest tests/ -k whoop -q` — **could not run locally, no Postgres available in this sandbox** (`DATABASE_URL` unset, no `pg_isready`/docker). Added `tests/test_whoop_cockpit_intraday.py` (pure render-fn tests + `test_user`-fixture-backed graceful-empty-state tests for every new series fn + full `cockpit_page` end-to-end) and extended `tests/test_whoop_cockpit_render.py`'s panel-list assertion. **Needs a CI/Postgres run to confirm green.**

Deferred: none of the 8 requested panels/rings were dropped — all 8 are implemented in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)