### PR TITLE
Sleep: tell the truth when the strap didn't record overnight (no fabricated 0.8h)

### DIFF
--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -262,7 +262,33 @@ def nightly_sleep(user_id: int, lookback_hours: int = 24) -> dict:
         for h in hr
         if h.get("bpm") and h.get("ts")
     ]
-    return _sleep_from_points(pts)
+    # Honest guard for a night the strap never recorded: if the core night hours (00:00–05:00 local)
+    # have almost no data, there is no sleep to detect — a short quiet block after the strap wakes in the
+    # morning is a capture artifact, not last night's sleep. Say so instead of inventing a number.
+    core = [
+        t for t, _ in pts if 0 <= t.astimezone(LOCAL_TZ).hour < 5
+    ]  # local small-hours samples
+    if (
+        len(core) < 60
+    ):  # < ~1–2 min of the deepest-night window captured → strap was silent
+        return {
+            "available": False,
+            "capture_dropout": True,
+            "reason": "No overnight data — the strap stopped recording last night (likely dropped out).",
+        }
+    res = _sleep_from_points(pts)
+    if res.get("available"):
+        onset = _parse_ts(res["sleep_start"]).astimezone(LOCAL_TZ)
+        # a genuine sleep onset is evening/late-night; a short block onsetting in the morning/day is a
+        # post-wake artifact, not the night — reject it rather than label it "last night's sleep"
+        plausible_onset = onset.hour >= 19 or onset.hour < 4
+        if not plausible_onset and res.get("duration_hours", 0) < 4:
+            return {
+                "available": False,
+                "capture_dropout": True,
+                "reason": "No overnight sleep window captured last night (the strap only recorded after you woke).",
+            }
+    return res
 
 
 def nightly_sleep_history(user_id: int, nights: int = 7) -> list[dict]:

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -1108,6 +1108,18 @@ def _hero_html(readiness: dict, trends: dict | None = None) -> str:
 
 def _sleep_card(night: dict, dip: dict, need_hours: float) -> str:
     if not night.get("available"):
+        # Distinguish "the strap didn't record" (honest, actionable) from cold-start "building".
+        if night.get("capture_dropout"):
+            msg = esc(
+                night.get(
+                    "reason", "No overnight data — the strap didn't record last night."
+                )
+            )
+            return (
+                '<div class="card"><div class="ico">🌙 Last night</div>'
+                '<div class="big">No data</div>'
+                f'<div class="sub">⚠️ {msg}</div></div>'
+            )
         return (
             '<div class="card"><div class="ico">🌙 Last night</div>'
             '<div class="big">—</div><div class="sub">building — no sleep window detected yet</div></div>'


### PR DESCRIPTION
## Diagnosis (from live data)
Pulled the actual overnight HR: last night the strap captured **zero samples from ~16:00 to ~05:00** — a 13-hour void. The whole night wasn't recorded (the overnight BLE dropout). No sleep algorithm can measure a night that never happened in the data, so the detector was locking onto the first quiet block after the strap woke (**05:25–06:15**) and reporting it as '0.8h sleep'.

## Fix — an honest guard in `nightly_sleep`
- If the **core night hours (00:00–05:00 local)** have almost no data (<~60 samples), there's no sleep to detect → return `capture_dropout` with a plain message.
- Else if the detected window **onsets in the morning/day** (not evening/late-night) and is <4h, it's a post-wake artifact → also `capture_dropout`.
- The sleep card now shows **"No data · the strap stopped recording last night"** instead of a fabricated number.

Verified: last-night shape → *No data / capture_dropout*; a normal full night → *7.9h, unaffected*. Lint clean (ruff/black).

## The real cure
This makes the **dashboard honest**; the underlying fix is **capture reliability** — the goose battery/BLE build (strap going silent and never recovering overnight) targets exactly this. Last night it clearly dropped ~4pm and never came back until morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)