### PR TITLE
feat(whoop): timestamped workout sessions — attach HR to logged workouts in the cockpit

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -229,6 +229,47 @@ def remove_tag_endpoint(
     return {"removed": {"day": day, "tag": tag}}
 
 
+class WhoopSessionCreate(BaseModel):
+    """A timestamped workout session — a real start/end window so per-second HR can attach."""
+
+    activity: str = Field(..., min_length=1, max_length=64)
+    started_at: str = Field(..., description="ISO8601 start timestamp")
+    ended_at: str | None = Field(
+        None, description="ISO8601 end timestamp (optional if still open)"
+    )
+
+
+class WhoopSessionEnd(BaseModel):
+    """Close an open workout session."""
+
+    ended_at: str = Field(..., description="ISO8601 end timestamp")
+
+
+@router.post("/session")
+@route_error_handler("whoop_create_session", detail="Failed to create session")
+def create_session_endpoint(
+    req: WhoopSessionCreate, current_user: dict = Depends(get_current_user)
+) -> dict:
+    """Log a timestamped workout session. The window lets the cockpit attach in-window WHOOP HR and
+    compute the deep-dive (curve, zones, load, hardness)."""
+    session_id = WhoopRepository.create_whoop_session(
+        current_user["id"], req.activity, req.started_at, req.ended_at
+    )
+    return {"id": session_id}
+
+
+@router.patch("/session/{session_id}/end")
+@route_error_handler("whoop_end_session", detail="Failed to end session")
+def end_session_endpoint(
+    session_id: int,
+    req: WhoopSessionEnd,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """Close an open workout session by stamping its end time."""
+    WhoopRepository.end_whoop_session(session_id, req.ended_at)
+    return {"ended": {"id": session_id, "ended_at": req.ended_at}}
+
+
 # ── Read + analytics (Phase 2 / shared access: RivaFlow UI, health dashboard, LLM/MCP) ──
 
 

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -59,7 +59,6 @@ from rivaflow.core.whoop_cockpit import (
     session_load_hardness,
 )
 from rivaflow.core.whoop_digest import compile_digest
-from rivaflow.db.repositories.session_repo import SessionRepository
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 # Ruby's profile-tuned constants
@@ -706,62 +705,73 @@ def stress_ribbon_series(user_id: int) -> dict:
     return {"available": True, "times": times, "values": values}
 
 
-def _session_window(s: dict) -> tuple[datetime, datetime] | None:
-    """Best-effort session start/end from `sessions` row fields, for windowing the WHOOP HR query."""
-    day = s.get("session_date")
-    if not day:
+# A logged session with fewer in-window HR samples than this is still listed, but marked 'no HR coverage'.
+_SESSION_MIN_HR_SAMPLES = 30
+# When a session was never closed (no ended_at), assume this window so recent HR can still attach.
+_SESSION_OPEN_MINUTES = 90
+
+
+def _whoop_session_window(row: dict) -> tuple[datetime, datetime] | None:
+    """(start, end) for a logged whoop_sessions row — end falls back to start + 90min while still open."""
+    started = row.get("started_at")
+    if not started:
         return None
-    day_str = day.isoformat() if hasattr(day, "isoformat") else str(day)[:10]
-    time_str = str(s.get("class_time") or "18:00")[:5]
     try:
-        start = datetime.fromisoformat(f"{day_str}T{time_str}").replace(tzinfo=LOCAL_TZ)
-    except ValueError:
+        start = _parse_ts(str(started))
+    except (ValueError, TypeError):
         return None
-    duration = int(s.get("duration_mins") or 60)
-    return start, start + timedelta(minutes=duration)
+    ended = row.get("ended_at")
+    if ended:
+        try:
+            return start, _parse_ts(str(ended))
+        except (ValueError, TypeError):
+            pass
+    return start, start + timedelta(minutes=_SESSION_OPEN_MINUTES)
 
 
-def _session_label(s: dict) -> str:
-    """Human label for a session card: CrossFit (via Garmin activity type) or BJJ gi/no-gi, else generic."""
-    garmin_type = (s.get("garmin_activity_type") or "").lower()
-    class_type = (s.get("class_type") or "").lower()
-    if "crossfit" in garmin_type or "cross" in garmin_type:
-        return "CrossFit"
-    if class_type in {"gi", "nogi", "no-gi", "open-mat", "openmat"}:
-        return f"BJJ ({class_type})"
-    return (s.get("garmin_activity_type") or s.get("class_type") or "Session").title()
+def _attach_session_hr(
+    user_id: int, start: datetime, end: datetime, analytics: dict
+) -> dict:
+    """Attach the downsampled in-window HR curve + protocol-HRR to a session's analytics (in place)."""
+    hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
+    pts = sorted(
+        ((_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm")),
+        key=lambda p: p[0],
+    )
+    times = [(t - start).total_seconds() / 60.0 for t, _ in pts]
+    vals = [float(b) for _, b in pts]
+    xs, ys = _downsample_xy(times, vals, max_points=200)
+    analytics["times"], analytics["values"] = xs, ys
+    hrr = analytics.get("protocol_hrr") or {}
+    analytics["hrr"] = hrr.get("hrr_bpm") if hrr.get("available") else None
+    return analytics
 
 
 def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
-    """P3.5 — MUST-HAVE: per-session HR analytics (BJJ + CrossFit) for the deep-dive cards — reuses
-    bjj_session_analytics's zone/HRR compute over each recent session's class-time window.
+    """P3.5 — per-session HR analytics for the Workouts list + the Tier-1 last-workout card. Sources
+    timestamped workouts from whoop_sessions and attaches in-window WHOOP HR (curve, zones via the
+    B1-calibrated max-HR, avg/peak, HRR). A session with too little in-window HR is still listed, but
+    marked 'no HR coverage'. Returns [] when there are no logged sessions. Shape per item is stable:
+    {"label": str, "day": "YYYY-MM-DD", "analytics": {...}} — consumed by render_workouts_list and the card.
     """
     mx = user_max_hr(user_id)["max_hr"]
     out: list[dict] = []
-    for s in SessionRepository.get_recent(user_id, limit=limit):
-        window = _session_window(s)
+    for row in WhoopRepository.list_whoop_sessions(user_id, limit=limit):
+        window = _whoop_session_window(row)
         if window is None:
             continue
         start, end = window
         a = bjj_session_analytics(
             user_id, start.isoformat(), end.isoformat(), max_hr=mx
         )
-        if a.get("available"):
-            hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
-            pts = sorted(
-                ((_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm")),
-                key=lambda p: p[0],
-            )
-            times = [(t - start).total_seconds() / 60.0 for t, _ in pts]
-            vals = [float(b) for _, b in pts]
-            xs, ys = _downsample_xy(times, vals, max_points=200)
-            a["times"], a["values"] = xs, ys
-            hrr = a.get("protocol_hrr") or {}
-            a["hrr"] = hrr.get("hrr_bpm") if hrr.get("available") else None
+        if a.get("available") and a.get("samples", 0) >= _SESSION_MIN_HR_SAMPLES:
+            a = _attach_session_hr(user_id, start, end, a)
+        else:
+            a = {"available": False, "reason": "no HR coverage"}
         out.append(
             {
-                "label": _session_label(s),
-                "day": str(s.get("session_date", "")),
+                "label": str(row.get("activity", "Session")),
+                "day": _local_day(start),
                 "analytics": a,
             }
         )

--- a/rivaflow/rivaflow/db/migrations/113_whoop_sessions.sql
+++ b/rivaflow/rivaflow/db/migrations/113_whoop_sessions.sql
@@ -1,0 +1,16 @@
+-- 113_whoop_sessions.sql
+-- SQLite local-dev variant of 113_whoop_sessions_pg.sql.
+-- (Keep these comments free of the semicolon character, which the migration runner splits on.)
+CREATE TABLE IF NOT EXISTS whoop_sessions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    activity    TEXT    NOT NULL,
+    started_at  TEXT    NOT NULL,
+    ended_at    TEXT,
+    source      TEXT    NOT NULL DEFAULT 'app',
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS whoop_sessions_user_started_idx
+    ON whoop_sessions (user_id, started_at DESC);

--- a/rivaflow/rivaflow/db/migrations/113_whoop_sessions_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/113_whoop_sessions_pg.sql
@@ -1,0 +1,22 @@
+-- 113_whoop_sessions_pg.sql
+-- Timestamped workout-session store for the WHOOP data platform (PostgreSQL / production).
+-- See 113_whoop_sessions.sql for the SQLite (local dev) variant.
+--
+-- The class `sessions` table only carries a date, so per-second WHOOP HR cannot attach to a workout.
+-- This is a dedicated store with a real start/end window (logged from the app, closed when the session
+-- ends), so the cockpit's Workouts list + last-workout card can attach in-window HR and compute the
+-- deep-dive (curve, zones, load, hardness). One row per logged workout.
+-- (Keep these comments free of the semicolon character, which the migration runner treats as a
+--  statement separator even inside a comment.)
+CREATE TABLE IF NOT EXISTS whoop_sessions (
+    id          SERIAL      PRIMARY KEY,
+    user_id     INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    activity    TEXT        NOT NULL,
+    started_at  TIMESTAMPTZ NOT NULL,
+    ended_at    TIMESTAMPTZ,
+    source      TEXT        NOT NULL DEFAULT 'app',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS whoop_sessions_user_started_idx
+    ON whoop_sessions (user_id, started_at DESC);

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -12,7 +12,7 @@ import hashlib
 import logging
 from datetime import UTC, datetime, timedelta
 
-from rivaflow.db.database import convert_query, get_connection
+from rivaflow.db.database import convert_query, execute_insert, get_connection
 from rivaflow.db.repositories.base_repository import BaseRepository
 
 logger = logging.getLogger(__name__)
@@ -268,6 +268,45 @@ class WhoopRepository:
             (user_id, tag),
         )
         return {str(r["day"])[:10] for r in rows}
+
+    # ── Timestamped workout sessions (real start/end window so HR can attach) ──
+
+    @staticmethod
+    def create_whoop_session(
+        user_id: int,
+        activity: str,
+        started_at: str,
+        ended_at: str | None = None,
+        source: str = "app",
+    ) -> int:
+        """Log a timestamped workout session and return its id. `started_at`/`ended_at` are ISO8601."""
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            return execute_insert(
+                cursor,
+                "INSERT INTO whoop_sessions (user_id, activity, started_at, ended_at, source) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (user_id, activity, started_at, ended_at, source),
+            )
+
+    @staticmethod
+    def end_whoop_session(session_id: int, ended_at: str) -> None:
+        """Close an open session by stamping its `ended_at` (ISO8601)."""
+        BaseRepository._execute(
+            convert_query("UPDATE whoop_sessions SET ended_at = ? WHERE id = ?"),
+            (ended_at, session_id),
+        )
+
+    @staticmethod
+    def list_whoop_sessions(user_id: int, limit: int = 10) -> list[dict]:
+        """A user's logged workout sessions, most recent first."""
+        return BaseRepository._fetchall(
+            convert_query(
+                "SELECT id, activity, started_at, ended_at, source, created_at "
+                "FROM whoop_sessions WHERE user_id = ? ORDER BY started_at DESC LIMIT ?"
+            ),
+            (user_id, limit),
+        )
 
     # ── Prevention alerts (P2 — delivery log + cooldown state) ───────────
 

--- a/tests/test_whoop_sessions.py
+++ b/tests/test_whoop_sessions.py
@@ -1,0 +1,159 @@
+"""Timestamped workout sessions — the dedicated whoop_sessions store that lets per-second WHOOP HR attach
+to a logged workout (the class `sessions` table only has a date). Covers the repo round-trip, the
+session_deepdives HR-attach + no-coverage paths, empty-state, and the write API. Uses the Postgres
+test_user/temp_db fixtures.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+_BASE = datetime(2026, 7, 4, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+class TestWhoopSessionRepo:
+    def test_create_list_end_round_trip(self, test_user):
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        uid = test_user["id"]
+        sid = WhoopRepository.create_whoop_session(
+            uid, "BJJ (gi)", _iso(_BASE), _iso(_BASE + timedelta(hours=1))
+        )
+        assert isinstance(sid, int) and sid > 0
+
+        rows = WhoopRepository.list_whoop_sessions(uid)
+        assert len(rows) == 1
+        row = rows[0]
+        # Exact dict shape the analytics + backfill/goose payload must match.
+        assert set(row.keys()) == {
+            "id",
+            "activity",
+            "started_at",
+            "ended_at",
+            "source",
+            "created_at",
+        }
+        assert row["id"] == sid
+        assert row["activity"] == "BJJ (gi)"
+        assert row["source"] == "app"  # default
+
+    def test_open_session_then_end(self, test_user):
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        uid = test_user["id"]
+        sid = WhoopRepository.create_whoop_session(uid, "CrossFit", _iso(_BASE))
+        assert WhoopRepository.list_whoop_sessions(uid)[0]["ended_at"] is None
+
+        WhoopRepository.end_whoop_session(sid, _iso(_BASE + timedelta(minutes=45)))
+        assert WhoopRepository.list_whoop_sessions(uid)[0]["ended_at"] is not None
+
+    def test_list_is_most_recent_first(self, test_user):
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        uid = test_user["id"]
+        WhoopRepository.create_whoop_session(uid, "old", _iso(_BASE))
+        WhoopRepository.create_whoop_session(
+            uid, "new", _iso(_BASE + timedelta(days=1))
+        )
+        rows = WhoopRepository.list_whoop_sessions(uid)
+        assert [r["activity"] for r in rows] == ["new", "old"]
+
+
+class TestSessionDeepdives:
+    def test_empty_state_returns_list(self, test_user):
+        from rivaflow.core.whoop_analytics import session_deepdives
+
+        assert session_deepdives(test_user["id"]) == []
+
+    def test_attaches_hr_to_in_window_session(self, test_user):
+        from rivaflow.core.whoop_analytics import session_deepdives
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        uid = test_user["id"]
+        WhoopRepository.create_whoop_session(
+            uid, "BJJ (gi)", _iso(_BASE), _iso(_BASE + timedelta(hours=1))
+        )
+        # 90 in-window HR samples, 1s apart — clears the min-sample coverage bar.
+        WhoopRepository.ingest_hr(
+            uid,
+            [{"ts": _iso(_BASE + timedelta(seconds=i)), "bpm": 140} for i in range(90)],
+        )
+
+        out = session_deepdives(uid)
+        assert len(out) == 1
+        item = out[0]
+        assert item["label"] == "BJJ (gi)"
+        assert item["day"] == "2026-07-04"
+        a = item["analytics"]
+        assert a["available"] is True
+        assert a["avg_hr"] == 140
+        assert a["samples"] >= 30
+        assert set(a["hr_zone_secs"].keys()) == {1, 2, 3, 4, 5}
+        assert a["times"] and a["values"]  # a curve was attached
+
+    def test_no_coverage_session_still_listed(self, test_user):
+        from rivaflow.core.whoop_analytics import session_deepdives
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        uid = test_user["id"]
+        # A session with no HR anywhere near its window.
+        WhoopRepository.create_whoop_session(
+            uid, "CrossFit", _iso(_BASE), _iso(_BASE + timedelta(hours=1))
+        )
+        out = session_deepdives(uid)
+        assert len(out) == 1
+        assert out[0]["label"] == "CrossFit"
+        assert out[0]["analytics"]["available"] is False
+        assert out[0]["analytics"]["reason"] == "no HR coverage"
+
+    def test_too_few_samples_marked_no_coverage(self, test_user):
+        from rivaflow.core.whoop_analytics import session_deepdives
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        uid = test_user["id"]
+        WhoopRepository.create_whoop_session(
+            uid, "Run", _iso(_BASE), _iso(_BASE + timedelta(hours=1))
+        )
+        # Only 5 in-window samples — below the coverage threshold.
+        WhoopRepository.ingest_hr(
+            uid,
+            [{"ts": _iso(_BASE + timedelta(seconds=i)), "bpm": 130} for i in range(5)],
+        )
+        out = session_deepdives(uid)
+        assert out[0]["analytics"]["available"] is False
+        assert out[0]["analytics"]["reason"] == "no HR coverage"
+
+
+class TestWhoopSessionApi:
+    def test_create_and_end_session(self, client, auth_headers):
+        r = client.post(
+            "/api/v1/whoop/session",
+            json={
+                "activity": "BJJ (gi)",
+                "started_at": _iso(_BASE),
+                "ended_at": _iso(_BASE + timedelta(hours=1)),
+            },
+            headers=auth_headers,
+        )
+        assert r.status_code == 200, r.text
+        sid = r.json()["id"]
+        assert isinstance(sid, int)
+
+        r2 = client.patch(
+            f"/api/v1/whoop/session/{sid}/end",
+            json={"ended_at": _iso(_BASE + timedelta(minutes=50))},
+            headers=auth_headers,
+        )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["ended"]["id"] == sid
+
+    def test_create_requires_auth(self, client):
+        r = client.post(
+            "/api/v1/whoop/session",
+            json={"activity": "BJJ", "started_at": _iso(_BASE)},
+        )
+        assert r.status_code in (401, 403)


### PR DESCRIPTION
## Summary

The cockpit's Workouts list + Tier-1 last-workout card had nothing real to show: the class `sessions` table only carries a **date**, so per-second WHOOP HR could never attach to a workout. This adds a dedicated **timestamped** workout-session store with a true start/end window, and rewires `session_deepdives` to source from it and attach in-window HR.

### 1. Migration `113_whoop_sessions` (pg + sqlite)
`whoop_sessions(id, user_id → users FK ON DELETE CASCADE, activity, started_at TIMESTAMPTZ, ended_at TIMESTAMPTZ?, source TEXT DEFAULT 'app', created_at)` + index on `(user_id, started_at DESC)`. Comments kept semicolon-free for the migration splitter (110-style).

### 2. Repo (`WhoopRepository`)
- `create_whoop_session(user_id, activity, started_at, ended_at=None, source='app') -> int` (id via `execute_insert`)
- `end_whoop_session(session_id, ended_at)` — stamps `ended_at`
- `list_whoop_sessions(user_id, limit=10) -> list[dict]` — most recent first

### 3. API (`routes/whoop.py`, bearer api-key auth — same `Depends(get_current_user)` as `/whoop/tag`)
- `POST /whoop/session {activity, started_at, ended_at?}` → `{"id": <int>}`
- `PATCH /whoop/session/{id}/end {ended_at}` → `{"ended": {"id", "ended_at"}}`
- ISO8601 timestamps (`WhoopSessionCreate` / `WhoopSessionEnd` pydantic models)

### 4. `session_deepdives` rewired
Now iterates `list_whoop_sessions` instead of the class `sessions` table. Per session it windows `[started_at, ended_at or started_at+90min]`, runs the existing `bjj_session_analytics` (zones via `user_max_hr`, avg/peak, HRR) and attaches the downsampled HR curve. A session with **< 30 in-window HR samples** is still listed but marked `available=False, reason="no HR coverage"`. The per-item shape is **unchanged** — `{"label", "day", "analytics"}` — so `render_workouts_list` and the Tier-1 last-workout card keep working untouched. The now-dead class-`sessions` `_session_window`/`_session_label` helpers + `SessionRepository` import were removed.

### `list_whoop_sessions` dict shape (for the backfill row + goose POST payload)
```
{
  "id":         int,
  "activity":   str,          # free text, becomes the workout label — e.g. "BJJ (gi)", "CrossFit"
  "started_at": str,          # ISO8601 (TIMESTAMPTZ)
  "ended_at":   str | None,   # ISO8601, None while a session is still open (analytics then windows +90min)
  "source":     str,          # defaults to "app"
  "created_at": str           # ISO8601
}
```
POST payload to create: `{"activity": "BJJ (gi)", "started_at": "2026-07-04T10:00:00+10:00", "ended_at": "2026-07-04T11:00:00+10:00"}` → `{"id": N}`. Close an open one: `PATCH /whoop/session/{id}/end {"ended_at": "..."}`.

## New functions
- repo: `create_whoop_session`, `end_whoop_session`, `list_whoop_sessions`
- routes: `create_session_endpoint`, `end_session_endpoint` (+ `WhoopSessionCreate`, `WhoopSessionEnd`)
- analytics: `_whoop_session_window`, `_attach_session_hr`; `session_deepdives` rewired

## Files changed
- `rivaflow/rivaflow/db/migrations/113_whoop_sessions.sql` + `_pg.sql` (new)
- `rivaflow/rivaflow/db/repositories/whoop_repo.py`
- `rivaflow/rivaflow/api/routes/whoop.py`
- `rivaflow/rivaflow/core/whoop_analytics.py`
- `tests/test_whoop_sessions.py` (new)

## Test plan
- [x] **black** `--check` · **isort** `--check-only --profile black` · **ruff** `--ignore=C901,N802,N818,UP042,F823` — all clean
- [x] **mypy** `rivaflow/ --ignore-missing-imports` — Success, no issues
- [x] **C901** — verified every changed function stays ≤10 (`ruff --select=C901 --max-complexity=10` clean; the HR-attach is factored into `_attach_session_hr`)
- [x] Pure-logic smoke tests: `_whoop_session_window` (closed / open→+90min / missing / malformed), route + model registration, repo/analytics symbol wiring
- [ ] `pytest tests/test_whoop_sessions.py` — **could not run locally, no Postgres in this sandbox** (`DATABASE_URL` unset). Added round-trip (create/end/list + exact shape), deep-dive HR-attach, no-coverage + too-few-samples, empty-state, and write-API tests on the standard `test_user`/`client`/`auth_headers` fixtures; **needs a CI/Postgres run to confirm green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)