### PR TITLE
fix(whoop): land cockpit snapshot work dropped by the #81 squash

### DIFF
--- a/rivaflow/rivaflow/core/scheduler.py
+++ b/rivaflow/rivaflow/core/scheduler.py
@@ -9,10 +9,15 @@ gunicorn workers each start their own scheduler instance.
 
 import logging
 from datetime import timedelta
+from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from rivaflow.core.time_utils import utcnow
+
+# Ruby is Melbourne-based — the cockpit snapshot runs on his local rhythm (wake / post-training / evening
+# / night), so the cron hours must be pinned to this tz, not the scheduler container's (likely UTC).
+_MELBOURNE_TZ = ZoneInfo("Australia/Melbourne")
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +30,7 @@ _LOCK_IDS = {
     "drip_emails": 900003,
     "coach_settings_reminder": 900004,
     "token_cleanup": 900005,
+    "cockpit_snapshot": 900006,
 }
 
 
@@ -317,6 +323,45 @@ async def _coach_settings_reminder_job() -> None:
         _release_advisory_lock("coach_settings_reminder")
 
 
+async def _cockpit_snapshot_job() -> None:
+    """Pre-compute the WHOOP deep-dive cockpit for each recently-active user and store the HTML snapshot.
+    The page runs ~15 multi-day analytics (~40s cold), so we render it off the request path (6-9-18-21
+    Melbourne-local) and the serve becomes a single instant SELECT. Runs once at startup to warm a deploy.
+    """
+    if not _try_advisory_lock("cockpit_snapshot"):
+        return
+    try:
+        from rivaflow.core.whoop_analytics import _build_cockpit_page
+        from rivaflow.db.database import convert_query, get_connection
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        # Users with any WHOOP HR captured in the last ~72h are the ones with a cockpit worth rebuilding.
+        cutoff = (utcnow() - timedelta(hours=72)).isoformat()
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                convert_query("SELECT DISTINCT user_id FROM whoop_hr WHERE ts >= ?"),
+                (cutoff,),
+            )
+            rows = cursor.fetchall()
+
+        user_ids = [r["user_id"] if hasattr(r, "keys") else r[0] for r in rows]
+        logger.info("Cockpit snapshot: %d active WHOOP users", len(user_ids))
+
+        for uid in user_ids:
+            try:
+                html = _build_cockpit_page(uid)
+                WhoopRepository.upsert_cockpit_snapshot(uid, html)
+            except Exception:
+                logger.warning(
+                    "Cockpit snapshot failed for user %d", uid, exc_info=True
+                )
+    except Exception:
+        logger.error("Cockpit snapshot job failed", exc_info=True)
+    finally:
+        _release_advisory_lock("cockpit_snapshot")
+
+
 async def _token_cleanup_job() -> None:
     """Delete expired refresh tokens and password reset tokens (daily 03:00 UTC)."""
     if not _try_advisory_lock("token_cleanup"):
@@ -405,6 +450,27 @@ def start_scheduler() -> None:
         hour=12,
         minute=0,
         id="coach_settings_reminder",
+        replace_existing=True,
+    )
+
+    # 06/09/18/21 Melbourne-local (wake / post-morning-training / evening / post-evening-training) —
+    # pre-compute the WHOOP cockpit snapshot. Explicit tz so these are Ruby's local hours, not UTC.
+    _scheduler.add_job(
+        _cockpit_snapshot_job,
+        "cron",
+        hour="6,9,18,21",
+        minute=0,
+        timezone=_MELBOURNE_TZ,
+        id="cockpit_snapshot",
+        replace_existing=True,
+    )
+
+    # Warm the snapshot shortly after startup so a fresh deploy serves instantly without waiting for a tick.
+    _scheduler.add_job(
+        _cockpit_snapshot_job,
+        "date",
+        run_date=utcnow() + timedelta(seconds=30),
+        id="cockpit_snapshot_warmup",
         replace_existing=True,
     )
 

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -8,7 +8,6 @@ HRV only, and BJJ session analytics use HR (not HRV) because motion corrupts bea
 
 from __future__ import annotations
 
