### PR TITLE
Fix main: restore session labels on deep-dive cards + update tests stale since cockpit overhaul

### DIFF
--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -970,6 +970,7 @@ def _session_card_html(s: dict, idx: int = 0) -> str:
     )
     return (
         '<div class="session-card">'
+        f'<div class="lbl">{esc(s.get("label", "Session"))}</div>'
         f'<div class="stats">{stats_html}</div>'
         f'<div class="chart"><div class="lbl">Heart rate · elapsed</div>{curve}</div>'
         f'<div class="chart"><div class="lbl">Time in zones</div>{_zone_bar_html(a.get("hr_zone_secs", {}))}</div>'

--- a/tests/test_whoop_cockpit_intraday.py
+++ b/tests/test_whoop_cockpit_intraday.py
@@ -116,7 +116,9 @@ class TestPanelRendersPopulatedState:
         out = render_hr_ribbon(
             {
                 "available": True,
-                "times": [0, 1, 2],
+                # dense samples (gaps < max_gap=0.34h) so the connected polyline
+                # renders; sparse points now honestly draw as dots (gap-honesty, #88)
+                "times": [0, 0.1, 0.2],
                 "values": [60, 90, 70],
                 "avg_hr": 73,
                 "max_bpm": 150,
@@ -163,7 +165,8 @@ class TestPanelRendersPopulatedState:
         ]
         out = render_session_deepdives(sessions)
         assert "BJJ (gi)" in out
-        assert "HRR: 22 bpm/60s" in out
+        # HRR renders as a stat card since the cockpit overhaul (#86)
+        assert "22 bpm recovery in 60s" in out
 
 
 class TestProgressWiring:

--- a/tests/test_whoop_cockpit_snapshot.py
+++ b/tests/test_whoop_cockpit_snapshot.py
@@ -15,7 +15,7 @@ class TestCockpitSnapshot:
         html = _build_cockpit_page(test_user["id"])
         assert html.startswith("<!doctype html>")
         assert "WHOOP Cockpit" in html
-        assert "recomputes every 4h" in html  # freshness stamp footer
+        assert "recomputes 6am · 9am · 6pm · 9pm" in html  # freshness stamp footer (schedule per whoop_cockpit.py)
 
     def test_cockpit_page_serves_stored_snapshot(self, test_user):
         """When a snapshot exists, cockpit_page returns it verbatim — no live re-render."""

--- a/tests/test_whoop_cockpit_snapshot.py
+++ b/tests/test_whoop_cockpit_snapshot.py
@@ -15,7 +15,9 @@ class TestCockpitSnapshot:
         html = _build_cockpit_page(test_user["id"])
         assert html.startswith("<!doctype html>")
         assert "WHOOP Cockpit" in html
-        assert "recomputes 6am · 9am · 6pm · 9pm" in html  # freshness stamp footer (schedule per whoop_cockpit.py)
+        assert (
+            "recomputes 6am · 9am · 6pm · 9pm" in html
+        )  # freshness stamp footer (schedule per whoop_cockpit.py)
 
     def test_cockpit_page_serves_stored_snapshot(self, test_user):
         """When a snapshot exists, cockpit_page returns it verbatim — no live re-render."""


### PR DESCRIPTION
## Why
**Main is red** — Tests workflow has failed since #86–#88 merged, which also blocks the production deploy gate (the #88 deploy run is stuck/failing, so this morning's strap-honesty fix likely hasn't reached the VPS, and PR #89 is queued behind the same gate).

## What
One real bug + three stale test expectations:
- **Bug:** populated session deep-dive cards lost their session label in the overhaul — up to 5 stacked cards with no way to tell BJJ from CrossFit. Restored a `.lbl` header; the failing `'BJJ (gi)'` assertion was correct all along.
- HR ribbon fixture densified (points 1h apart now honestly render as dots under #88 gap-honesty; dense points still exercise the polyline path).
- Snapshot footer assertion updated to the deliberate new recompute-schedule copy.
- HRR assertion updated to the stat-card format from #86.

## Verification
Local: `tests/test_whoop_cockpit_intraday.py` → **20 passed** (9 DB-fixture errors expected without local Postgres; CI's real PG covers them). Snapshot test verified by CI here.

Merge this before #89; both then deploy cleanly through the VPS auto-pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)