### PR TITLE
refactor(whoop): Wave 1b — point grapple coaching at raw-derived biometrics (F2)

### DIFF
--- a/rivaflow/rivaflow/core/services/grapple/ai_insight_service.py
+++ b/rivaflow/rivaflow/core/services/grapple/ai_insight_service.py
@@ -176,38 +176,30 @@ async def generate_post_session_insight(user_id: int, session_id: int) -> dict |
     except Exception:
         pass
 
-    # Enrich with WHOOP recovery for session date
+    # Enrich with WHOOP recovery for the session date (raw-derived).
+    # recovery_score is a today rollup, so it enriches a same-day session; the
+    # legacy workout-cache (frozen archive) still carries strain for old sessions.
     try:
-        from rivaflow.db.repositories.whoop_connection_repo import (
-            WhoopConnectionRepository,
-        )
-        from rivaflow.db.repositories.whoop_recovery_cache_repo import (
-            WhoopRecoveryCacheRepository,
-        )
+        from rivaflow.core.services import whoop_biometrics
         from rivaflow.db.repositories.whoop_workout_cache_repo import (
             WhoopWorkoutCacheRepository,
         )
 
-        conn = WhoopConnectionRepository.get_by_user_id(user_id)
-        if conn and conn.get("is_active"):
-            s_date = session.get("session_date", "")
-            if s_date:
-                d = str(s_date)
-                recs = WhoopRecoveryCacheRepository.get_by_date_range(
-                    user_id, d, d + "T23:59:59"
-                )
-                if recs:
-                    rec = recs[-1]
-                    rs = rec.get("recovery_score")
-                    hv = rec.get("hrv_ms")
-                    if rs is not None:
-                        context += f"WHOOP Recovery: {rs:.0f}%"
-                        if hv is not None:
-                            context += f", HRV: {hv:.0f}ms"
-                        wo = WhoopWorkoutCacheRepository.get_by_session_id(session_id)
-                        if wo and wo.get("strain") is not None:
-                            context += f", Session Strain: {wo['strain']}"
-                        context += ". "
+        s_date = str(session.get("session_date", ""))[:10]
+        if s_date:
+            recs = whoop_biometrics.recovery_series(user_id, days=30)
+            rec = next((r for r in recs if str(r.get("date", ""))[:10] == s_date), None)
+            if rec:
+                rs = rec.get("recovery_score")
+                hv = rec.get("hrv_ms")
+                if rs is not None:
+                    context += f"WHOOP Recovery: {rs:.0f}%"
+                    if hv is not None:
+                        context += f", HRV: {hv:.0f}ms"
+                    wo = WhoopWorkoutCacheRepository.get_by_session_id(session_id)
+                    if wo and wo.get("strain") is not None:
+                        context += f", Session Strain: {wo['strain']}"
+                    context += ". "
     except Exception:
         pass
 
@@ -294,50 +286,34 @@ async def generate_weekly_insight(
         )
         summary_lines.append(line)
 
-    # Enrich with WHOOP weekly averages
+    # Enrich with WHOOP weekly averages (raw-derived)
     whoop_line = ""
     try:
-        from datetime import date as date_cls
-        from datetime import timedelta
+        from rivaflow.core.services import whoop_biometrics
 