-import time
 from collections import defaultdict
 from datetime import datetime, timedelta
 from math import log1p
@@ -588,8 +587,11 @@ def overnight_hrv_curve(user_id: int) -> dict:
         vals = buckets[idx]
         if len(vals) < 5:
             continue
+        lnr = ln_rmssd([float(v) for v in vals])
+        if lnr is None:
+            continue
         times.append(idx * 5 / 60.0)
-        values.append(round(ln_rmssd([float(v) for v in vals]), 3))
+        values.append(round(lnr, 3))
     if len(values) < 3:
         return {"available": False, "reason": "Too few clean 5-min buckets overnight."}
     return {"available": True, "times": times, "values": values}
@@ -779,23 +781,17 @@ def _history_progress(user_id: int) -> dict:
     }
 
 
-# Rendering the full cockpit runs ~15 multi-day analytics (~30s cold). The page auto-refreshes every 120s
-# and the underlying data only updates ~every 2.5min, so a short-TTL cache keeps every refresh/revisit
-# instant while a fresh session pays a single cold render. Keyed per user; process-local.
-_COCKPIT_CACHE: dict[int, tuple[float, str]] = {}
-_COCKPIT_TTL_S = 150.0
-
-
 def cockpit_page(user_id: int) -> str:
-    """Cached entry point for the deep-dive cockpit — serves a recent render (≤150s) instantly and only
-    rebuilds when the cache is cold or stale. See `_build_cockpit_page` for the actual render.
+    """Hot path for the deep-dive cockpit — serves the pre-computed snapshot the scheduler stores (one
+    instant SELECT). Rendering runs ~15 multi-day analytics (~40s cold), which black-screens the browser
+    on-demand, so `_cockpit_snapshot_job` recomputes every 4h and this only reads. On a cold first-ever
+    hit (no snapshot yet) it renders once, stores it, and returns it. See `_build_cockpit_page`.
     """
-    hit = _COCKPIT_CACHE.get(user_id)
-    nowt = time.monotonic()
-    if hit is not None and nowt - hit[0] < _COCKPIT_TTL_S:
-        return hit[1]
+    snap = WhoopRepository.get_cockpit_snapshot(user_id)
+    if snap is not None:
+        return str(snap["html"])
     html = _build_cockpit_page(user_id)
-    _COCKPIT_CACHE[user_id] = (nowt, html)
+    WhoopRepository.upsert_cockpit_snapshot(user_id, html)
     return html
 
 
@@ -854,7 +850,7 @@ def _build_cockpit_page(user_id: int) -> str:
             render_behaviour(effects),  # P3.4
         ]
     )
-    return render_cockpit_page(panels)
+    return render_cockpit_page(panels, rendered_at=now.strftime("%H:%M"))
 
 
 def behaviour_correlation(

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -295,12 +295,15 @@ def render_recovery_load(
     )
 
 
-def render_cockpit_page(panels_html: str) -> str:
-    """Full server-rendered cockpit page (dark, self-contained, auto-refresh)."""
+def render_cockpit_page(panels_html: str, rendered_at: str = "") -> str:
+    """Full server-rendered cockpit page (dark, self-contained). Serves a pre-computed snapshot, so the
+    footer shows when it was rendered and the tab re-fetches every 10 min to pick up the next snapshot.
+    """
+    stamp = f"as of {rendered_at} · " if rendered_at else ""
     return (
         "<!doctype html><html><head><meta charset='utf-8'>"
         "<meta name='viewport' content='width=device-width, initial-scale=1'>"
-        "<meta http-equiv='refresh' content='120'><title>WHOOP Cockpit</title><style>"
+        "<meta http-equiv='refresh' content='600'><title>WHOOP Cockpit</title><style>"
         "body{font-family:system-ui,-apple-system,sans-serif;background:#0b1120;color:#e2e8f0;margin:0;padding:16px}"
         "h1{font-size:18px;margin:0 0 12px}h2{font-size:14px;color:#94a3b8;margin:0 0 10px;text-transform:uppercase;letter-spacing:.05em}"
         ".panel{background:#111827;border:1px solid #1f2937;border-radius:12px;padding:16px;margin-bottom:14px}"
@@ -319,7 +322,7 @@ def render_cockpit_page(panels_html: str) -> str:
         "@media (max-width:640px){.dual{grid-template-columns:1fr}}"
         "</style></head><body><h1>WHOOP Cockpit · analyst deep-dive</h1>"
         f"{panels_html}"
-        "<div class='foot'>RivaFlow · self-hosted · renders server-computed series · auto-refresh 2 min</div>"
+        f"<div class='foot'>RivaFlow · self-hosted · {stamp}recomputes 6am · 9am · 6pm · 9pm</div>"
         "</body></html>"
     )
 
@@ -633,7 +636,11 @@ def render_stress_ribbon(ribbon: dict) -> str:
     if not ribbon.get("available"):
         body = f'<div class="sub">{esc(ribbon.get("reason", "not enough HR history for a baseline yet"))}</div>'
     else:
-        bands = [(0, 34, "#34d399"), (34, 67, "#fbbf24"), (67, 100, "#f87171")]
+        bands: list[tuple[float, float, str]] = [
+            (0.0, 34.0, "#34d399"),
+            (34.0, 67.0, "#fbbf24"),
+            (67.0, 100.0, "#f87171"),
+        ]
         chart = svg_area_line(
             ribbon["times"], ribbon["values"], bands=bands, stroke="#e2e8f0"
         )

--- a/rivaflow/rivaflow/db/migrations/112_whoop_cockpit_snapshot.sql
+++ b/rivaflow/rivaflow/db/migrations/112_whoop_cockpit_snapshot.sql
@@ -1,0 +1,9 @@
+-- 112_whoop_cockpit_snapshot.sql
+-- SQLite local-dev variant of 112_whoop_cockpit_snapshot_pg.sql.
+-- (Keep these comments free of the semicolon character, which the migration runner splits on.)
+CREATE TABLE IF NOT EXISTS whoop_cockpit_snapshot (
+    user_id     INTEGER PRIMARY KEY,
+    html        TEXT    NOT NULL,
+    rendered_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/rivaflow/rivaflow/db/migrations/112_whoop_cockpit_snapshot_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/112_whoop_cockpit_snapshot_pg.sql
@@ -1,0 +1,14 @@
+-- 112_whoop_cockpit_snapshot_pg.sql
+-- Pre-computed cockpit HTML snapshot for the WHOOP data platform (PostgreSQL / production).
+-- See 112_whoop_cockpit_snapshot.sql for the SQLite (local dev) variant.
+--
+-- The analyst cockpit runs ~15 multi-day analytics per render (~40s cold), which black-screens the
+-- browser on an on-demand fetch. Instead a scheduled job pre-computes the full page every 4h and stores
+-- it here, so the serve is a single instant SELECT. One row per user, upserted in place.
+-- (Keep these comments free of the semicolon character, which the migration runner treats as a
+--  statement separator even inside a comment.)
+CREATE TABLE IF NOT EXISTS whoop_cockpit_snapshot (
+    user_id     INTEGER     PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    html        TEXT        NOT NULL,
+    rendered_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -306,3 +306,26 @@ class WhoopRepository:
             ),
             (user_id, limit),
         )
+
+    # ── Cockpit snapshot (pre-computed page — scheduled render, instant serve) ──
+
+    @staticmethod
+    def get_cockpit_snapshot(user_id: int) -> dict | None:
+        """The stored pre-computed cockpit page for a user ({html, rendered_at}) or None if never built."""
+        return BaseRepository._fetchone(
+            convert_query(
+                "SELECT html, rendered_at FROM whoop_cockpit_snapshot WHERE user_id = ?"
+            ),
+            (user_id,),
+        )
+
+    @staticmethod
+    def upsert_cockpit_snapshot(user_id: int, html: str) -> None:
+        """Store (or replace) a user's pre-computed cockpit HTML, stamping rendered_at to now."""
+        BaseRepository._execute(
+            convert_query(
+                "INSERT INTO whoop_cockpit_snapshot (user_id, html) VALUES (?, ?) "
+                "ON CONFLICT (user_id) DO UPDATE SET html = EXCLUDED.html, rendered_at = NOW()"
+            ),
+            (user_id, html),
+        )

