### PR TITLE
feat(whoop): Wave 2.2 — structured cockpit snapshot (metrics JSON + version)

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -636,6 +636,27 @@ def summary(current_user: dict = Depends(get_current_user)) -> dict:
     return _cached_whoop_summary(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+@router.get("/cockpit-metrics")
+@route_error_handler("whoop_cockpit_metrics", detail="Failed to read cockpit metrics")
+def cockpit_metrics(current_user: dict = Depends(get_current_user)) -> dict:
+    """The structured metrics JSON behind the cockpit snapshot — the same data
+    the deep-dive HTML was rendered from, served instantly (one SELECT) instead
+    of the ~40s recompute. The stable contract for the phone and a future model
+    narrator layer. Returns {metrics, deriver_version, rendered_at} or nulls
+    until the first snapshot exists.
+    """
+    import json
+
+    row = WhoopRepository.get_cockpit_metrics(current_user["id"])
+    if not row or not row.get("metrics_json"):
+        return {"metrics": None, "deriver_version": None, "rendered_at": None}
+    return {
+        "metrics": json.loads(row["metrics_json"]),
+        "deriver_version": row.get("deriver_version"),
+        "rendered_at": str(row.get("rendered_at")),
+    }
+
+
 @router.get("/cockpit", response_class=HTMLResponse)
 def cockpit(key: str) -> HTMLResponse:
     """P3 — server-rendered web deep-dive cockpit (analyst panels). Zero client compute; key-auth like /view."""

--- a/rivaflow/rivaflow/core/scheduler.py
+++ b/rivaflow/rivaflow/core/scheduler.py
@@ -331,7 +331,7 @@ async def _cockpit_snapshot_job() -> None:
     if not _try_advisory_lock("cockpit_snapshot"):
         return
     try:
-        from rivaflow.core.whoop_analytics import _build_cockpit_page
+        from rivaflow.core.whoop_analytics import build_cockpit_snapshot
         from rivaflow.db.database import convert_query, get_connection
         from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
@@ -350,8 +350,10 @@ async def _cockpit_snapshot_job() -> None:
 
         for uid in user_ids:
             try:
-                html = _build_cockpit_page(uid)
-                WhoopRepository.upsert_cockpit_snapshot(uid, html)
+                html, metrics_json, deriver_version = build_cockpit_snapshot(uid)
+                WhoopRepository.upsert_cockpit_snapshot(
+                    uid, html, metrics_json, deriver_version
+                )
             except Exception:
                 logger.warning(
                     "Cockpit snapshot failed for user %d", uid, exc_info=True

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -951,6 +951,25 @@ def daily_narrative(
     return f"{body} — {guidance}."
 
 
+# Version of the structured metrics contract stored beside the cockpit HTML.
+# Bump when whoop_summary's shape changes so a stored snapshot is attributable.
+COCKPIT_DERIVER_VERSION = "whoop-summary-v1"
+
+
+def build_cockpit_snapshot(user_id: int) -> tuple[str, str, str]:
+    """Compute a full cockpit snapshot: (html, metrics_json, deriver_version).
+
+    metrics_json is the whoop_summary JSON contract — the structured data the
+    HTML was rendered from — so the phone and a future model layer can read it
+    instantly instead of re-running the ~40s recompute.
+    """
+    import json
+
+    html = _build_cockpit_page(user_id)
+    metrics = whoop_summary(user_id)
+    return html, json.dumps(metrics, default=str), COCKPIT_DERIVER_VERSION
+
+
 def cockpit_page(user_id: int) -> str:
     """Hot path for the deep-dive cockpit — serves the pre-computed snapshot the scheduler stores (one
     instant SELECT). Rendering runs ~15 multi-day analytics (~40s cold), which black-screens the browser
@@ -960,8 +979,10 @@ def cockpit_page(user_id: int) -> str:
     snap = WhoopRepository.get_cockpit_snapshot(user_id)
     if snap is not None:
         return str(snap["html"])
-    html = _build_cockpit_page(user_id)
-    WhoopRepository.upsert_cockpit_snapshot(user_id, html)
+    html, metrics_json, deriver_version = build_cockpit_snapshot(user_id)
+    WhoopRepository.upsert_cockpit_snapshot(
+        user_id, html, metrics_json, deriver_version
+    )
     return html
 
 

--- a/rivaflow/rivaflow/db/migrations/115_whoop_cockpit_metrics.sql
+++ b/rivaflow/rivaflow/db/migrations/115_whoop_cockpit_metrics.sql
@@ -1,0 +1,5 @@
+-- 115_whoop_cockpit_metrics.sql
+-- Persist the cockpit's structured metrics alongside the HTML (SQLite/test).
+-- metrics_json = the whoop_summary JSON contract, deriver_version = its version.
+ALTER TABLE whoop_cockpit_snapshot ADD COLUMN metrics_json TEXT;
+ALTER TABLE whoop_cockpit_snapshot ADD COLUMN deriver_version TEXT;

--- a/rivaflow/rivaflow/db/migrations/115_whoop_cockpit_metrics_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/115_whoop_cockpit_metrics_pg.sql
@@ -1,0 +1,8 @@
+-- 115_whoop_cockpit_metrics_pg.sql
+-- Persist the cockpit's structured metrics alongside the rendered HTML (PG).
+-- Before this the snapshot stored only HTML, so nothing could read "what the
+-- cockpit knew" as data without re-running the ~40s recompute. metrics_json is
+-- the whoop_summary JSON contract the phone and a future model layer consume,
+-- deriver_version records which analytics version produced it.
+ALTER TABLE whoop_cockpit_snapshot ADD COLUMN IF NOT EXISTS metrics_json TEXT;
+ALTER TABLE whoop_cockpit_snapshot ADD COLUMN IF NOT EXISTS deriver_version TEXT;

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -367,12 +367,37 @@ class WhoopRepository:
         )
 
     @staticmethod
-    def upsert_cockpit_snapshot(user_id: int, html: str) -> None:
-        """Store (or replace) a user's pre-computed cockpit HTML, stamping rendered_at to now."""
+    def get_cockpit_metrics(user_id: int) -> dict | None:
+        """The structured metrics JSON contract behind the snapshot, or None.
+
+        Returns {metrics_json (str), deriver_version, rendered_at}; consumers
+        json.loads the metrics_json. This is the data the cockpit rendered from,
+        readable instantly without the ~40s recompute.
+        """
+        return BaseRepository._fetchone(
+            convert_query(
+                "SELECT metrics_json, deriver_version, rendered_at "
+                "FROM whoop_cockpit_snapshot WHERE user_id = ?"
+            ),
+            (user_id,),
+        )
+
+    @staticmethod
+    def upsert_cockpit_snapshot(
+        user_id: int,
+        html: str,
+        metrics_json: str | None = None,
+        deriver_version: str | None = None,
+    ) -> None:
+        """Store (or replace) a user's pre-computed cockpit HTML + structured
+        metrics JSON, stamping rendered_at to now."""
         BaseRepository._execute(
             convert_query(
-                "INSERT INTO whoop_cockpit_snapshot (user_id, html) VALUES (?, ?) "
-                "ON CONFLICT (user_id) DO UPDATE SET html = EXCLUDED.html, rendered_at = NOW()"
+                "INSERT INTO whoop_cockpit_snapshot "
+                "(user_id, html, metrics_json, deriver_version) VALUES (?, ?, ?, ?) "
+                "ON CONFLICT (user_id) DO UPDATE SET html = EXCLUDED.html, "
+                "metrics_json = EXCLUDED.metrics_json, "
+                "deriver_version = EXCLUDED.deriver_version, rendered_at = NOW()"
             ),
-            (user_id, html),
+            (user_id, html, metrics_json, deriver_version),
         )

--- a/tests/test_whoop_cockpit_metrics.py
+++ b/tests/test_whoop_cockpit_metrics.py
@@ -1,0 +1,32 @@
+"""Wave 2.2 — structured cockpit snapshot (metrics JSON beside the HTML).
+
+build_cockpit_snapshot is stubbed off its two DB-backed dependencies, so this
+verifies the (html, metrics_json, deriver_version) contract without a DB.
+"""
+
+import json
+
+from rivaflow.core import whoop_analytics
+
+
+def test_build_cockpit_snapshot_returns_html_and_metrics_json(monkeypatch):
+    monkeypatch.setattr(
+        whoop_analytics, "_build_cockpit_page", lambda uid: "<html>ok</html>"
+    )
+    monkeypatch.setattr(
+        whoop_analytics,
+        "whoop_summary",
+        lambda uid, today_is_sabbath=False: {
+            "readiness": {"state": "Prime", "score": 87},
+            "hrv_today": {"rmssd": 50.1},
+        },
+    )
+
+    html, metrics_json, version = whoop_analytics.build_cockpit_snapshot(1)
+
+    assert html == "<html>ok</html>"
+    assert version == whoop_analytics.COCKPIT_DERIVER_VERSION == "whoop-summary-v1"
+    # metrics_json is a valid JSON string carrying the structured summary contract
+    parsed = json.loads(metrics_json)
+    assert parsed["readiness"]["score"] == 87
+    assert parsed["hrv_today"]["rmssd"] == 50.1


### PR DESCRIPTION
Bitter-Lesson audit **E3**. The cockpit snapshot stored only rendered HTML — nothing could read "what the cockpit knew" as data without the ~40s recompute, and a stored page wasn't attributable to an analytics version.

The snapshot now also persists the **structured metrics JSON** (the `whoop_summary` contract the HTML was rendered from) + a `deriver_version`:
- migration 115: `whoop_cockpit_snapshot += metrics_json, deriver_version`
- `build_cockpit_snapshot(user_id) -> (html, metrics_json, deriver_version)`; scheduler job + cold-render store both
- **`GET /api/v1/whoop/cockpit-metrics`** serves the stored JSON instantly (one SELECT) — the stable contract the phone + a future model-narrator layer read

Additive — HTML rendering + existing snapshot read unchanged. Verified: route registered, migration round-trips + preserves rows, builder unit-tested, ruff/black/isort clean. Full pg suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)