-        from rivaflow.db.repositories.whoop_connection_repo import (
-            WhoopConnectionRepository,
-        )
-        from rivaflow.db.repositories.whoop_recovery_cache_repo import (
-            WhoopRecoveryCacheRepository,
-        )
-
-        conn = WhoopConnectionRepository.get_by_user_id(user_id)
-        if conn and conn.get("is_active"):
-            end_dt = date_cls.today().isoformat() + "T23:59:59"
-            start_dt = (date_cls.today() - timedelta(days=7)).isoformat()
-            recs = WhoopRecoveryCacheRepository.get_by_date_range(
-                user_id, start_dt, end_dt
-            )
-            if recs:
-                rec_vals = [
-                    r["recovery_score"]
-                    for r in recs
-                    if r.get("recovery_score") is not None
-                ]
-                hrv_vals = [r["hrv_ms"] for r in recs if r.get("hrv_ms") is not None]
-                sleep_vals = [
-                    r["sleep_performance"]
-                    for r in recs
-                    if r.get("sleep_performance") is not None
-                ]
-                parts = []
-                if rec_vals:
-                    avg_r = sum(rec_vals) / len(rec_vals)
-                    parts.append(f"avg recovery {avg_r:.0f}%")
-                if hrv_vals:
-                    avg_h = sum(hrv_vals) / len(hrv_vals)
-                    parts.append(f"avg HRV {avg_h:.0f}ms")
-                if sleep_vals:
-                    avg_s = sum(sleep_vals) / len(sleep_vals)
-                    parts.append(f"avg sleep {avg_s:.0f}%")
-                if parts:
-                    whoop_line = "WHOOP Weekly: " + ", ".join(parts)
+        recs = whoop_biometrics.recovery_series(user_id, days=7)
+        if recs:
+            rec_vals = [
+                r["recovery_score"] for r in recs if r.get("recovery_score") is not None
+            ]
+            hrv_vals = [r["hrv_ms"] for r in recs if r.get("hrv_ms") is not None]
+            sleep_vals = [
+                r["sleep_performance"]
+                for r in recs
+                if r.get("sleep_performance") is not None
+            ]
+            parts = []
+            if rec_vals:
+                avg_r = sum(rec_vals) / len(rec_vals)
+                parts.append(f"avg recovery {avg_r:.0f}%")
+            if hrv_vals:
+                avg_h = sum(hrv_vals) / len(hrv_vals)
+                parts.append(f"avg HRV {avg_h:.0f}ms")
+            if sleep_vals:
+                avg_s = sum(sleep_vals) / len(sleep_vals)
+                parts.append(f"avg sleep {avg_s:.0f}%")
+            if parts:
+                whoop_line = "WHOOP Weekly: " + ", ".join(parts)
     except Exception:
         pass
 
