### PR TITLE
Honest static landing: crawlers and no-JS visitors see real copy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,13 +8,56 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#FF4D2D" />
     <!-- v1.9.0 -->
-    <meta name="description" content="RivaFlow is the training OS for Brazilian Jiu-Jitsu athletes. Log sessions, track readiness, analyse performance, and connect with your team." />
+    <meta name="description" content="RivaFlow is a training OS for Brazilian Jiu-Jitsu — session logging in under a minute, readiness from your own biometrics, honest analytics on every roll. Built by one grappler, for one grappler. Open source." />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://rivaflow.app/" />
+    <meta property="og:title" content="RivaFlow — Training OS for the Mat" />
+    <meta property="og:description" content="A BJJ training OS built by one grappler, for one grappler. Session logging, readiness, roll analytics. Not a product — practice. Open source." />
+    <meta property="og:image" content="https://rivaflow.app/logo.png" />
+    <meta name="author" content="Ruby Wolff" />
     <title>RivaFlow - Training OS for the Mat</title>
+    <style>
+      .rf-landing {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0e0f12;
+        color: #e8e6e3;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        padding: 2rem;
+        text-align: center;
+      }
+      .rf-landing__inner { max-width: 34rem; }
+      .rf-landing h1 { font-size: 1.9rem; margin: 0 0 0.5rem; }
+      .rf-landing h1 span { color: #ff4d2d; }
+      .rf-landing p { line-height: 1.65; color: #b8b5b0; margin: 0.75rem 0; }
+      .rf-landing a { color: #ff4d2d; text-decoration: none; }
+      .rf-landing a:hover { text-decoration: underline; }
+      .rf-landing__links { margin-top: 1.5rem; font-size: 0.95rem; }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- Static fallback: visible to crawlers, no-JS visitors, and pre-hydration.
+           The app replaces this on mount. -->
+      <div class="rf-landing">
+        <div class="rf-landing__inner">
+          <h1><span>RivaFlow</span> — a training OS for the mat.</h1>
+          <p>
+            Built by one grappler, for one grappler: me. Session logging in under a
+            minute, readiness from my own biometrics, and honest analytics on every
+            roll. It's not a product — it's practice, and it's open source.
+          </p>
+          <p class="rf-landing__links">
+            Code → <a href="https://github.com/RubyWolff27/rivaflow">github.com/RubyWolff27/rivaflow</a><br />
+            The builder → <a href="https://rubywolff.au">rubywolff.au</a>
+          </p>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Why
rivaflow.app currently serves an empty JS shell to anything without a browser — search engines, link previews, and curious strangers see nothing (confirmed via external audit 2026-07-06). Part of the graceful public parking of RivaFlow per the ikigai-focus plan.

## What
- Static pre-hydration content inside `#root`: the honest one-paragraph story (built by one grappler, for one grappler, open source) + links to the repo and rubywolff.au. Replaced on app mount (`createRoot().render()` — verified), so logged-in users see zero difference.
- OG tags (title/description/image/url) for link previews.
- Truthful meta description.

## Risk
Minimal — index.html only, no app code touched. CI gates + VPS auto-pull with health-check/auto-rollback cover the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)