### PR TITLE
feat(whoop): Wave 2.5 — Readiness Scorer seam (versioned, swappable weights)

### DIFF
--- a/rivaflow/rivaflow/core/readiness.py
+++ b/rivaflow/rivaflow/core/readiness.py
@@ -40,6 +40,57 @@ GREEN_CAVEAT = (
     "I'm blind to temperature and blood oxygen, so trust your symptoms over a green light."
 )
 
+# ── Readiness scoring model — the swappable seam ──────────────────────────────
+# The weights, band cutoffs and score version are bundled into one versioned
+# model rather than frozen as bare constants welded into blend_readiness().
+# The default is the hand-tuned heuristic; a fitted/learned blend can replace it
+# at runtime via set_readiness_model() with NO change to the fusion core, and
+# every verdict carries `score_version` so a stored score is attributable to the
+# model that produced it (and re-derivable when the model changes).
+
+# (composite_z >= threshold, state, headline), highest threshold first; anything
+# below the last band falls to `rundown`.
+_HEURISTIC_BANDS: tuple[tuple[float, str, str], ...] = (
+    (0.5, "Prime", "Above your baseline — green light to train hard."),
+    (-0.5, "Balanced", "In your normal range — train as planned."),
+    (-1.5, "Strained", "Below baseline — technical/skills over hard rolls today."),
+)
+_RUNDOWN_BAND: tuple[str, str] = (
+    "Rundown",
+    "Well below baseline — prioritise recovery.",
+)
+
+
+@dataclass(frozen=True)
+class ReadinessModel:
+    """A swappable readiness scoring model: signal weights, band cutoffs and a
+    version stamp. Defaults to the HRV-led heuristic; ``set_readiness_model`` is
+    the seam a learned/refit blend plugs into without touching the fusion core.
+    """
+
+    weights: dict[str, float]
+    bands: tuple[tuple[float, str, str], ...] = _HEURISTIC_BANDS
+    rundown: tuple[str, str] = _RUNDOWN_BAND
+    version: str = "heuristic-v1"
+
+
+_DEFAULT_MODEL = ReadinessModel(weights=dict(WEIGHTS))
+_active_model = _DEFAULT_MODEL
+
+
+def get_readiness_model() -> ReadinessModel:
+    """The model ``blend_readiness`` currently scores with."""
+    return _active_model
+
+
+def set_readiness_model(model: ReadinessModel | None) -> None:
+    """Swap the active scoring model (``None`` restores the default heuristic).
+
+    The seam for a fitted/learned readiness blend — no edit to the fusion core.
+    """
+    global _active_model
+    _active_model = model or _DEFAULT_MODEL
+
 
 def zscore(values: list[float], window: int = 7) -> dict | None:
     """z-score of the latest value vs the personal baseline formed by the PRIOR `window` days.
@@ -110,29 +161,28 @@ def blend_readiness(
             "caveat": None,
         }
 
+    # The active scoring model (default heuristic; swappable for a fitted blend).
+    model = get_readiness_model()
+
     # Renormalise weights over the signals we actually have.
-    available = {k: v for k, v in signal_z.items() if v is not None and k in WEIGHTS}
-    wsum = sum(WEIGHTS[k] for k in available)
+    available = {
+        k: v for k, v in signal_z.items() if v is not None and k in model.weights
+    }
+    wsum = sum(model.weights[k] for k in available)
     contributors: list[Contributor] = []
     composite = 0.0
     for name, z in available.items():
-        w = WEIGHTS[name] / wsum
+        w = model.weights[name] / wsum
         contribution = w * z * DIRECTION[name]
         composite += contribution
         contributors.append(Contributor(name, LABELS[name], z, w, contribution))
 
     # Bands on the recovery-oriented composite z (higher = more recovered).
-    if composite >= 0.5:
-        state, head = "Prime", "Above your baseline — green light to train hard."
-    elif composite >= -0.5:
-        state, head = "Balanced", "In your normal range — train as planned."
-    elif composite >= -1.5:
-        state, head = (
-            "Strained",
-            "Below baseline — technical/skills over hard rolls today.",
-        )
-    else:
-        state, head = "Rundown", "Well below baseline — prioritise recovery."
+    state, head = model.rundown
+    for threshold, band_state, band_head in model.bands:
+        if composite >= threshold:
+            state, head = band_state, band_head
+            break
 
     contributors.sort(key=lambda c: abs(c.ready_contribution), reverse=True)
     caveat = GREEN_CAVEAT if state in ("Prime", "Balanced") else None
@@ -141,6 +191,7 @@ def blend_readiness(
         "state": state,
         "headline": head,
         "driver": "multi_input_lnrmssd_led",
+        "score_version": model.version,
         "score": max(0, min(100, round(50 + composite * 20))),
         "composite_z": round(composite, 2),
         "contributors": [c.as_dict() for c in contributors],

--- a/tests/test_readiness_scorer.py
+++ b/tests/test_readiness_scorer.py
@@ -1,0 +1,67 @@
+"""Readiness Scorer seam (Wave 2.5).
+
+The weights/bands/version live in a swappable ReadinessModel. These verify the
+default heuristic is behaviour-identical and that a fitted/learned model can be
+swapped in without touching blend_readiness. Pure functions — no DB.
+"""
+
+import pytest
+
+from rivaflow.core.readiness import (
+    ReadinessModel,
+    blend_readiness,
+    get_readiness_model,
+    set_readiness_model,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_model():
+    yield
+    set_readiness_model(None)  # never leak a swapped model into other tests
+
+
+@pytest.mark.parametrize(
+    "hrv_z,expected_state",
+    [
+        (1.0, "Prime"),
+        (0.5, "Prime"),
+        (0.0, "Balanced"),
+        (-0.5, "Balanced"),
+        (-1.0, "Strained"),
+        (-1.5, "Strained"),
+        (-2.0, "Rundown"),
+    ],
+)
+def test_default_bands_unchanged(hrv_z, expected_state):
+    assert blend_readiness({"hrv": hrv_z})["state"] == expected_state
+
+
+def test_default_stamps_heuristic_version_and_score():
+    r = blend_readiness({"hrv": 1.0})
+    assert r["score_version"] == "heuristic-v1"
+    assert r["score"] == 70  # 50 + composite(1.0) * 20
+
+
+def test_sabbath_and_cold_start_still_guard():
+    assert blend_readiness({}, today_is_sabbath=True)["state"] == "Rest"
+    assert blend_readiness({"hrv": None})["state"] == "Building"
+
+
+def test_swap_model_changes_weights_and_version():
+    set_readiness_model(
+        ReadinessModel(
+            weights={"hrv": 1.0, "rhr": 0.0, "sleep": 0.0, "resp": 0.0},
+            version="test-v2",
+        )
+    )
+    # rhr weight is now 0, so a terrible rhr z must not drag the score down.
+    r = blend_readiness({"hrv": 0.6, "rhr": -3.0})
+    assert r["score_version"] == "test-v2"
+    assert r["state"] == "Prime"  # composite 0.6 >= 0.5, rhr ignored
+
+
+def test_set_none_restores_default():
+    set_readiness_model(ReadinessModel(weights={"hrv": 1.0}, version="tmp"))
+    set_readiness_model(None)
+    assert get_readiness_model().version == "heuristic-v1"


### PR DESCRIPTION
Bitter-Lesson audit **Wave 2.5 (D2)**. The readiness weights `0.50/0.25/0.15/0.10` + band cutoffs were bare constants welded into `blend_readiness` — frozen, un-swappable, no version record.

Now a versioned **`ReadinessModel`** (weights + bands + version). Default = the hand-tuned heuristic (`heuristic-v1`); **`set_readiness_model()`** is the seam a fitted/learned blend plugs into at runtime with no change to the fusion core, and every verdict carries **`score_version`** so a stored score is attributable to (and re-derivable from) the model that produced it.

**Behaviour-identical** by construction (the default model *is* the old constants). Verified: 11 unit tests (bands unchanged at every boundary, version stamped, model swap ignores zeroed weights, restore + sabbath/cold-start guards), ruff/black/isort + mypy clean. Full pg suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)