@@ -359,6 +335,9 @@ async def generate_weekly_insight(
 
     # Enrich with check-in data
     try:
+        from datetime import date as date_cls
+        from datetime import timedelta
+
         checkin_repo = CheckinRepository()
         end_d = date_cls.today()
         start_d = end_d - timedelta(days=7)

--- a/rivaflow/rivaflow/core/services/grapple/context_builder.py
+++ b/rivaflow/rivaflow/core/services/grapple/context_builder.py
@@ -933,23 +933,10 @@ Athlete competes under NAGA (North American Grappling Association) rules:
         return "\n".join(parts)
 
     def _build_whoop_context(self) -> str:
-        """Build WHOOP recovery context if user has an active connection."""
-        from rivaflow.db.repositories.whoop_connection_repo import (
-            WhoopConnectionRepository,
-        )
-        from rivaflow.db.repositories.whoop_recovery_cache_repo import (
-            WhoopRecoveryCacheRepository,
-        )
+        """Build WHOOP recovery context from the raw-derived biometrics seam."""
+        from rivaflow.core.services import whoop_biometrics
 
-        conn = WhoopConnectionRepository.get_by_user_id(self.user_id)
-        if not conn or not conn.get("is_active"):
-            return ""
-
-        end_dt = date.today().isoformat() + "T23:59:59"
-        start_dt = (date.today() - timedelta(days=7)).isoformat()
-        records = WhoopRecoveryCacheRepository.get_by_date_range(
-            self.user_id, start_dt, end_dt
-        )
+        records = whoop_biometrics.recovery_series(self.user_id, days=7)
         if not records:
             return ""
 

--- a/rivaflow/rivaflow/core/services/insights_summary.py
+++ b/rivaflow/rivaflow/core/services/insights_summary.py
@@ -93,49 +93,38 @@ def compute_overtraining_risk(
     recovery_decline_risk = 0
 
     try:
-        from rivaflow.db.repositories.whoop_connection_repo import (
-            WhoopConnectionRepository,
-        )
-        from rivaflow.db.repositories.whoop_recovery_cache_repo import (
-            WhoopRecoveryCacheRepository,
-        )
+        from rivaflow.core.services import whoop_biometrics
 
-        conn = WhoopConnectionRepository.get_by_user_id(user_id)
-        if conn and conn.get("is_active"):
-            end_dt = end.isoformat() + "T23:59:59"
-            start_dt = start_14d.isoformat()
-            recs = WhoopRecoveryCacheRepository.get_by_date_range(
-                user_id, start_dt, end_dt
-            )
+        recs = whoop_biometrics.recovery_series(user_id, days=14)
 
-            # HRV decline: slope over 14-day HRV values
-            hrv_values = [r["hrv_ms"] for r in recs if r.get("hrv_ms") is not None]
-            if len(hrv_values) >= 3:
-                hrv_slope = _linear_slope(hrv_values)
-                if hrv_slope < -1.0:
-                    hrv_risk = 15
-                elif hrv_slope < -0.5:
-                    hrv_risk = 10
-                elif hrv_slope < 0:
-                    hrv_risk = 3
+        # HRV decline: slope over 14-day HRV values
+        hrv_values = [r["hrv_ms"] for r in recs if r.get("hrv_ms") is not None]
+        if len(hrv_values) >= 3:
+            hrv_slope = _linear_slope(hrv_values)
+            if hrv_slope < -1.0:
+                hrv_risk = 15
+            elif hrv_slope < -0.5:
+                hrv_risk = 10
+            elif hrv_slope < 0:
+                hrv_risk = 3
 
-            # Recovery decline: consecutive days with recovery < 34%
-            consecutive_red = 0
-            max_consecutive = 0
-            for r in recs:
-                rs = r.get("recovery_score")
-                if rs is not None and rs < 34:
-                    consecutive_red += 1
-                    max_consecutive = max(max_consecutive, consecutive_red)
-                else:
-                    consecutive_red = 0
+        # Recovery decline: consecutive days with recovery < 34%
+        consecutive_red = 0
+        max_consecutive = 0
+        for r in recs:
+            rs = r.get("recovery_score")
+            if rs is not None and rs < 34:
+                consecutive_red += 1
+                max_consecutive = max(max_consecutive, consecutive_red)
+            else:
+                consecutive_red = 0
 
-            if max_consecutive >= 3:
-                recovery_decline_risk = 15
-            elif max_consecutive >= 2:
-                recovery_decline_risk = 10
-            elif max_consecutive >= 1:
-                recovery_decline_risk = 5
+        if max_consecutive >= 3:
+            recovery_decline_risk = 15
+        elif max_consecutive >= 2:
+            recovery_decline_risk = 10
+        elif max_consecutive >= 1:
+            recovery_decline_risk = 5
     except Exception:
         pass
 

--- a/rivaflow/rivaflow/core/services/suggestion_engine.py
+++ b/rivaflow/rivaflow/core/services/suggestion_engine.py
@@ -135,55 +135,42 @@ class SuggestionEngine:
         except Exception:
             logger.debug("Gym timetable enrichment skipped", exc_info=True)
 
-        # Enrich readiness with WHOOP recovery data if available
+        # Enrich readiness with WHOOP recovery data (raw-derived) if available
         try:
-            from rivaflow.db.repositories.whoop_connection_repo import (
-                WhoopConnectionRepository,
-            )
-            from rivaflow.db.repositories.whoop_recovery_cache_repo import (
-                WhoopRecoveryCacheRepository,
-            )
+            from rivaflow.core.services import whoop_biometrics
 
-            conn_repo = WhoopConnectionRepository()
-            whoop_conn = conn_repo.get_by_user_id(user_id)
-            if whoop_conn and whoop_conn.get("is_active"):
-                recovery_repo = WhoopRecoveryCacheRepository()
-                latest_rec = recovery_repo.get_latest(user_id)
-                if latest_rec and readiness:
-                    readiness["whoop_recovery_score"] = latest_rec.get("recovery_score")
-                    readiness["hrv_ms"] = latest_rec.get("hrv_ms")
+            recent = whoop_biometrics.recovery_series(user_id, days=7)
+            latest_rec = recent[-1] if recent else None
+            if latest_rec and readiness:
+                readiness["whoop_recovery_score"] = latest_rec.get("recovery_score")
+                readiness["hrv_ms"] = latest_rec.get("hrv_ms")
 
-                # Calculate HRV drop percentage
-                if latest_rec and latest_rec.get("hrv_ms"):
-                    week_ago = (date.today() - timedelta(days=7)).isoformat()
-                    today_str = date.today().isoformat() + "T23:59:59"
-                    recent = recovery_repo.get_by_date_range(
-                        user_id, week_ago, today_str
-                    )
-                    hrv_values = [
-                        r["hrv_ms"] for r in recent if r.get("hrv_ms") is not None
-                    ]
-                    if len(hrv_values) >= 2:
-                        avg_hrv = statistics.mean(hrv_values)
-                        if avg_hrv > 0:
-                            drop_pct = round(
-                                ((avg_hrv - latest_rec["hrv_ms"]) / avg_hrv) * 100,
-                                1,
-                            )
-                            if drop_pct > 0:
-                                session_context["hrv_drop_pct"] = drop_pct
-
-                    # Compute sustained HRV slope for 5+ day rule
-                    if len(hrv_values) >= 5:
-                        session_context["hrv_slope_5d"] = round(
-                            _linear_slope(hrv_values), 4
+            # Calculate HRV drop percentage
+            if latest_rec and latest_rec.get("hrv_ms"):
+                hrv_values = [
+                    r["hrv_ms"] for r in recent if r.get("hrv_ms") is not None
+                ]
+                if len(hrv_values) >= 2:
+                    avg_hrv = statistics.mean(hrv_values)
+                    if avg_hrv > 0:
+                        drop_pct = round(
+                            ((avg_hrv - latest_rec["hrv_ms"]) / avg_hrv) * 100,
+                            1,
                         )
+                        if drop_pct > 0:
+                            session_context["hrv_drop_pct"] = drop_pct
 
-                # Sleep debt from latest recovery record
-                if latest_rec and latest_rec.get("sleep_debt_ms") is not None:
-                    session_context["sleep_debt_min"] = round(
-                        latest_rec["sleep_debt_ms"] / 60_000
+                # Compute sustained HRV slope for 5+ day rule
+                if len(hrv_values) >= 5:
+                    session_context["hrv_slope_5d"] = round(
+                        _linear_slope(hrv_values), 4
                     )
+
+            # Sleep debt from latest recovery record
+            if latest_rec and latest_rec.get("sleep_debt_ms") is not None:
+                session_context["sleep_debt_min"] = round(
+                    latest_rec["sleep_debt_ms"] / 60_000
+                )
         except Exception:
             logger.debug("WHOOP context enrichment skipped", exc_info=True)
 

--- a/rivaflow/rivaflow/core/services/whoop_biometrics.py
+++ b/rivaflow/rivaflow/core/services/whoop_biometrics.py
@@ -1,0 +1,89 @@
+"""Raw-derived biometrics provider — the single seam that replaced the
+cancelled WHOOP-cloud recovery cache (Bitter-Lesson audit, Wave 1b).
+
+Grapple coaching, suggestions and insights used to read recovery/HRV from
+`whoop_recovery_cache` — a cloud-API table that went static when Ruby cancelled
+the WHOOP subscription, gated behind a `whoop_connections` row that no longer
+matches the live BLE user, so every consumer silently returned empty.
+
+They now read from here instead: recent recovery/HRV/resting-HR/sleep derived
+from the raw HR+RR the phone streams to `/whoop/ingest`, via the self-hosted
+`whoop_analytics` engine. Records keep the old cache shape so consumers need
+only swap the source and drop the dead connection gate.
+
+Honest ceiling: `spo2`, `rem_sleep_ms`, `slow_wave_ms` stay `None` — they need
+the un-cracked R22/K21 decode. Consumers already skip `None` fields.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rivaflow.core import whoop_analytics
+
+logger = logging.getLogger(__name__)
+
+# Fields a consumer may read off a record but which we cannot derive from HR+RR.
+_LOCKED_FIELDS = {"spo2": None, "rem_sleep_ms": None, "slow_wave_ms": None}
+
+
+def recovery_series(user_id: int, days: int = 7) -> list[dict]:
+    """Recent per-day recovery records, oldest→newest, in the recovery-cache shape.
+
+    Each record carries `date`, `hrv_ms`, `resting_hr` (raw-derived per day) plus
+    the locked fields as `None`. The most recent record additionally carries the
+    full readiness snapshot — `recovery_score` (today's readiness score),
+    `sleep_performance`, `sleep_duration_ms` — since those are a today rollup.
+
+    Returns `[]` when there is not enough raw data yet (consumers treat an empty
+    series exactly as they treated an empty cache).
+    """
+    rmssd_days = whoop_analytics.daily_resting_rmssd(user_id, days=days)
+    rhr_by_day = {
+        r["day"]: r.get("resting_hr")
+        for r in whoop_analytics.daily_resting_hr(user_id, days=days)
+    }
+
+    records: list[dict] = []
+    for r in rmssd_days:
+        records.append(
+            {
+                "date": r.get("day"),
+                "recovery_score": None,
+                "hrv_ms": r.get("rmssd"),
+                "resting_hr": rhr_by_day.get(r.get("day")),
+                "sleep_performance": None,
+                "sleep_duration_ms": None,
+                **_LOCKED_FIELDS,
+            }
+        )
+
+    if not records:
+        return records
+
+    # Attach today's readiness snapshot to the newest record.
+    latest = records[-1]
+    summary = whoop_analytics.whoop_summary(user_id)
+    readiness = summary.get("readiness") or {}
+    latest["recovery_score"] = readiness.get("score")
+
+    hrv_today = summary.get("hrv_today") or {}
+    if latest["hrv_ms"] is None:
+        latest["hrv_ms"] = hrv_today.get("rmssd")
+    rhr_today = summary.get("resting_hr_today") or {}
+    if latest["resting_hr"] is None:
+        latest["resting_hr"] = rhr_today.get("resting_hr")
+
+    sleep = summary.get("sleep") or {}
+    dur_h = sleep.get("duration_hours")
+    if dur_h is not None:
+        latest["sleep_duration_ms"] = round(dur_h * 3_600_000)
+        latest["sleep_performance"] = sleep.get("quality_score")
+
+    return records
+
+
+def latest_recovery(user_id: int) -> dict | None:
+    """The most recent recovery record, or None when there is no raw data yet."""
+    series = recovery_series(user_id, days=7)
+    return series[-1] if series else None

--- a/tests/test_grapple_context_whoop.py
+++ b/tests/test_grapple_context_whoop.py
@@ -1,7 +1,14 @@
-"""Tests for WHOOP recovery context in Grapple AI Coach."""
+"""Tests for WHOOP recovery context in the Grapple AI Coach.
+
+Wave 1b: the coach reads recovery from the raw-derived `whoop_biometrics` seam
+(not the retired WHOOP-cloud cache), so these mock `recovery_series`. The
+records `_make_recovery` produces match that seam's output shape.
+"""
 
 from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
+
+_SERIES = "rivaflow.core.services.whoop_biometrics.recovery_series"
 
 
 def _make_recovery(
@@ -9,16 +16,17 @@ def _make_recovery(
     recovery_score=72,
     hrv_ms=45,
     resting_hr=52,
-    spo2=97,
+    spo2=None,
     sleep_performance=85,
     sleep_duration_ms=25_920_000,
-    rem_sleep_ms=5_961_600,
-    slow_wave_ms=4_924_800,
-    sleep_debt_ms=2_520_000,
+    rem_sleep_ms=None,
+    slow_wave_ms=None,
+    sleep_debt_ms=None,
 ):
-    """Create a fake recovery cache record."""
+    """A recovery record in the whoop_biometrics.recovery_series shape."""
     d = date.today() - timedelta(days=day_offset)
     return {
+        "date": d.isoformat(),
         "recovery_score": recovery_score,
         "hrv_ms": hrv_ms,
         "resting_hr": resting_hr,
@@ -28,23 +36,17 @@ def _make_recovery(
         "rem_sleep_ms": rem_sleep_ms,
         "slow_wave_ms": slow_wave_ms,
         "sleep_debt_ms": sleep_debt_ms,
-        "cycle_start": d.isoformat(),
     }
 
 
-@patch(
-    "rivaflow.db.repositories.whoop_recovery_cache_repo" ".WhoopRecoveryCacheRepository"
-)
-@patch("rivaflow.db.repositories.whoop_connection_repo" ".WhoopConnectionRepository")
-def test_whoop_context_with_data(mock_conn_repo, mock_rec_repo):
-    """WHOOP section appears when user has active connection + data."""
+@patch(_SERIES)
+def test_whoop_context_with_data(mock_series):
+    """WHOOP section appears when the seam returns recent recovery data."""
     from rivaflow.core.services.grapple.context_builder import (
         GrappleContextBuilder,
     )
 
-    mock_conn_repo.get_by_user_id.return_value = {"is_active": True}
-    records = [_make_recovery(day_offset=i) for i in range(6, -1, -1)]
-    mock_rec_repo.get_by_date_range.return_value = records
+    mock_series.return_value = [_make_recovery(day_offset=i) for i in range(6, -1, -1)]
 
     builder = GrappleContextBuilder.__new__(GrappleContextBuilder)
     builder.user_id = 1
@@ -58,14 +60,14 @@ def test_whoop_context_with_data(mock_conn_repo, mock_rec_repo):
     assert "7-Day Avg Recovery:" in result
 
 
-@patch("rivaflow.db.repositories.whoop_connection_repo" ".WhoopConnectionRepository")
-def test_whoop_context_no_connection(mock_conn_repo):
-    """No crash and empty string when user has no WHOOP connection."""
+@patch(_SERIES)
+def test_whoop_context_no_data(mock_series):
+    """No crash and empty string when the seam has no data yet."""
     from rivaflow.core.services.grapple.context_builder import (
         GrappleContextBuilder,
     )
 
-    mock_conn_repo.get_by_user_id.return_value = None
+    mock_series.return_value = []
 
     builder = GrappleContextBuilder.__new__(GrappleContextBuilder)
     builder.user_id = 1
@@ -74,30 +76,22 @@ def test_whoop_context_no_connection(mock_conn_repo):
     assert result == ""
 
 
-@patch(
-    "rivaflow.db.repositories.whoop_recovery_cache_repo" ".WhoopRecoveryCacheRepository"
-)
-@patch("rivaflow.db.repositories.whoop_connection_repo" ".WhoopConnectionRepository")
-def test_whoop_context_partial_data(mock_conn_repo, mock_rec_repo):
+@patch(_SERIES)
+def test_whoop_context_partial_data(mock_series):
     """Handles records with some null fields gracefully."""
     from rivaflow.core.services.grapple.context_builder import (
         GrappleContextBuilder,
     )
 
-    mock_conn_repo.get_by_user_id.return_value = {"is_active": True}
-    records = [
+    mock_series.return_value = [
         _make_recovery(
             day_offset=0,
             hrv_ms=None,
             spo2=None,
             sleep_performance=None,
             sleep_duration_ms=None,
-            rem_sleep_ms=None,
-            slow_wave_ms=None,
-            sleep_debt_ms=None,
         )
     ]
-    mock_rec_repo.get_by_date_range.return_value = records
 
     builder = GrappleContextBuilder.__new__(GrappleContextBuilder)
     builder.user_id = 1
@@ -113,14 +107,7 @@ def test_whoop_context_partial_data(mock_conn_repo, mock_rec_repo):
     "rivaflow.db.repositories.whoop_workout_cache_repo"
     ".WhoopWorkoutCacheRepository.get_by_session_id"
 )
-@patch(
-    "rivaflow.db.repositories.whoop_recovery_cache_repo"
-    ".WhoopRecoveryCacheRepository.get_by_date_range"
-)
-@patch(
-    "rivaflow.db.repositories.whoop_connection_repo"
-    ".WhoopConnectionRepository.get_by_user_id"
-)
+@patch(_SERIES)
 @patch("rivaflow.core.services.grapple.ai_insight_service.GrappleLLMClient")
 @patch("rivaflow.core.services.grapple.ai_insight_service.InsightsAnalyticsService")
 @patch("rivaflow.core.services.grapple.ai_insight_service.SessionRepository")
@@ -128,11 +115,10 @@ def test_insight_includes_whoop_recovery(
     mock_sess_repo,
     mock_insights,
     mock_llm,
-    mock_conn_get,
-    mock_rec_range,
+    mock_series,
     mock_wo_get,
 ):
-    """Post-session insight prompt includes WHOOP recovery data."""
+    """Post-session insight prompt reads WHOOP recovery from the seam."""
     import asyncio
 
     from rivaflow.core.services.grapple.ai_insight_service import (
@@ -165,8 +151,9 @@ def test_insight_includes_whoop_recovery(
     }
     mock_insights.return_value = mock_insights_inst
 
-    mock_conn_get.return_value = {"is_active": True}
-    mock_rec_range.return_value = [{"recovery_score": 80, "hrv_ms": 50}]
+    mock_series.return_value = [
+        _make_recovery(day_offset=0, recovery_score=80, hrv_ms=50)
+    ]
     mock_wo_get.return_value = {"strain": 14.2}
 
     mock_llm_inst = MagicMock()
@@ -181,14 +168,10 @@ def test_insight_includes_whoop_recovery(
     mock_llm_inst.chat = _fake_chat
     mock_llm.return_value = mock_llm_inst
 
-    # Run the async function synchronously
-    # May fail due to AIInsightRepository not being mocked,
-    # but the WHOOP enrichment should not raise
     try:
         asyncio.get_event_loop().run_until_complete(generate_post_session_insight(1, 1))
     except Exception:
         pass
 
-    # Verify WHOOP repos were called
-    mock_conn_get.assert_called_once_with(1)
-    mock_rec_range.assert_called_once()
+    # The insight path read recovery from the raw-derived seam.
+    mock_series.assert_called()

--- a/tests/test_overtraining_whoop.py
+++ b/tests/test_overtraining_whoop.py
@@ -34,11 +34,8 @@ def _make_recovery(day_offset=0, recovery_score=72, hrv_ms=45):
     }
 
 
-@patch(
-    "rivaflow.db.repositories.whoop_recovery_cache_repo" ".WhoopRecoveryCacheRepository"
-)
-@patch("rivaflow.db.repositories.whoop_connection_repo" ".WhoopConnectionRepository")
-def test_hrv_decline_factor_max(mock_conn, mock_rec):
+@patch("rivaflow.core.services.whoop_biometrics.recovery_series")
+def test_hrv_decline_factor_max(mock_series):
     """Declining HRV over 14 days yields max 15 points."""
     from rivaflow.core.services.insights_analytics import (
         InsightsAnalyticsService,
@@ -54,12 +51,10 @@ def test_hrv_decline_factor_max(mock_conn, mock_rec):
         _make_session(i) for i in range(10)
     ]
 
-    mock_conn.get_by_user_id.return_value = {"is_active": True}
     # HRV steeply declining: 60, 57, 54, ... (slope ~ -2.1)
-    declining_hrv = [
+    mock_series.return_value = [
         _make_recovery(day_offset=13 - i, hrv_ms=60 - i * 3) for i in range(14)
     ]
-    mock_rec.get_by_date_range.return_value = declining_hrv
 
     # Mock training load to avoid DB calls
     svc.get_training_load_management = MagicMock(
@@ -99,11 +94,8 @@ def test_hrv_decline_no_whoop(mock_conn):
     assert result["factors"]["recovery_decline"]["score"] == 0
 
 
-@patch(
-    "rivaflow.db.repositories.whoop_recovery_cache_repo" ".WhoopRecoveryCacheRepository"
-)
-@patch("rivaflow.db.repositories.whoop_connection_repo" ".WhoopConnectionRepository")
-def test_recovery_decline_consecutive_red(mock_conn, mock_rec):
+@patch("rivaflow.core.services.whoop_biometrics.recovery_series")
+def test_recovery_decline_consecutive_red(mock_series):
     """3+ consecutive red recovery days → 15 points."""
     from rivaflow.core.services.insights_analytics import (
         InsightsAnalyticsService,
@@ -119,9 +111,8 @@ def test_recovery_decline_consecutive_red(mock_conn, mock_rec):
         _make_session(i) for i in range(10)
     ]
 
-    mock_conn.get_by_user_id.return_value = {"is_active": True}
     # 3 consecutive red days (<34%), rest normal
-    recs = [
+    mock_series.return_value = [
         _make_recovery(day_offset=13 - i, recovery_score=70, hrv_ms=50)
         for i in range(11)
     ] + [
@@ -129,7 +120,6 @@ def test_recovery_decline_consecutive_red(mock_conn, mock_rec):
         _make_recovery(day_offset=1, recovery_score=20, hrv_ms=50),
         _make_recovery(day_offset=0, recovery_score=30, hrv_ms=50),
     ]
-    mock_rec.get_by_date_range.return_value = recs
 
     svc.get_training_load_management = MagicMock(
         return_value={"current_acwr": 1.0, "current_zone": "sweet_spot"}

--- a/tests/test_whoop_biometrics.py
+++ b/tests/test_whoop_biometrics.py
@@ -1,0 +1,80 @@
+"""Unit tests for the raw-derived biometrics provider (Wave 1b).
+
+Pure logic — the underlying whoop_analytics functions are stubbed, so no DB is
+needed. Verifies the provider reconstructs the recovery-cache record shape that
+the grapple consumers expect.
+"""
+
+import pytest
+
+from rivaflow.core import whoop_analytics
+from rivaflow.core.services import whoop_biometrics
+
+
+@pytest.fixture
+def stub_analytics(monkeypatch):
+    monkeypatch.setattr(
+        whoop_analytics,
+        "daily_resting_rmssd",
+        lambda uid, days=21: [
+            {"day": "2026-07-08", "rmssd": 55.0},
+            {"day": "2026-07-09", "rmssd": 48.0},
+            {"day": "2026-07-10", "rmssd": 60.0},
+        ],
+    )
+    monkeypatch.setattr(
+        whoop_analytics,
+        "daily_resting_hr",
+        lambda uid, days=14: [
+            {"day": "2026-07-09", "resting_hr": 50},
+            {"day": "2026-07-10", "resting_hr": 49},
+        ],
+    )
+    monkeypatch.setattr(
+        whoop_analytics,
+        "whoop_summary",
+        lambda uid, today_is_sabbath=False: {
+            "readiness": {"score": 72, "state": "Balanced"},
+            "hrv_today": {"rmssd": 60.0},
+            "resting_hr_today": {"resting_hr": 49},
+            "sleep": {"duration_hours": 7.4, "quality_score": 82},
+        },
+    )
+
+
+def test_latest_record_carries_full_snapshot(stub_analytics):
+    series = whoop_biometrics.recovery_series(1, days=7)
+    assert len(series) == 3
+    latest = series[-1]
+    assert latest["date"] == "2026-07-10"
+    assert latest["recovery_score"] == 72
+    assert latest["hrv_ms"] == 60.0
+    assert latest["resting_hr"] == 49
+    assert latest["sleep_duration_ms"] == round(7.4 * 3_600_000)
+    assert latest["sleep_performance"] == 82
+
+
+def test_earlier_days_are_hrv_only(stub_analytics):
+    series = whoop_biometrics.recovery_series(1, days=7)
+    first = series[0]
+    assert first["hrv_ms"] == 55.0
+    assert first["recovery_score"] is None  # readiness is a today rollup
+    assert first["resting_hr"] is None  # no rhr series entry for that day
+
+
+def test_locked_fields_are_none(stub_analytics):
+    for r in whoop_biometrics.recovery_series(1, days=7):
+        assert r["spo2"] is None
+        assert r["rem_sleep_ms"] is None
+        assert r["slow_wave_ms"] is None
+
+
+def test_empty_when_no_raw_data(monkeypatch):
+    monkeypatch.setattr(whoop_analytics, "daily_resting_rmssd", lambda uid, days=21: [])
+    monkeypatch.setattr(whoop_analytics, "daily_resting_hr", lambda uid, days=14: [])
+    assert whoop_biometrics.recovery_series(1) == []
+    assert whoop_biometrics.latest_recovery(1) is None
+
+
+def test_latest_recovery_returns_newest(stub_analytics):
+    assert whoop_biometrics.latest_recovery(1)["date"] == "2026-07-10"


### PR DESCRIPTION
Bitter-Lesson audit **Wave 1b** (F2). The AI coach / suggestions / insights read recovery+HRV from the cancelled-subscription `whoop_recovery_cache`, gated on a `whoop_connections` row that no longer matches the live BLE user (user 4 vs 1) — so they **silently returned empty**. Now they read one raw-derived seam. **Net effect: the coach sees Ruby's real biometrics instead of nothing.**

## New
`core/services/whoop_biometrics.py` — `recovery_series()` / `latest_recovery()` return recovery-cache-shaped records (`recovery_score`, `hrv_ms`, `resting_hr`, sleep) from the self-hosted `whoop_analytics` engine (raw HR+RR). `recovery_score` is a today rollup → populates the latest day; `hrv_ms`/`resting_hr` per-day for trends. `spo2`/`rem_sleep_ms`/`slow_wave_ms` stay `None` (honest ceiling).

## Rewired (dropped the dead connection gate + cache imports)
`context_builder`, `suggestion_engine`, `insights_summary`, `ai_insight_service` (both blocks). `WhoopConnectionRepository` now has **zero readers**.

## Kept (frozen archives — next tranche)
`whoop_recovery_cache`/`whoop_workout_cache` repos + tables (still read by `whoop_analytics_engine` + `readiness_analytics`).

## Notes
- Also fixes a latent `NameError`: removing the WHOOP block's datetime imports had orphaned a downstream checkin block.
- Verified: 5 provider unit tests pass locally, ruff/black/isort clean, all consumers import. Full pg suite (incl. grapple) in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)