--- a/tests/test_whoop_cockpit_snapshot.py
+++ b/tests/test_whoop_cockpit_snapshot.py
@@ -1,0 +1,58 @@
+"""Perf — the cockpit is served from a pre-computed snapshot, not rendered live per request.
+
+`cockpit_page` reads the stored snapshot (instant SELECT) when one exists, and only falls back to a live
+render (storing it) on the cold first-ever hit. `_build_cockpit_page` remains the pure full-page renderer
+the scheduler calls. Uses the Postgres test_user/temp_db fixtures.
+"""
+
+from __future__ import annotations
+
+
+class TestCockpitSnapshot:
+    def test_build_returns_full_page(self, test_user):
+        from rivaflow.core.whoop_analytics import _build_cockpit_page
+
+        html = _build_cockpit_page(test_user["id"])
+        assert html.startswith("<!doctype html>")
+        assert "WHOOP Cockpit" in html
+        assert "recomputes every 4h" in html  # freshness stamp footer
+
+    def test_cockpit_page_serves_stored_snapshot(self, test_user):
+        """When a snapshot exists, cockpit_page returns it verbatim — no live re-render."""
+        from rivaflow.core.whoop_analytics import cockpit_page
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        marker = "<!doctype html><html><head></head><body>STORED-SNAPSHOT-MARKER</body></html>"
+        WhoopRepository.upsert_cockpit_snapshot(test_user["id"], marker)
+
+        assert cockpit_page(test_user["id"]) == marker
+
+    def test_cockpit_page_falls_back_and_stores_when_absent(self, test_user):
+        """With no snapshot, cockpit_page renders live, persists it, and subsequent reads hit the store."""
+        from rivaflow.core.whoop_analytics import cockpit_page
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        assert WhoopRepository.get_cockpit_snapshot(test_user["id"]) is None
+
+        html = cockpit_page(test_user["id"])
+        assert html.startswith("<!doctype html>")
+
+        snap = WhoopRepository.get_cockpit_snapshot(test_user["id"])
+        assert snap is not None
+        assert snap["html"] == html
+        assert snap["rendered_at"] is not None
+
+    def test_upsert_replaces_existing_snapshot(self, test_user):
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        WhoopRepository.upsert_cockpit_snapshot(test_user["id"], "<p>first</p>")
+        WhoopRepository.upsert_cockpit_snapshot(test_user["id"], "<p>second</p>")
+
+        snap = WhoopRepository.get_cockpit_snapshot(test_user["id"])
+        assert snap is not None
+        assert snap["html"] == "<p>second</p>"
+
+    def test_get_snapshot_none_for_fresh_user(self, test_user):
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        assert WhoopRepository.get_cockpit_snapshot(test_user["id"]) is None


### PR DESCRIPTION
PR #81's squash captured only the TTL-cache commit; the snapshot pre-render (scheduler job at 6/9/18/21 Melbourne, migration 112, repo upsert/get, snapshot-serving cockpit_page, footer) was dropped. main shipped a cockpit that SELECTs a non-existent table. This re-lands the full 7-file delta in one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)