### PR TITLE
fix(whoop): Wave 0 security — scoped read-only keys, session IDOR, webhook gate, rate limits

### DIFF
--- a/rivaflow/rivaflow/api/main.py
+++ b/rivaflow/rivaflow/api/main.py
@@ -334,6 +334,10 @@ app.include_router(dashboard.router, prefix="/api/v1", tags=["dashboard"])
 app.include_router(transcribe.router, prefix="/api/v1", tags=["transcribe"])
 app.include_router(events.router, prefix="/api/v1/events", tags=["events"])
 app.include_router(integrations.router, prefix="/api/v1", tags=["integrations"])
+# The only route here is the WHOOP-cloud webhook — a JWT-less POST from the
+# cancelled-subscription era. The handler self-gates on ENABLE_WHOOP_INTEGRATION
+# (default false → 404), so it presents no attack surface by default, matching
+# how integrations.py gates the rest of the WHOOP-cloud OAuth routes.
 app.include_router(webhooks.router, prefix="/api/v1", tags=["webhooks"])
 app.include_router(waitlist.router, prefix="/api/v1/waitlist", tags=["waitlist"])
 app.include_router(

--- a/rivaflow/rivaflow/api/rate_limit.py
+++ b/rivaflow/rivaflow/api/rate_limit.py
@@ -1,20 +1,21 @@
 """Shared rate limiter instance for all routes.
 
-X-Forwarded-For trust model
----------------------------
-RivaFlow runs behind Render's reverse proxy, which appends the true client
-IP as the **rightmost** entry in X-Forwarded-For.  An attacker can spoof
-the leftmost entries but cannot control the rightmost one that the proxy
-adds.  We therefore always use ``ips[-1]`` (rightmost-1 hop = Render's
-append).
+Client-IP trust model
+---------------------
+RivaFlow is fronted by a Cloudflare tunnel (``cloudflared`` in
+docker-compose.prod.yml), so the authoritative client IP is the one
+Cloudflare sets in ``CF-Connecting-IP`` — a header the origin only ever sees
+from Cloudflare and which the client cannot forge past the tunnel. We trust
+that first, then fall back to the rightmost ``X-Forwarded-For`` hop (the older
+Render topology), then the socket peer.
 
-If the deployment moves to a multi-proxy chain (e.g. CDN → Render), this
-logic must be updated to use rightmost-N where N = number of trusted
-proxies.
+Historical note: this used to trust only ``X-Forwarded-For[-1]`` for Render's
+reverse proxy. Under the current single-CF-tunnel chain that rightmost hop is
+the tunnel, not the true client, so every client collapsed onto one key —
+weakening every IP-scoped limit, including auth. ``CF-Connecting-IP`` fixes it.
 
-Note: The rate limiter storage is currently in-process memory
-(``slowapi`` default).  This means limits are per-worker, not global.
-A Redis backend migration is tracked for a future sprint.
+Note: rate-limit storage is in-process memory (``slowapi`` default), so limits
+are per-worker, not global. A Redis backend migration is tracked separately.
 """
 
 from slowapi import Limiter
@@ -22,17 +23,20 @@ from starlette.requests import Request
 
 
 def _get_real_client_ip(request: Request) -> str:
-    """Extract the real client IP, accounting for reverse proxies.
+    """Extract the real client IP for the Cloudflare-tunnel topology.
 
-    Uses the rightmost X-Forwarded-For entry (set by our trusted proxy)
-    to prevent spoofing via attacker-controlled leftmost entries.
-    Falls back to request.client.host when no forwarding header present.
+    Prefers ``CF-Connecting-IP`` (set by Cloudflare, unforgeable past the
+    tunnel), then the rightmost ``X-Forwarded-For`` hop, then the socket peer.
     """
+    cf_ip = request.headers.get("cf-connecting-ip")
+    if cf_ip and cf_ip.strip():
+        return cf_ip.strip()
+
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
-        # Rightmost entry is from the closest trusted proxy (Render)
-        ips = [ip.strip() for ip in forwarded.split(",")]
-        return ips[-1] if ips else "127.0.0.1"
+        ips = [ip.strip() for ip in forwarded.split(",") if ip.strip()]
+        if ips:
+            return ips[-1]
     return request.client.host if request.client else "127.0.0.1"
 
 

--- a/rivaflow/rivaflow/api/routes/api_keys.py
+++ b/rivaflow/rivaflow/api/routes/api_keys.py
@@ -10,14 +10,18 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from rivaflow.core.dependencies import get_current_user
+from rivaflow.core.dependencies import get_current_user, require_write_scope
 from rivaflow.core.error_handling import route_error_handler
 from rivaflow.core.models import (
     ApiKeyCreate,
     ApiKeyCreatedResponse,
     ApiKeyMetadata,
 )
-from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
+from rivaflow.db.repositories.api_key_repo import (
+    SCOPE_FULL,
+    SCOPE_READ,
+    ApiKeyRepository,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +53,7 @@ def list_api_keys(current_user: dict = Depends(get_current_user)) -> list[dict]:
 @route_error_handler("create_api_key", detail="Failed to create API key")
 def create_api_key(
     req: ApiKeyCreate,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_write_scope),
 ) -> dict:
     """Generate a new API key.
 
@@ -61,11 +65,19 @@ def create_api_key(
 
         Authorization: Bearer rf_pk_<the-key>
 
-    Keys carry the same authorization as the issuing user.
+    `read_only=true` mints an `rf_vk_` view key (scope='read') for the
+    bookmarkable dashboard URLs — it can read every endpoint but is rejected on
+    every write/admin route. A full key carries the same authorization as the
+    issuing user.
     """
     user_id: int = current_user["id"]
-    raw_key = ApiKeyRepository.generate_raw_key()
-    row = ApiKeyRepository.create(user_id=user_id, name=req.name, raw_key=raw_key)
+    raw_key = ApiKeyRepository.generate_raw_key(read_only=req.read_only)
+    row = ApiKeyRepository.create(
+        user_id=user_id,
+        name=req.name,
+        raw_key=raw_key,
+        scopes=SCOPE_READ if req.read_only else SCOPE_FULL,
+    )
     if not row:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -88,7 +100,7 @@ def create_api_key(
 @route_error_handler("revoke_api_key", detail="Failed to revoke API key")
 def revoke_api_key(
     api_key_id: int,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_write_scope),
 ) -> None:
     """Revoke an API key.
 

--- a/rivaflow/rivaflow/api/routes/webhooks.py
+++ b/rivaflow/rivaflow/api/routes/webhooks.py
@@ -11,6 +11,7 @@ from rivaflow.core.error_handling import route_error_handler
 from rivaflow.core.exceptions import (
     AuthenticationError,
     ExternalServiceError,
+    NotFoundError,
     ValidationError,
 )
 from rivaflow.core.services.whoop_service import WhoopService
@@ -64,7 +65,15 @@ async def whoop_webhook(request: Request):
     This endpoint is NOT JWT-protected — WHOOP calls it directly.
     Authentication is via HMAC signature verification using the
     Client Secret as the signing key.
+
+    Gated on ENABLE_WHOOP_INTEGRATION (default false): the WHOOP-cloud
+    subscription is cancelled, so by default this dead-era endpoint 404s and
+    presents no unauthenticated attack surface. Enable the flag only if a live
+    WHOOP OAuth connection is ever restored.
     """
+    if not settings.ENABLE_WHOOP_INTEGRATION:
+        raise NotFoundError(message="WHOOP integration is disabled")
+
     # Read raw body for signature verification
     body = await request.body()
 

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -17,12 +17,14 @@ import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Cookie, Depends, Query
+from fastapi import APIRouter, Cookie, Depends, Query, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
-from rivaflow.core.dependencies import get_current_user
+from rivaflow.api.rate_limit import limiter
+from rivaflow.core.dependencies import get_current_user, require_write_scope
 from rivaflow.core.error_handling import route_error_handler
+from rivaflow.core.exceptions import NotFoundError
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 logger = logging.getLogger(__name__)
@@ -32,6 +34,27 @@ router = APIRouter(prefix="/whoop", tags=["whoop"])
 # Root-mounted (no /api/v1 prefix) for a short, bookmarkable cockpit URL.
 short_router = APIRouter(tags=["whoop"])
 
+_UNAUTH_HTML = (
+    "<h1 style='font-family:system-ui;color:#eee;background:#111'>Unauthorized</h1>"
+)
+
+
+def _resolve_dashboard_key(raw: str) -> dict | None:
+    """Resolve a dashboard URL/cookie key to its api_keys row, or None.
+
+    Accepts either a full `rf_pk_` key or a read-only `rf_vk_` view key — the
+    dashboards are read-only, so a leaked view URL cannot forge writes (the
+    write routes reject a 'read'-scoped key via require_write_scope).
+    """
+    from rivaflow.db.repositories.api_key_repo import (
+        API_KEY_PREFIXES,
+        ApiKeyRepository,
+    )
+
+    if not raw or not raw.startswith(API_KEY_PREFIXES):
+        return None
+    return ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(raw))
+
 
 @short_router.get("/cockpit", response_class=HTMLResponse)
 def cockpit_short(key: str = "", rf_key: str = Cookie(default="")) -> HTMLResponse:
@@ -39,19 +62,14 @@ def cockpit_short(key: str = "", rf_key: str = Cookie(default="")) -> HTMLRespon
     stored in a cookie, so you can bookmark the bare URL afterwards. Same key-auth as /api/v1/whoop/cockpit.
     """
     from rivaflow.core.whoop_analytics import cockpit_page
-    from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
 
     k = key or rf_key
-    api_key = (
-        ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(k))
-        if k.startswith("rf_pk_")
-        else None
-    )
+    api_key = _resolve_dashboard_key(k)
     if not api_key:
         return HTMLResponse(
             "<body style='font-family:system-ui;background:#0b1120;color:#e2e8f0;padding:24px'>"
             "<h2>WHOOP Cockpit</h2><p>Add <code>?key=YOUR_KEY</code> to this URL once "
-            "(your rf_pk_… api key), then bookmark the bare page.</p></body>",
+            "(your rf_vk_… view key), then bookmark the bare page.</p></body>",
             status_code=401,
         )
     resp = HTMLResponse(cockpit_page(api_key["user_id"]))
@@ -128,11 +146,19 @@ def _span(payload: WhoopIngest) -> tuple[str | None, str | None]:
 
 
 @router.post("/ingest")
+@limiter.limit("120/minute")
 @route_error_handler("whoop_ingest", detail="Failed to ingest WHOOP data")
 def ingest(
-    payload: WhoopIngest, current_user: dict = Depends(get_current_user)
+    request: Request,
+    payload: WhoopIngest,
+    current_user: dict = Depends(require_write_scope),
 ) -> dict:
-    """Idempotent raw-first ingest for the authenticated user."""
+    """Idempotent raw-first ingest for the authenticated user.
+
+    Rate limit (120/min) is a flood backstop for a leaked key — generous
+    enough for the phone's chained backlog-drain bursts, tight enough to stop
+    unbounded raw-frame pollution.
+    """
     user_id: int = current_user["id"]
 
     raw = WhoopRepository.ingest_raw_frames(
@@ -202,7 +228,7 @@ class TagCreate(BaseModel):
 @router.post("/tag")
 @route_error_handler("whoop_add_tag", detail="Failed to add tag")
 def add_tag_endpoint(
-    req: TagCreate, current_user: dict = Depends(get_current_user)
+    req: TagCreate, current_user: dict = Depends(require_write_scope)
 ) -> dict:
     """Tag a local day (alcohol, late-training, ill, poor-sleep, travel, sabbath-rest…). Idempotent.
     Feeds B11 behaviour correlation and the B6 validation gate (an 'ill' tag is an illness-onset label).
@@ -223,7 +249,7 @@ def list_tags_endpoint(
 @router.delete("/tag")
 @route_error_handler("whoop_remove_tag", detail="Failed to remove tag")
 def remove_tag_endpoint(
-    day: str, tag: str, current_user: dict = Depends(get_current_user)
+    day: str, tag: str, current_user: dict = Depends(require_write_scope)
 ) -> dict:
     """Remove one (day, tag)."""
     WhoopRepository.remove_tag(current_user["id"], day, tag)
@@ -247,9 +273,12 @@ class WhoopSessionEnd(BaseModel):
 
 
 @router.post("/session")
+@limiter.limit("30/minute")
 @route_error_handler("whoop_create_session", detail="Failed to create session")
 def create_session_endpoint(
-    req: WhoopSessionCreate, current_user: dict = Depends(get_current_user)
+    request: Request,
+    req: WhoopSessionCreate,
+    current_user: dict = Depends(require_write_scope),
 ) -> dict:
     """Log a timestamped workout session. The window lets the cockpit attach in-window WHOOP HR and
     compute the deep-dive (curve, zones, load, hardness)."""
@@ -260,14 +289,18 @@ def create_session_endpoint(
 
 
 @router.patch("/session/{session_id}/end")
+@limiter.limit("30/minute")
 @route_error_handler("whoop_end_session", detail="Failed to end session")
 def end_session_endpoint(
+    request: Request,
     session_id: int,
     req: WhoopSessionEnd,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_write_scope),
 ) -> dict:
     """Close an open workout session by stamping its end time."""
-    WhoopRepository.end_whoop_session(session_id, req.ended_at)
+    ok = WhoopRepository.end_whoop_session(session_id, req.ended_at, current_user["id"])
+    if not ok:
+        raise NotFoundError(f"WHOOP session {session_id} not found")
     return {"ended": {"id": session_id, "ended_at": req.ended_at}}
 
 
@@ -465,7 +498,7 @@ def digest_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
 
 @router.post("/digest/deliver")
 @route_error_handler("whoop_digest_deliver", detail="Failed to deliver digest")
-def deliver_digest_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
+def deliver_digest_endpoint(current_user: dict = Depends(require_write_scope)) -> dict:
     """P2 — deliver today's digest: applies the cooldown and records any safety alert that fires. Called
     once each morning by the briefing cron (idempotent per day/key)."""
     from rivaflow.core.whoop_analytics import deliver_digest
@@ -607,18 +640,10 @@ def summary(current_user: dict = Depends(get_current_user)) -> dict:
 def cockpit(key: str) -> HTMLResponse:
     """P3 — server-rendered web deep-dive cockpit (analyst panels). Zero client compute; key-auth like /view."""
     from rivaflow.core.whoop_analytics import cockpit_page
-    from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
 
-    api_key = (
-        ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(key))
-        if key.startswith("rf_pk_")
-        else None
-    )
+    api_key = _resolve_dashboard_key(key)
     if not api_key:
-        return HTMLResponse(
-            "<h1 style='font-family:system-ui;color:#eee;background:#111'>Unauthorized</h1>",
-            status_code=401,
-        )
+        return HTMLResponse(_UNAUTH_HTML, status_code=401)
     return HTMLResponse(cockpit_page(api_key["user_id"]))
 
 
@@ -627,18 +652,9 @@ def view(key: str) -> HTMLResponse:
     """Server-rendered thin-display dashboard — the phone/browser opens a URL and the VPS renders the
     metrics into HTML. Zero client compute. Personal tool: auth via the owner's own api-key query param.
     """
-    from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
-
-    api_key = (
-        ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(key))
-        if key.startswith("rf_pk_")
-        else None
-    )
+    api_key = _resolve_dashboard_key(key)
     if not api_key:
-        return HTMLResponse(
-            "<h1 style='font-family:system-ui;color:#eee;background:#111'>Unauthorized</h1>",
-            status_code=401,
-        )
+        return HTMLResponse(_UNAUTH_HTML, status_code=401)
 
     is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
     s = _cached_whoop_summary(api_key["user_id"], today_is_sabbath=is_sabbath)

--- a/rivaflow/rivaflow/core/dependencies.py
+++ b/rivaflow/rivaflow/core/dependencies.py
@@ -10,7 +10,8 @@ from rivaflow.core.auth import decode_access_token
 from rivaflow.core.exceptions import AuthenticationError, ForbiddenError
 from rivaflow.core.utils.cache import get_cache
 from rivaflow.db.repositories.api_key_repo import (
-    KEY_PREFIX_LITERAL,
+    API_KEY_PREFIXES,
+    SCOPE_READ,
     ApiKeyRepository,
 )
 from rivaflow.db.repositories.user_repo import UserRepository
@@ -56,6 +57,39 @@ def _load_user_with_cache(user_id: int) -> dict:
     return user
 
 
+def _authenticate_api_key(token: str) -> dict:
+    """Resolve an `rf_pk_`/`rf_vk_` API key to its owning user.
+
+    Returns a COPY of the cached user annotated with `_auth_scope` (the key's
+    scope) — copied because the user cache is shared across requests and
+    mutating it would leak one key's scope onto another request.
+    """
+    try:
+        key_hash = ApiKeyRepository.hash_key(token)
+        api_key = ApiKeyRepository.get_active_by_hash(key_hash)
+        if api_key is None:
+            raise AuthenticationError(message="Invalid or revoked API key")
+
+        user = dict(_load_user_with_cache(api_key["user_id"]))
+        user["_auth_scope"] = api_key.get("scopes") or "full"
+
+        # Best-effort last-used bump — never fatal to the auth path.
+        try:
+            ApiKeyRepository.update_last_used(api_key["id"])
+        except Exception as bump_err:  # pragma: no cover — non-critical
+            logger.warning(
+                "update_last_used failed for api_key id=%s: %s",
+                api_key["id"],
+                bump_err,
+            )
+        return user
+    except AuthenticationError:
+        raise
+    except (ValueError, KeyError, TypeError) as e:
+        logger.error("API key authentication error: %s", e)
+        raise AuthenticationError(message="Authentication failed")
+
+
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> dict:
@@ -84,31 +118,8 @@ async def get_current_user(
     token = credentials.credentials
 
     # ── API key path ────────────────────────────────────────────────────────
-    if token.startswith(KEY_PREFIX_LITERAL):
-        try:
-            key_hash = ApiKeyRepository.hash_key(token)
-            api_key = ApiKeyRepository.get_active_by_hash(key_hash)
-            if api_key is None:
-                raise AuthenticationError(message="Invalid or revoked API key")
-
-            user = _load_user_with_cache(api_key["user_id"])
-
-            # Best-effort last-used bump — never fatal to the auth path.
-            try:
-                ApiKeyRepository.update_last_used(api_key["id"])
-            except Exception as bump_err:  # pragma: no cover — non-critical
-                logger.warning(
-                    "update_last_used failed for api_key id=%s: %s",
-                    api_key["id"],
-                    bump_err,
-                )
-
-            return user
-        except AuthenticationError:
-            raise
-        except (ValueError, KeyError, TypeError) as e:
-            logger.error("API key authentication error: %s", e)
-            raise AuthenticationError(message="Authentication failed")
+    if token.startswith(API_KEY_PREFIXES):
+        return _authenticate_api_key(token)
 
     # ── JWT path (existing behaviour) ───────────────────────────────────────
     try:
@@ -130,6 +141,20 @@ async def get_current_user(
     except (ValueError, KeyError, TypeError) as e:
         logger.error("Authentication error: %s", e)
         raise AuthenticationError(message="Authentication failed")
+
+
+def require_write_scope(current_user: dict = Depends(get_current_user)) -> dict:
+    """Dependency for mutating routes: reject read-only API keys.
+
+    A read-scoped `rf_vk_` key (minted for the bookmarkable cockpit URL) can
+    read every endpoint but must never write. JWT sessions and full `rf_pk_`
+    keys carry no read restriction and pass through unchanged.
+    """
+    if current_user.get("_auth_scope") == SCOPE_READ:
+        raise ForbiddenError(
+            message="This API key is read-only and cannot perform writes"
+        )
+    return current_user
 
 
 def get_admin_user(current_user: dict = Depends(get_current_user)) -> dict:

--- a/rivaflow/rivaflow/core/models.py
+++ b/rivaflow/rivaflow/core/models.py
@@ -444,6 +444,14 @@ class ApiKeyCreate(BaseModel):
     name: str = Field(
         ..., min_length=1, max_length=120, description="Human label, e.g. 'Sage MCP'"
     )
+    read_only: bool = Field(
+        default=False,
+        description=(
+            "Mint a read-only 'rf_vk_' view key (scope='read') for dashboard "
+            "URLs. Rejected on every write/admin route. Default False = full "
+            "user-equivalent 'rf_pk_' key."
+        ),
+    )
 
 
 class ApiKeyMetadata(BaseModel):

--- a/rivaflow/rivaflow/db/migrate.py
+++ b/rivaflow/rivaflow/db/migrate.py
@@ -33,9 +33,12 @@ def _ensure_critical_columns(conn):
         ("profile", "timezone", "TEXT DEFAULT 'UTC'"),
         ("users", "failed_login_attempts", "INTEGER DEFAULT 0"),
         ("users", "locked_until", "TIMESTAMP"),
+        # Auth-critical: the API-key scope gate reads this on every request.
+        # Guarantee it exists even if migration 114 is skipped or fails.
+        ("api_keys", "scopes", "TEXT NOT NULL DEFAULT 'full'"),
     ]
     # Whitelist of allowed table/column names to prevent SQL injection
-    allowed_tables = {"profile", "sessions", "users"}
+    allowed_tables = {"profile", "sessions", "users", "api_keys"}
     allowed_columns = {
         "timezone",
         "session_score",
@@ -43,6 +46,7 @@ def _ensure_critical_columns(conn):
         "score_version",
         "failed_login_attempts",
         "locked_until",
+        "scopes",
     }
 
     cursor = conn.cursor()

--- a/rivaflow/rivaflow/db/migrations/114_api_key_scopes.sql
+++ b/rivaflow/rivaflow/db/migrations/114_api_key_scopes.sql
@@ -1,0 +1,5 @@
+-- 114_api_key_scopes.sql
+-- Add a scope to api_keys so a read-only dashboard key can exist (SQLite/test).
+-- Existing keys default to 'full' so nothing is locked out. Read-only keys
+-- carry 'read' and are rejected on write and admin routes.
+ALTER TABLE api_keys ADD COLUMN scopes TEXT NOT NULL DEFAULT 'full';

--- a/rivaflow/rivaflow/db/migrations/114_api_key_scopes_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/114_api_key_scopes_pg.sql
@@ -1,0 +1,6 @@
+-- 114_api_key_scopes_pg.sql
+-- Add a scope to api_keys so a read-only dashboard key can exist (PG).
+-- Existing keys default to 'full' (user-equivalent) so nothing is locked out.
+-- Read-only keys carry 'read' and are rejected on every write and admin route,
+-- letting the bookmarkable cockpit URL carry a non-write credential.
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS scopes TEXT NOT NULL DEFAULT 'full';

--- a/rivaflow/rivaflow/db/repositories/api_key_repo.py
+++ b/rivaflow/rivaflow/db/repositories/api_key_repo.py
@@ -14,21 +14,35 @@ import secrets
 from rivaflow.db.database import convert_query, execute_insert, get_connection
 from rivaflow.db.repositories.base_repository import BaseRepository
 
-# Public-facing prefix for all RivaFlow API keys: "rf_pk_" + 32 hex chars.
-# `rf` = RivaFlow, `pk` = "personal key" (room to add e.g. `rf_sk_` for service
-# keys later without colliding).
+# Public-facing prefix for full (user-equivalent) RivaFlow API keys:
+# "rf_pk_" + 32 hex chars. `rf` = RivaFlow, `pk` = "personal key".
 KEY_PREFIX_LITERAL = "rf_pk_"
+# Read-only display keys used for the bookmarkable cockpit/dashboard URLs.
+# Same lookup path, but scoped 'read' so they are rejected on every write and
+# admin route — a leaked view URL cannot forge ingest or delete data.
+VIEW_KEY_PREFIX_LITERAL = "rf_vk_"
+# Every prefix the auth path treats as an API key (vs a JWT).
+API_KEY_PREFIXES = (KEY_PREFIX_LITERAL, VIEW_KEY_PREFIX_LITERAL)
 KEY_BODY_LENGTH = 32  # hex characters after the prefix
-KEY_DISPLAY_PREFIX_LENGTH = len(KEY_PREFIX_LITERAL) + 6  # "rf_pk_" + first 6 of body
+KEY_DISPLAY_PREFIX_LENGTH = len(KEY_PREFIX_LITERAL) + 6  # prefix + first 6 of body
+
+# Scope values persisted in api_keys.scopes.
+SCOPE_FULL = "full"  # user-equivalent: read + write + admin (default, legacy)
+SCOPE_READ = "read"  # dashboards only: every mutating/admin route rejects it
 
 
 class ApiKeyRepository(BaseRepository):
     """Data access layer for the api_keys table."""
 
     @staticmethod
-    def generate_raw_key() -> str:
-        """Generate a fresh API key — returned only once at creation time."""
-        return KEY_PREFIX_LITERAL + secrets.token_hex(KEY_BODY_LENGTH // 2)
+    def generate_raw_key(*, read_only: bool = False) -> str:
+        """Generate a fresh API key — returned only once at creation time.
+
+        `read_only=True` mints an `rf_vk_` view key (paired with scopes='read'
+        at create time); otherwise a full `rf_pk_` key.
+        """
+        prefix = VIEW_KEY_PREFIX_LITERAL if read_only else KEY_PREFIX_LITERAL
+        return prefix + secrets.token_hex(KEY_BODY_LENGTH // 2)
 
     @staticmethod
     def hash_key(raw_key: str) -> str:
@@ -46,6 +60,7 @@ class ApiKeyRepository(BaseRepository):
         user_id: int,
         name: str,
         raw_key: str,
+        scopes: str = SCOPE_FULL,
     ) -> dict | None:
         """Create a new API key row.
 
@@ -54,6 +69,8 @@ class ApiKeyRepository(BaseRepository):
             name: Human label (e.g. "Sage MCP", "iOS app").
             raw_key: Already-generated raw key (caller hashes via
                 `ApiKeyRepository.hash_key` and we store only the hash).
+            scopes: 'full' (user-equivalent, default) or 'read' (dashboards
+                only — rejected on every write/admin route).
 
         Returns:
             Created row as dict (without the raw key — caller is responsible
@@ -67,15 +84,15 @@ class ApiKeyRepository(BaseRepository):
             api_key_id = execute_insert(
                 cursor,
                 """
-                INSERT INTO api_keys (user_id, name, key_hash, key_prefix)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO api_keys (user_id, name, key_hash, key_prefix, scopes)
+                VALUES (?, ?, ?, ?, ?)
                 """,
-                (user_id, name, key_hash, key_prefix),
+                (user_id, name, key_hash, key_prefix, scopes),
             )
 
             cursor.execute(
                 convert_query("""
-                    SELECT id, user_id, name, key_prefix, created_at,
+                    SELECT id, user_id, name, key_prefix, scopes, created_at,
                            last_used_at, revoked_at
                     FROM api_keys
                     WHERE id = ?
@@ -111,7 +128,7 @@ class ApiKeyRepository(BaseRepository):
         """
         return BaseRepository._fetchone(
             """
-            SELECT id, user_id, name, key_prefix, created_at,
+            SELECT id, user_id, name, key_prefix, scopes, created_at,
                    last_used_at, revoked_at
             FROM api_keys
             WHERE key_hash = ? AND revoked_at IS NULL

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -290,12 +290,20 @@ class WhoopRepository:
             )
 
     @staticmethod
-    def end_whoop_session(session_id: int, ended_at: str) -> None:
-        """Close an open session by stamping its `ended_at` (ISO8601)."""
-        BaseRepository._execute(
-            convert_query("UPDATE whoop_sessions SET ended_at = ? WHERE id = ?"),
-            (ended_at, session_id),
+    def end_whoop_session(session_id: int, ended_at: str, user_id: int) -> bool:
+        """Close an open session by stamping its `ended_at` (ISO8601).
+
+        Scoped to the owning `user_id` so a key holder cannot close another
+        user's session by guessing its id (cross-user IDOR). Returns True iff a
+        row was updated, letting the route 404 on a missing/foreign session.
+        """
+        cursor = BaseRepository._execute(
+            convert_query(
+                "UPDATE whoop_sessions SET ended_at = ? WHERE id = ? AND user_id = ?"
+            ),
+            (ended_at, session_id, user_id),
         )
+        return bool(cursor.rowcount and cursor.rowcount > 0)
 
     @staticmethod
     def list_whoop_sessions(user_id: int, limit: int = 10) -> list[dict]:

--- a/tests/test_whoop_sessions.py
+++ b/tests/test_whoop_sessions.py
@@ -48,7 +48,12 @@ class TestWhoopSessionRepo:
         sid = WhoopRepository.create_whoop_session(uid, "CrossFit", _iso(_BASE))
         assert WhoopRepository.list_whoop_sessions(uid)[0]["ended_at"] is None
 
-        WhoopRepository.end_whoop_session(sid, _iso(_BASE + timedelta(minutes=45)))
+        assert (
+            WhoopRepository.end_whoop_session(
+                sid, _iso(_BASE + timedelta(minutes=45)), uid
+            )
+            is True
+        )
         assert WhoopRepository.list_whoop_sessions(uid)[0]["ended_at"] is not None
 
     def test_list_is_most_recent_first(self, test_user):

--- a/tests/test_whoop_wave0_security.py
+++ b/tests/test_whoop_wave0_security.py
@@ -1,0 +1,136 @@
+"""Wave 0 security regression tests for the WHOOP platform.
+
+Covers the fixes from the 2026-07-09 Bitter-Lesson audit:
+  - IDOR: PATCH /whoop/session/{id}/end is scoped to the owning user
+  - Read-only 'rf_vk_' API keys are rejected on every write/admin route
+    but accepted on reads and on the bookmarkable dashboard URLs
+  - The dead WHOOP-cloud webhook is not registered by default
+
+Requires PostgreSQL (see conftest). These run in CI where DATABASE_URL is set.
+"""
+
+from rivaflow.core.auth import create_access_token
+from rivaflow.db.repositories.api_key_repo import ApiKeyRepository
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+
+def _headers_for(user_id: int) -> dict:
+    return {
+        "Authorization": f"Bearer {create_access_token(data={'sub': str(user_id)})}"
+    }
+
+
+def _mint_key(client, auth_headers, *, read_only: bool) -> str:
+    resp = client.post(
+        "/api/v1/users/me/api-keys",
+        headers=auth_headers,
+        json={"name": "view" if read_only else "full", "read_only": read_only},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["raw_key"]
+
+
+class TestSessionEndIDOR:
+    def test_cannot_end_another_users_session(
+        self, client, test_user, test_user2, auth_headers
+    ):
+        # user A (auth_headers == test_user) opens a session
+        created = client.post(
+            "/api/v1/whoop/session",
+            headers=auth_headers,
+            json={"activity": "bjj", "started_at": "2026-07-09T12:00:00+10:00"},
+        )
+        assert created.status_code == 200, created.text
+        session_id = created.json()["id"]
+
+        # user B tries to close it → 404, and the row must be untouched
+        attack = client.patch(
+            f"/api/v1/whoop/session/{session_id}/end",
+            headers=_headers_for(test_user2["id"]),
+            json={"ended_at": "2026-07-09T13:00:00+10:00"},
+        )
+        assert attack.status_code == 404, attack.text
+        rows = WhoopRepository.list_whoop_sessions(test_user["id"])
+        assert (
+            rows[0]["ended_at"] is None
+        ), "session must remain open after IDOR attempt"
+
+        # the owner can close it
+        ok = client.patch(
+            f"/api/v1/whoop/session/{session_id}/end",
+            headers=auth_headers,
+            json={"ended_at": "2026-07-09T13:00:00+10:00"},
+        )
+        assert ok.status_code == 200, ok.text
+
+
+class TestReadOnlyKeyScope:
+    def test_read_only_key_has_view_prefix_and_scope(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=True)
+        assert raw.startswith("rf_vk_"), raw[:8]
+        row = ApiKeyRepository.get_active_by_hash(ApiKeyRepository.hash_key(raw))
+        assert row["scopes"] == "read"
+
+    def test_read_only_key_can_read(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=True)
+        resp = client.get(
+            "/api/v1/whoop/summary", headers={"Authorization": f"Bearer {raw}"}
+        )
+        # Authenticated + not scope-blocked (data may be empty, but never 401/403).
+        assert resp.status_code not in (401, 403), resp.text
+
+    def test_read_only_key_rejected_on_ingest(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=True)
+        resp = client.post(
+            "/api/v1/whoop/ingest",
+            headers={"Authorization": f"Bearer {raw}"},
+            json={},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_only_key_rejected_on_session_create(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=True)
+        resp = client.post(
+            "/api/v1/whoop/session",
+            headers={"Authorization": f"Bearer {raw}"},
+            json={"activity": "bjj", "started_at": "2026-07-09T12:00:00+10:00"},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_only_key_cannot_mint_keys(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=True)
+        resp = client.post(
+            "/api/v1/users/me/api-keys",
+            headers={"Authorization": f"Bearer {raw}"},
+            json={"name": "escalate"},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_full_key_can_write(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=False)
+        assert raw.startswith("rf_pk_")
+        resp = client.post(
+            "/api/v1/whoop/ingest",
+            headers={"Authorization": f"Bearer {raw}"},
+            json={},
+        )
+        assert resp.status_code != 403, resp.text
+
+
+class TestDashboardAcceptsViewKey:
+    def test_cockpit_accepts_read_only_key(self, client, auth_headers):
+        raw = _mint_key(client, auth_headers, read_only=True)
+        resp = client.get("/api/v1/whoop/cockpit", params={"key": raw})
+        assert resp.status_code != 401, resp.text
+
+    def test_cockpit_rejects_bogus_key(self, client):
+        resp = client.get("/api/v1/whoop/cockpit", params={"key": "rf_vk_bogus"})
+        assert resp.status_code == 401
+
+
+class TestDeadWebhookGated:
+    def test_whoop_webhook_404s_when_integration_disabled(self, client):
+        # Default ENABLE_WHOOP_INTEGRATION=false → the dead-era webhook 404s and
+        # exposes no unauthenticated surface.
+        resp = client.post("/api/v1/webhooks/whoop", json={})
+        assert resp.status_code == 404, resp.text


### PR DESCRIPTION
Bitter-Lesson audit **Wave 0** (2026-07-09). Closes the two live security holes plus hardening. **Non-breaking** — existing \`rf_pk_\` keys keep working (migration defaults them to \`full\`).

## Fixes
- **P0 key-in-URL** — new \`api_keys.scopes\` column (migration 114, defaults \`full\` → no lockout). Mint read-only \`rf_vk_\` view keys (\`read_only=true\`) for the bookmarkable \`/view\`+\`/cockpit\` URLs; \`require_write_scope\` rejects them (403) on ingest / tag / session / key mint+revoke. A leaked dashboard URL can no longer forge writes.
- **P1 IDOR** — \`end_whoop_session\` scoped to \`user_id\` → 404 on a foreign/missing session.
- **Dead webhook** — self-gates on \`ENABLE_WHOOP_INTEGRATION\` (default false → 404); no unauthenticated surface by default.
- **Rate limits** — 120/min \`/ingest\`, 30/min session routes; client-IP resolver trusts \`CF-Connecting-IP\` (Cloudflare tunnel) instead of the stale rightmost-XFF Render assumption.

## Verification
Local: ruff clean, all modules import, slowapi limits attach to ingest/session, migration 114 backfills existing keys to \`full\`, write-scope guard unit-checked. Postgres-backed suite \`tests/test_whoop_wave0_security.py\` runs in CI.

## Post-merge (manual)
Mint a read-only key — \`POST /api/v1/users/me/api-keys {"name":"cockpit","read_only":true}\` — and point dashboard bookmarks at it. Goose cockpit-link swap (finding B1) lands in a later goose wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)