### PR TITLE
Wave 2.1 coach→VPS + Wave 2.3 NarrativeProvider seam

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -636,6 +636,58 @@ def summary(current_user: dict = Depends(get_current_user)) -> dict:
     return _cached_whoop_summary(current_user["id"], today_is_sabbath=is_sabbath)
 
 
+class CoachTurn(BaseModel):
+    """One turn of the recovery/readiness coach chat (Wave 2.1)."""
+
+    message: str = Field(..., min_length=1, max_length=2000)
+    history: list[dict] = Field(
+        default_factory=list,
+        description="Trailing conversation as [{role:'user'|'assistant', content:str}, …]",
+    )
+
+
+@router.post("/coach")
+@limiter.limit("30/minute")
+@route_error_handler("whoop_coach", detail="Failed to get coach response")
+async def coach(
+    request: Request,
+    req: CoachTurn,
+    current_user: dict = Depends(require_write_scope),
+) -> dict:
+    """WHOOP recovery & readiness coach — server-side and provider-agnostic (Wave 2.1).
+
+    Reasons over the SAME `whoop_summary` the phone renders (so answers cite the
+    numbers Ruby sees) and generates via `GrappleLLMClient` — provider + model are
+    a server config row, so swapping the model is an env edit, no app rebuild.
+    Write-scoped: a paid outbound LLM call is a side-effect, so a read-only view
+    key cannot invoke it. Rate-limited as an LLM-budget backstop.
+    """
+    from rivaflow.core.services import whoop_coach
+
+    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
+    try:
+        return await whoop_coach.answer(
+            current_user["id"],
+            req.message,
+            history=req.history,
+            today_is_sabbath=is_sabbath,
+        )
+    except RuntimeError as exc:
+        # No LLM provider configured, or every provider failed — degrade gracefully
+        # rather than 500, so the phone shows a message instead of a broken chat.
+        logger.warning("Coach unavailable for user %s: %s", current_user["id"], exc)
+        return {
+            "reply": (
+                "I can't reach the coaching model right now — your numbers are still "
+                "live on your dashboard. Try again in a moment."
+            ),
+            "provider": None,
+            "model": None,
+            "tokens": None,
+            "unavailable": True,
+        }
+
+
 @router.get("/cockpit-metrics")
 @route_error_handler("whoop_cockpit_metrics", detail="Failed to read cockpit metrics")
 def cockpit_metrics(current_user: dict = Depends(get_current_user)) -> dict:

--- a/rivaflow/rivaflow/core/services/grapple/llm_client.py
+++ b/rivaflow/rivaflow/core/services/grapple/llm_client.py
@@ -134,6 +134,139 @@ class GrappleLLMClient:
         )
         raise RuntimeError(f"All LLM providers failed: {last_error}")
 
+    def chat_sync(
+        self,
+        messages: list[dict[str, str]],
+        user_id: int,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+    ) -> dict[str, Any]:
+        """Blocking sibling of `chat` for callers already outside the request path.
+
+        The cockpit snapshot builder is sync and runs inside an async cron job
+        (already blocking on ~40s of analytics), so it cannot `await` and must
+        not spin an event loop. This keeps the SAME provider-agnostic priority
+        and config as `chat`, over `httpx.Client`.
+        """
+        if not self.providers:
+            raise RuntimeError("No LLM providers configured")
+
+        last_error = None
+        for provider in self.providers:
+            try:
+                if provider == "groq":
+                    return self._call_openai_compatible_sync(
+                        "groq",
+                        self.GROQ_API_URL,
+                        self.groq_api_key,
+                        messages,
+                        temperature,
+                        max_tokens,
+                    )
+                if provider == "together":
+                    return self._call_openai_compatible_sync(
+                        "together",
+                        self.TOGETHER_API_URL,
+                        self.together_api_key,
+                        messages,
+                        temperature,
+                        max_tokens,
+                    )
+                if provider == "ollama":
+                    return self._call_ollama_sync(messages, temperature, max_tokens)
+            except (
+                ConnectionError,
+                OSError,
+                TimeoutError,
+                RuntimeError,
+                httpx.HTTPStatusError,
+            ) as e:
+                logger.warning(
+                    f"Provider {provider} (sync) failed: {type(e).__name__}: {str(e)}"
+                )
+                last_error = e
+                continue
+
+        raise RuntimeError(f"All LLM providers failed (sync): {last_error}")
+
+    def _call_openai_compatible_sync(
+        self,
+        provider: str,
+        url: str,
+        api_key: str | None,
+        messages: list[dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        """Groq and Together both speak the OpenAI chat-completions shape."""
+        model = self.MODELS[provider]["name"]
+        with httpx.Client(timeout=30.0) as client:
+            response = client.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        content = data["choices"][0]["message"]["content"]
+        usage = data.get("usage", {})
+        input_tokens = usage.get("prompt_tokens", 0)
+        output_tokens = usage.get("completion_tokens", 0)
+        return {
+            "content": content,
+            "provider": provider,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+            "cost_usd": self._calculate_cost(provider, input_tokens, output_tokens),
+        }
+
+    def _call_ollama_sync(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        model = self.MODELS["ollama"]["name"]
+        with httpx.Client(timeout=60.0) as client:
+            response = client.post(
+                f"{self.ollama_url}/api/chat",
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {
+                        "temperature": temperature,
+                        "num_predict": max_tokens,
+                    },
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        content = data["message"]["content"]
+        input_tokens = int(sum(len(m["content"].split()) * 1.3 for m in messages))
+        output_tokens = int(len(content.split()) * 1.3)
+        return {
+            "content": content,
+            "provider": "ollama",
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+            "cost_usd": 0.0,
+        }
+
     async def _call_groq(
         self,
         messages: list[dict[str, str]],

--- a/rivaflow/rivaflow/core/services/whoop_coach.py
+++ b/rivaflow/rivaflow/core/services/whoop_coach.py
@@ -1,0 +1,176 @@
+"""WHOOP recovery & readiness coach — server-side, provider-agnostic (Wave 2.1).
+
+The Bitter-Lesson audit (H1/H2) found the phone's coach triple-hardwired to an
+*unofficial* OpenAI backend, reasoning over the DEAD on-device Extract scores —
+so it could contradict the home screen and never benefited from VPS improvements.
+
+This moves the coach's judgment to the VPS, where it belongs: context is built
+from the SAME `whoop_summary` rollup the phone renders (so the coach cites the
+numbers Ruby sees), and generation goes through `GrappleLLMClient` — provider and
+model are a server config row, so swapping the model is an env edit, no app
+rebuild. The phone becomes a dumb chat renderer.
+
+Honesty rails (audit §6 red-team): recovery/readiness guidance only, never a
+medical diagnosis, defer to professionals, green ≠ healthy, Sabbath rest is
+prescribed. The biometric ceiling is stated (no SpO₂/skin-temp/sleep-staging).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from rivaflow.core import whoop_analytics
+from rivaflow.core.services.grapple.llm_client import GrappleLLMClient
+
+logger = logging.getLogger(__name__)
+
+# Recent turns to keep for context (the phone sends the trailing conversation).
+_MAX_HISTORY_TURNS = 8
+
+COACH_SYSTEM_PROMPT = """You are Sage's recovery & readiness coach inside RivaFlow \
+— the same brain that renders Ruby's WHOOP screen. Ruby is a masters BJJ athlete \
+(blue belt, purple-belt goal) who also lifts and does conditioning. You reason \
+ONLY over the biometric context you're given, which is derived from his own \
+WHOOP 5.0 heart-rate and RR data (self-hosted — no WHOOP subscription).
+
+YOUR JOB:
+- Answer readiness / recovery / training-load questions: should I roll hard \
+today, is this a deload day, why is my HRV down, how did I sleep, am I \
+overreaching. Ground every answer in the specific numbers below.
+- Cite his ACTUAL figures (readiness state + score, HRV, resting HR, sleep, \
+respiratory rate, cardio load, strain target, ACWR) — never generic advice \
+when you have his data. If a number is missing or still building a baseline, \
+say so plainly rather than inventing it.
+- Read across signals: a resting-HR climb + HRV drop + respiratory-rate rise \
+together mean more than any one alone. Point at trends, not just today.
+- Be concise and direct (1-3 short paragraphs). Honest, supportive, calm.
+
+HONESTY RAILS (do not break these):
+- You are NOT a medical device and NOT a doctor. Never diagnose illness, \
+infection, heart conditions, or any disease. If a signal looks off, say the \
+autonomics look strained and it could be many things (sleep, stress, alcohol, \
+oncoming bug) — and to see a professional for anything concerning. Defer to \
+qualified medical professionals for any medical, injury, or safety question.
+- "Green / Prime" means his HRV is above his own baseline — it does NOT mean \
+"healthy." Don't equate a good readiness score with health.
+- On the Sabbath (Sunday, his rest day) rest is prescribed — don't push a \
+training target; frame the day as recovery.
+- Be honest about the ceiling: this platform computes HRV, resting HR, \
+readiness, sleep duration/timing, respiratory rate, cardio load and stress \
+from HR+RR. It does NOT measure SpO₂, skin temperature, blood pressure, or \
+sleep stages — never claim those.
+- Stay in the recovery/readiness/training-load lane. If asked something \
+outside it (coding, general knowledge), politely redirect to what you can help \
+with: his readiness, recovery, sleep, and training load."""
+
+
+def _fmt(value: Any, unit: str = "") -> str:
+    if value is None:
+        return "—"
+    return f"{value}{unit}"
+
+
+def build_coach_context(user_id: int, *, today_is_sabbath: bool = False) -> str:
+    """Render the `whoop_summary` rollup — the exact data the phone shows — into a
+    compact, model-readable brief. Same source as `/whoop/summary`, so the coach's
+    numbers match SlimHomeView to the minute (the Wave 2.1 sunset test)."""
+    s = whoop_analytics.whoop_summary(user_id, today_is_sabbath=today_is_sabbath)
+
+    r = s.get("readiness") or {}
+    hrv = s.get("hrv_today") or {}
+    rhr = s.get("resting_hr_today") or {}
+    sleep = s.get("sleep") or {}
+    resp = s.get("respiratory_rate") or {}
+    cardio = s.get("cardio_load_today") or {}
+    strain = s.get("strain_target") or {}
+    stress = s.get("stress") or {}
+    prevention = s.get("prevention") or {}
+
+    hrv_trend = s.get("hrv_trend") or []
+    rhr_trend = s.get("resting_hr_trend") or []
+    hrv_pts = " → ".join(str(p.get("rmssd")) for p in hrv_trend[-7:]) or "building"
+    rhr_pts = (
+        " → ".join(str(p.get("resting_hr")) for p in rhr_trend[-7:]) or "building"
+    )
+
+    sleep_line = (
+        f"{_fmt(sleep.get('duration_hours'), 'h')} "
+        f"(quality {_fmt(sleep.get('quality_score'))}/100)"
+        if sleep.get("available")
+        else f"no data ({sleep.get('reason', 'not captured')})"
+    )
+
+    lines = [
+        f"Readiness: {_fmt(r.get('state'))} "
+        f"(score {_fmt(r.get('score'))}/100) — {r.get('headline', '')}".strip(),
+        f"HRV today: {_fmt(hrv.get('rmssd'), ' ms')} (resting RMSSD); "
+        f"last 7 days: {hrv_pts}",
+        f"Resting HR today: {_fmt(rhr.get('resting_hr'), ' bpm')}; "
+        f"last 7 days: {rhr_pts}",
+        f"Sleep last night: {sleep_line} (his need is >9h)",
+        f"Respiratory rate: {_fmt(resp.get('respiratory_rate') if resp.get('available') else None, ' rpm')}",
+        f"Cardio load today: {_fmt(cardio.get('cardio_load'))}/21",
+        f"Strain target today: {_fmt(strain.get('target_load'))}/21 "
+        f"({strain.get('headline', '')})".strip(),
+        f"ACWR (acute:chronic load): {_fmt(s.get('acwr'))}",
+        f"Stress now: {_fmt(stress.get('stress') if stress.get('available') else None)}/100",
+    ]
+
+    tier = prevention.get("tier")
+    if tier in ("amber", "red"):
+        lines.append(
+            f"Baseline-deviation watch: {tier.upper()} — "
+            f"{prevention.get('headline', 'a signal has drifted from his baseline')} "
+            "(a personal safety net; it detects deviation, NEVER diagnoses)"
+        )
+
+    if today_is_sabbath:
+        lines.append("Today is the Sabbath (Sunday) — his rest day; rest is prescribed.")
+
+    return "TODAY'S BIOMETRIC CONTEXT (self-hosted WHOOP, all from HR+RR):\n" + "\n".join(
+        f"- {ln}" for ln in lines
+    )
+
+
+def _sanitize_history(history: list[dict] | None) -> list[dict[str, str]]:
+    """Keep only well-formed user/assistant turns, trailing `_MAX_HISTORY_TURNS`."""
+    if not history:
+        return []
+    clean: list[dict[str, str]] = []
+    for turn in history:
+        role = turn.get("role")
+        content = turn.get("content")
+        if role in ("user", "assistant") and isinstance(content, str) and content.strip():
+            clean.append({"role": role, "content": content})
+    return clean[-_MAX_HISTORY_TURNS:]
+
+
+async def answer(
+    user_id: int,
+    message: str,
+    *,
+    history: list[dict] | None = None,
+    today_is_sabbath: bool = False,
+) -> dict[str, Any]:
+    """Answer one coach turn over the VPS biometrics. Returns the reply plus the
+    provider/model actually used (so the phone can show provenance and so a config
+    swap is observable). Raises RuntimeError only when no LLM provider is configured
+    or all fail — the route maps that to a graceful message."""
+    context = build_coach_context(user_id, today_is_sabbath=today_is_sabbath)
+
+    messages: list[dict[str, str]] = [
+        {"role": "system", "content": COACH_SYSTEM_PROMPT},
+        {"role": "system", "content": context},
+        *_sanitize_history(history),
+        {"role": "user", "content": message},
+    ]
+
+    client = GrappleLLMClient()
+    result = await client.chat(messages, user_id=user_id, max_tokens=700)
+    return {
+        "reply": result["content"],
+        "provider": result.get("provider"),
+        "model": result.get("model"),
+        "tokens": result.get("total_tokens"),
+    }

--- a/rivaflow/rivaflow/core/services/whoop_coach.py
+++ b/rivaflow/rivaflow/core/services/whoop_coach.py
@@ -90,9 +90,7 @@ def build_coach_context(user_id: int, *, today_is_sabbath: bool = False) -> str:
     hrv_trend = s.get("hrv_trend") or []
     rhr_trend = s.get("resting_hr_trend") or []
     hrv_pts = " → ".join(str(p.get("rmssd")) for p in hrv_trend[-7:]) or "building"
-    rhr_pts = (
-        " → ".join(str(p.get("resting_hr")) for p in rhr_trend[-7:]) or "building"
-    )
+    rhr_pts = " → ".join(str(p.get("resting_hr")) for p in rhr_trend[-7:]) or "building"
 
     sleep_line = (
         f"{_fmt(sleep.get('duration_hours'), 'h')} "
@@ -126,10 +124,13 @@ def build_coach_context(user_id: int, *, today_is_sabbath: bool = False) -> str:
         )
 
     if today_is_sabbath:
-        lines.append("Today is the Sabbath (Sunday) — his rest day; rest is prescribed.")
+        lines.append(
+            "Today is the Sabbath (Sunday) — his rest day; rest is prescribed."
+        )
 
-    return "TODAY'S BIOMETRIC CONTEXT (self-hosted WHOOP, all from HR+RR):\n" + "\n".join(
-        f"- {ln}" for ln in lines
+    return (
+        "TODAY'S BIOMETRIC CONTEXT (self-hosted WHOOP, all from HR+RR):\n"
+        + "\n".join(f"- {ln}" for ln in lines)
     )
 
 
@@ -141,7 +142,11 @@ def _sanitize_history(history: list[dict] | None) -> list[dict[str, str]]:
     for turn in history:
         role = turn.get("role")
         content = turn.get("content")
-        if role in ("user", "assistant") and isinstance(content, str) and content.strip():
+        if (
+            role in ("user", "assistant")
+            and isinstance(content, str)
+            and content.strip()
+        ):
             clean.append({"role": role, "content": content})
     return clean[-_MAX_HISTORY_TURNS:]
 

--- a/rivaflow/rivaflow/core/services/whoop_narrative.py
+++ b/rivaflow/rivaflow/core/services/whoop_narrative.py
@@ -1,0 +1,179 @@
+"""NarrativeProvider seam for the WHOOP cockpit's daily data-story (Wave 2.3).
+
+The Bitter-Lesson audit (E1) found the cockpit narrative is a hand-written prose
+state machine — it can only combine four readiness states × a sleep shortfall × a
+hard workout, and can NEVER notice a three-day resting-HR climb or an ACWR spike
+even though those are computed in the same call. The violation isn't the text; it's
+that a template is the *only possible* implementation.
+
+This adds the seam. The rule-based composer (`whoop_analytics.daily_narrative`)
+stays the deterministic default — with the LLM adapter OFF, `compose_narrative`
+returns EXACTLY what it did before. With `WHOOP_NARRATIVE_LLM` on, an LLM adapter
+composes the story from the full cross-signal context at snapshot time (a handful
+of calls/day, cached in the snapshot), honesty-post-checked. ANY failure or a
+failed check falls straight back to the rule-based line — the cockpit can never
+break or over-claim because of this.
+
+Honesty rails (audit §6 red-team): the Sabbath always uses the rule-based line
+(rest is prescribed — never an LLM push); no medical diagnosis; green ≠ healthy;
+one or two sentences only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+from rivaflow.core import whoop_analytics
+from rivaflow.core.whoop_analytics import LOCAL_TZ
+
+logger = logging.getLogger(__name__)
+
+_NARRATIVE_SYSTEM_PROMPT = """You write ONE honest, one-to-two-sentence recovery \
+data-story for a masters BJJ athlete's dashboard, from his own WHOOP-derived \
+numbers. Voice: calm, direct, second person ("you"), no hype, no emoji.
+
+RULES:
+- Ground it in the actual numbers you're given. When a cross-signal is notable — \
+a multi-day resting-HR climb, an HRV trend, an ACWR spike, a respiratory-rate \
+rise — reference it; that's the point of you existing over a template.
+- End with a brief training steer that matches the readiness state (push / train \
+as planned / ease into technical work / prioritise recovery).
+- NEVER diagnose illness or any medical condition. If signals look off, say the \
+autonomics look strained and it could be many things — never name a disease.
+- A good readiness score means HRV is above his baseline; it does NOT mean \
+"healthy" — never say he's healthy.
+- Output ONLY the sentence(s). No preamble, no label, no quotes, no markdown."""
+
+# If the model emits any of these it has over-claimed (diagnosis / false health
+# reassurance) — reject and fall back to the deterministic line.
+_FORBIDDEN_SUBSTRINGS = (
+    "diagnos",
+    "infection",
+    "infected",
+    "covid",
+    "influenza",
+    " flu",
+    "virus",
+    "disease",
+    "arrhythmia",
+    "afib",
+    "a-fib",
+    "atrial fib",
+    "you're healthy",
+    "you are healthy",
+    "perfectly healthy",
+    "you're fine",  # false all-clear
+)
+
+_MAX_NARRATIVE_CHARS = 400
+
+
+def _llm_enabled() -> bool:
+    return os.getenv("WHOOP_NARRATIVE_LLM", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _is_sabbath() -> bool:
+    """Sunday is Ruby's rest day — the Sabbath narrative is prescriptive rest and
+    must never be reframed by the model."""
+    return datetime.now(LOCAL_TZ).weekday() == 6
+
+
+def _passes_honesty_checks(text: str) -> bool:
+    """Post-generation guard: length-bounded, no diagnosis, no false health all-clear."""
+    if not text or not text.strip():
+        return False
+    if len(text) > _MAX_NARRATIVE_CHARS:
+        return False
+    low = text.lower()
+    return not any(bad in low for bad in _FORBIDDEN_SUBSTRINGS)
+
+
+def _build_cross_signal_brief(
+    readiness: dict, night: dict, last_workout: dict | None, cross: dict
+) -> str:
+    """Compact, model-readable brief of the signals the template bank can't combine."""
+    hrv = cross.get("hrv_ln_trend") or []
+    rhr = cross.get("rhr_trend") or []
+    prevention = cross.get("prevention") or {}
+
+    parts = [
+        f"Readiness: {readiness.get('state')} (score {readiness.get('score')}).",
+        f"lnRMSSD last {len(hrv)}d: {[round(v, 2) for v in hrv]}" if hrv else "HRV baseline still building.",
+        f"Resting HR last {len(rhr)}d: {rhr}" if rhr else "Resting-HR trend building.",
+    ]
+    if night.get("available") and night.get("duration_hours") is not None:
+        parts.append(f"Slept {night['duration_hours']}h (need >9h).")
+    if cross.get("acwr") is not None:
+        parts.append(f"ACWR {cross['acwr']} (acute:chronic load).")
+    if cross.get("cardio_today") is not None:
+        parts.append(f"Cardio load today {cross['cardio_today']}/21.")
+    if cross.get("strain_target") is not None:
+        parts.append(f"Strain target {cross['strain_target']}/21.")
+    if last_workout:
+        parts.append(f"Last session: {last_workout.get('label', 'workout')}.")
+    tier = prevention.get("tier")
+    if tier in ("amber", "red"):
+        parts.append(
+            f"Baseline-deviation watch: {tier} — a signal has drifted from baseline "
+            "(deviation, NOT a diagnosis)."
+        )
+    return " ".join(parts)
+
+
+def compose_narrative(
+    user_id: int,
+    *,
+    readiness: dict,
+    night: dict,
+    last_workout: dict | None = None,
+    cross_signals: dict[str, Any] | None = None,
+) -> str:
+    """The cockpit narrative seam.
+
+    Returns the deterministic rule-based line (identical to before) unless the LLM
+    adapter is enabled AND it produces an honest, in-bounds story from the
+    cross-signal context. On the Sabbath, or on any error / failed honesty check,
+    the rule-based line is returned — this NEVER raises and NEVER over-claims.
+    """
+    rule_based = whoop_analytics.daily_narrative(
+        user_id, readiness=readiness, night=night, last_workout=last_workout
+    )
+
+    if not _llm_enabled():
+        return rule_based
+
+    # The Sabbath line is prescriptive rest — never let the model reframe it.
+    if _is_sabbath():
+        return rule_based
+
+    try:
+        from rivaflow.core.services.grapple.llm_client import GrappleLLMClient
+
+        brief = _build_cross_signal_brief(
+            readiness, night, last_workout, cross_signals or {}
+        )
+        messages = [
+            {"role": "system", "content": _NARRATIVE_SYSTEM_PROMPT},
+            {"role": "user", "content": brief},
+        ]
+        result = GrappleLLMClient().chat_sync(
+            messages, user_id=user_id, temperature=0.5, max_tokens=160
+        )
+        text = (result.get("content") or "").strip().strip('"')
+        if _passes_honesty_checks(text):
+            return text
+        logger.warning(
+            "WHOOP narrative LLM output failed honesty check for user %s; using rule-based",
+            user_id,
+        )
+    except Exception:  # noqa: BLE001 — any adapter failure must degrade, never break the cockpit
+        logger.warning(
+            "WHOOP narrative LLM adapter failed for user %s; using rule-based",
+            user_id,
+            exc_info=True,
+        )
+
+    return rule_based

--- a/rivaflow/rivaflow/core/services/whoop_narrative.py
+++ b/rivaflow/rivaflow/core/services/whoop_narrative.py
@@ -72,7 +72,12 @@ _MAX_NARRATIVE_CHARS = 400
 
 
 def _llm_enabled() -> bool:
-    return os.getenv("WHOOP_NARRATIVE_LLM", "").strip().lower() in ("1", "true", "yes", "on")
+    return os.getenv("WHOOP_NARRATIVE_LLM", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
 
 
 def _is_sabbath() -> bool:
@@ -101,7 +106,11 @@ def _build_cross_signal_brief(
 
     parts = [
         f"Readiness: {readiness.get('state')} (score {readiness.get('score')}).",
-        f"lnRMSSD last {len(hrv)}d: {[round(v, 2) for v in hrv]}" if hrv else "HRV baseline still building.",
+        (
+            f"lnRMSSD last {len(hrv)}d: {[round(v, 2) for v in hrv]}"
+            if hrv
+            else "HRV baseline still building."
+        ),
         f"Resting HR last {len(rhr)}d: {rhr}" if rhr else "Resting-HR trend building.",
     ]
     if night.get("available") and night.get("duration_hours") is not None:
@@ -169,7 +178,9 @@ def compose_narrative(
             "WHOOP narrative LLM output failed honesty check for user %s; using rule-based",
             user_id,
         )
-    except Exception:  # noqa: BLE001 — any adapter failure must degrade, never break the cockpit
+    except (
+        Exception
+    ):  # noqa: BLE001 — any adapter failure must degrade, never break the cockpit
         logger.warning(
             "WHOOP narrative LLM adapter failed for user %s; using rule-based",
             user_id,

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -1095,11 +1095,14 @@ def _build_cockpit_page(user_id: int) -> str:
     sessions = session_deepdives(user_id, limit=10)
     tags = sorted({t["tag"] for t in WhoopRepository.list_tags(user_id)})
 
+    cardio_series = daily_cardio_load(user_id, days=28, max_hr=mx)
+    acwr_data = training_acwr(user_id)
+    prevention = prevention_watch(user_id)
     ctx = {
         "readiness": readiness,
         "strain": strain,
-        "acwr": training_acwr(user_id),
-        "cardio": daily_cardio_load(user_id, days=28, max_hr=mx),
+        "acwr": acwr_data,
+        "cardio": cardio_series,
         "rec_cost": recovery_cost_coupling(user_id),
         "progress": _history_progress(user_id),
         "coverage": capture_coverage(user_id),
@@ -1107,7 +1110,7 @@ def _build_cockpit_page(user_id: int) -> str:
         "sleep_analysis": sleep_a,
         "sessions": sessions,
         "effects": [behaviour_for_tag(user_id, t) for t in tags],
-        "prevention": prevention_watch(user_id),
+        "prevention": prevention,
     }
 
     need_hours = sleep_a.get("debt", {}).get("need_hours", 9)
@@ -1126,7 +1129,6 @@ def _build_cockpit_page(user_id: int) -> str:
     # falls straight back to this rule-based line. See services/whoop_narrative.py.
     from rivaflow.core.services.whoop_narrative import compose_narrative
 
-    acwr_ctx = ctx["acwr"]
     narrative = compose_narrative(
         user_id,
         readiness=readiness,
@@ -1135,12 +1137,12 @@ def _build_cockpit_page(user_id: int) -> str:
         cross_signals={
             "hrv_ln_trend": trends["hrv"],
             "rhr_trend": trends["rhr"],
-            "acwr": acwr_ctx.get("ratio") if isinstance(acwr_ctx, dict) else None,
-            "cardio_today": ctx["cardio"][-1]["cardio_load"] if ctx["cardio"] else None,
-            "strain_target": strain.get("target_load")
-            if isinstance(strain, dict)
-            else None,
-            "prevention": ctx["prevention"],
+            "acwr": acwr_data.get("ratio"),
+            "cardio_today": (
+                cardio_series[-1]["cardio_load"] if cardio_series else None
+            ),
+            "strain_target": strain.get("target_load"),
+            "prevention": prevention,
         },
     )
     story = render_today_story(

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -1068,7 +1068,7 @@ def _lab_panels(user_id: int, *, ctx: dict) -> str:
             "Your recent sessions beat by beat — zones, drift, and between-round recovery.",
         ),
         (
-            render_prevention_log(prevention_log(user_id), prevention_watch(user_id)),
+            render_prevention_log(prevention_log(user_id), ctx["prevention"]),
             "A personal safety net — flags when a signal drifts from your own baseline. Never diagnoses.",
         ),
         (
@@ -1107,15 +1107,10 @@ def _build_cockpit_page(user_id: int) -> str:
         "sleep_analysis": sleep_a,
         "sessions": sessions,
         "effects": [behaviour_for_tag(user_id, t) for t in tags],
+        "prevention": prevention_watch(user_id),
     }
 
     need_hours = sleep_a.get("debt", {}).get("need_hours", 9)
-    narrative = daily_narrative(
-        user_id,
-        readiness=readiness,
-        night=night,
-        last_workout=sessions[0] if sessions else None,
-    )
     # Tier-3 — 14-day history behind the verdict (hero tap-to-expand sparklines)
     trends = {
         "hrv": [d["ln_rmssd"] for d in daily_resting_rmssd(user_id, days=14)],
@@ -1124,6 +1119,30 @@ def _build_cockpit_page(user_id: int) -> str:
             d.get("duration_hours") for d in nightly_sleep_history(user_id, nights=14)
         ],
     }
+
+    # Wave 2.3 — narrative behind a provider seam. Rule-based by default (byte-for-byte
+    # the same line as before); the optional LLM adapter composes from the cross-signals
+    # below (which the rule template bank cannot combine) and honesty-post-checks, else
+    # falls straight back to this rule-based line. See services/whoop_narrative.py.
+    from rivaflow.core.services.whoop_narrative import compose_narrative
+
+    acwr_ctx = ctx["acwr"]
+    narrative = compose_narrative(
+        user_id,
+        readiness=readiness,
+        night=night,
+        last_workout=sessions[0] if sessions else None,
+        cross_signals={
+            "hrv_ln_trend": trends["hrv"],
+            "rhr_trend": trends["rhr"],
+            "acwr": acwr_ctx.get("ratio") if isinstance(acwr_ctx, dict) else None,
+            "cardio_today": ctx["cardio"][-1]["cardio_load"] if ctx["cardio"] else None,
+            "strain_target": strain.get("target_load")
+            if isinstance(strain, dict)
+            else None,
+            "prevention": ctx["prevention"],
+        },
+    )
     story = render_today_story(
         readiness,
         narrative,

--- a/rivaflow/tests/unit/test_whoop_coach.py
+++ b/rivaflow/tests/unit/test_whoop_coach.py
@@ -14,7 +14,11 @@ import rivaflow.core.services.whoop_coach as wc
 
 SUMMARY = {
     "readiness": {"state": "Prime", "score": 87, "headline": "green light to push"},
-    "strain_target": {"available": True, "target_load": 12.0, "headline": "push to ~12"},
+    "strain_target": {
+        "available": True,
+        "target_load": 12.0,
+        "headline": "push to ~12",
+    },
     "acwr": 1.15,
     "hrv_today": {"rmssd": 57},
     "hrv_trend": [{"rmssd": 48}, {"rmssd": 52}, {"rmssd": 57}],
@@ -46,7 +50,10 @@ def test_build_coach_context_cites_real_numbers(monkeypatch):
 
 
 def test_context_marks_missing_data_honestly(monkeypatch):
-    thin = {"readiness": {"state": "Building", "score": None, "headline": ""}, "sleep": {"available": False, "reason": "strap silent"}}
+    thin = {
+        "readiness": {"state": "Building", "score": None, "headline": ""},
+        "sleep": {"available": False, "reason": "strap silent"},
+    }
     monkeypatch.setattr(
         wc.whoop_analytics, "whoop_summary", lambda uid, today_is_sabbath=False: thin
     )
@@ -64,10 +71,14 @@ def test_sabbath_line_present(monkeypatch):
 
 
 def test_sanitize_history_filters_and_trims():
-    history = [{"role": "system", "content": "junk"}] + [
-        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
-        for i in range(12)
-    ] + [{"role": "user", "content": ""}, {"role": "bogus", "content": "x"}]
+    history = (
+        [{"role": "system", "content": "junk"}]
+        + [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+            for i in range(12)
+        ]
+        + [{"role": "user", "content": ""}, {"role": "bogus", "content": "x"}]
+    )
     clean = wc._sanitize_history(history)
     assert len(clean) == wc._MAX_HISTORY_TURNS
     assert all(t["role"] in ("user", "assistant") and t["content"] for t in clean)
@@ -75,15 +86,25 @@ def test_sanitize_history_filters_and_trims():
 
 
 def test_answer_returns_reply_and_provider(monkeypatch):
-    monkeypatch.setattr(wc, "build_coach_context", lambda uid, today_is_sabbath=False: "CTX")
+    monkeypatch.setattr(
+        wc, "build_coach_context", lambda uid, today_is_sabbath=False: "CTX"
+    )
 
     class _FakeClient:
         async def chat(self, messages, user_id, **kwargs):
             # System persona + biometric context + the user turn are all present.
             roles = [m["role"] for m in messages]
             assert roles[0] == "system" and messages[1]["content"] == "CTX"
-            assert messages[-1] == {"role": "user", "content": "Should I roll hard today?"}
-            return {"content": "Your HRV's up — green light.", "provider": "groq", "model": "llama-3.3-70b-versatile", "total_tokens": 210}
+            assert messages[-1] == {
+                "role": "user",
+                "content": "Should I roll hard today?",
+            }
+            return {
+                "content": "Your HRV's up — green light.",
+                "provider": "groq",
+                "model": "llama-3.3-70b-versatile",
+                "total_tokens": 210,
+            }
 
     monkeypatch.setattr(wc, "GrappleLLMClient", lambda *a, **k: _FakeClient())
 
@@ -96,5 +117,13 @@ def test_answer_returns_reply_and_provider(monkeypatch):
 def test_no_dead_cloud_cache_reads():
     """ISC-A2 anti-criterion: the coach must not touch the retired WHOOP-cloud stack."""
     src = Path(wc.__file__).read_text()
-    for dead in ("WhoopConnectionRepository", "recovery_cache", "whoop_recovery_cache", "GooseRustBridge", "FeatureScoreSummary"):
-        assert dead not in src, f"coach must not read the dead cloud/Extract path: {dead}"
+    for dead in (
+        "WhoopConnectionRepository",
+        "recovery_cache",
+        "whoop_recovery_cache",
+        "GooseRustBridge",
+        "FeatureScoreSummary",
+    ):
+        assert (
+            dead not in src
+        ), f"coach must not read the dead cloud/Extract path: {dead}"

--- a/rivaflow/tests/unit/test_whoop_coach.py
+++ b/rivaflow/tests/unit/test_whoop_coach.py
@@ -1,0 +1,100 @@
+"""Wave 2.1 — WHOOP coach service (pure; no DB, no network).
+
+Verifies the coach reasons over the raw-derived `whoop_summary` (so it cites the
+numbers the phone shows), is provider-agnostic via GrappleLLMClient, keeps its
+honesty rails, and reads NONE of the dead WHOOP-cloud caches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import rivaflow.core.services.whoop_coach as wc
+
+SUMMARY = {
+    "readiness": {"state": "Prime", "score": 87, "headline": "green light to push"},
+    "strain_target": {"available": True, "target_load": 12.0, "headline": "push to ~12"},
+    "acwr": 1.15,
+    "hrv_today": {"rmssd": 57},
+    "hrv_trend": [{"rmssd": 48}, {"rmssd": 52}, {"rmssd": 57}],
+    "resting_hr_today": {"resting_hr": 50},
+    "resting_hr_trend": [{"resting_hr": 52}, {"resting_hr": 51}, {"resting_hr": 50}],
+    "sleep": {"available": True, "duration_hours": 7.6, "quality_score": 84},
+    "respiratory_rate": {"available": True, "respiratory_rate": 10.2},
+    "cardio_load_today": {"cardio_load": 8.5},
+    "stress": {"available": True, "stress": 12},
+    "prevention": {"tier": "amber", "headline": "resting HR drifting above baseline"},
+}
+
+
+def test_build_coach_context_cites_real_numbers(monkeypatch):
+    monkeypatch.setattr(
+        wc.whoop_analytics, "whoop_summary", lambda uid, today_is_sabbath=False: SUMMARY
+    )
+    ctx = wc.build_coach_context(1)
+    # The exact figures the phone's /summary shows must be present.
+    assert "Prime" in ctx and "87" in ctx
+    assert "57 ms" in ctx  # HRV today
+    assert "50 bpm" in ctx  # resting HR today
+    assert "7.6h" in ctx and "84" in ctx  # sleep
+    assert "10.2 rpm" in ctx  # respiratory
+    assert "12.0/21" in ctx  # strain target_load
+    assert "1.15" in ctx  # acwr
+    # Prevention amber surfaced, framed as deviation not diagnosis.
+    assert "AMBER" in ctx and "NEVER diagnoses" in ctx
+
+
+def test_context_marks_missing_data_honestly(monkeypatch):
+    thin = {"readiness": {"state": "Building", "score": None, "headline": ""}, "sleep": {"available": False, "reason": "strap silent"}}
+    monkeypatch.setattr(
+        wc.whoop_analytics, "whoop_summary", lambda uid, today_is_sabbath=False: thin
+    )
+    ctx = wc.build_coach_context(1)
+    assert "no data" in ctx and "strap silent" in ctx
+    assert "Building" in ctx
+
+
+def test_sabbath_line_present(monkeypatch):
+    monkeypatch.setattr(
+        wc.whoop_analytics, "whoop_summary", lambda uid, today_is_sabbath=False: SUMMARY
+    )
+    ctx = wc.build_coach_context(1, today_is_sabbath=True)
+    assert "Sabbath" in ctx and "rest is prescribed" in ctx
+
+
+def test_sanitize_history_filters_and_trims():
+    history = [{"role": "system", "content": "junk"}] + [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+        for i in range(12)
+    ] + [{"role": "user", "content": ""}, {"role": "bogus", "content": "x"}]
+    clean = wc._sanitize_history(history)
+    assert len(clean) == wc._MAX_HISTORY_TURNS
+    assert all(t["role"] in ("user", "assistant") and t["content"] for t in clean)
+    assert clean[-1]["content"] == "m11"  # trailing turns kept
+
+
+def test_answer_returns_reply_and_provider(monkeypatch):
+    monkeypatch.setattr(wc, "build_coach_context", lambda uid, today_is_sabbath=False: "CTX")
+
+    class _FakeClient:
+        async def chat(self, messages, user_id, **kwargs):
+            # System persona + biometric context + the user turn are all present.
+            roles = [m["role"] for m in messages]
+            assert roles[0] == "system" and messages[1]["content"] == "CTX"
+            assert messages[-1] == {"role": "user", "content": "Should I roll hard today?"}
+            return {"content": "Your HRV's up — green light.", "provider": "groq", "model": "llama-3.3-70b-versatile", "total_tokens": 210}
+
+    monkeypatch.setattr(wc, "GrappleLLMClient", lambda *a, **k: _FakeClient())
+
+    out = asyncio.run(wc.answer(1, "Should I roll hard today?"))
+    assert out["reply"] == "Your HRV's up — green light."
+    assert out["provider"] == "groq" and out["model"].startswith("llama")
+    assert out["tokens"] == 210
+
+
+def test_no_dead_cloud_cache_reads():
+    """ISC-A2 anti-criterion: the coach must not touch the retired WHOOP-cloud stack."""
+    src = Path(wc.__file__).read_text()
+    for dead in ("WhoopConnectionRepository", "recovery_cache", "whoop_recovery_cache", "GooseRustBridge", "FeatureScoreSummary"):
+        assert dead not in src, f"coach must not read the dead cloud/Extract path: {dead}"

--- a/rivaflow/tests/unit/test_whoop_narrative.py
+++ b/rivaflow/tests/unit/test_whoop_narrative.py
@@ -25,9 +25,7 @@ RULE_SENTINEL = "RULE_BASED_NARRATIVE_LINE"
 
 
 def _stub_rule_based(monkeypatch, sentinel=RULE_SENTINEL):
-    monkeypatch.setattr(
-        wn.whoop_analytics, "daily_narrative", lambda *a, **k: sentinel
-    )
+    monkeypatch.setattr(wn.whoop_analytics, "daily_narrative", lambda *a, **k: sentinel)
     return sentinel
 
 
@@ -64,7 +62,10 @@ def test_llm_enabled_uses_honest_output(monkeypatch):
     monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
     story = "Your resting HR has crept up three days running while HRV held — ease into technical work."
     _stub_client(monkeypatch, content=story)
-    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == story
+    assert (
+        wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
+        == story
+    )
 
 
 # ── ISC-B4: honesty post-checks reject over-claiming output → fallback ───────
@@ -74,16 +75,26 @@ def test_diagnosis_output_falls_back(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
     monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
-    _stub_client(monkeypatch, content="Your numbers suggest you have the flu — rest up.")
-    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+    _stub_client(
+        monkeypatch, content="Your numbers suggest you have the flu — rest up."
+    )
+    assert (
+        wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
+        == sentinel
+    )
 
 
 def test_false_health_allclear_falls_back(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
     monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
-    _stub_client(monkeypatch, content="Everything's green — you're healthy, push hard today.")
-    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+    _stub_client(
+        monkeypatch, content="Everything's green — you're healthy, push hard today."
+    )
+    assert (
+        wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
+        == sentinel
+    )
 
 
 # ── ISC-B6: any adapter failure → rule-based, never raises ───────────────────
@@ -94,7 +105,10 @@ def test_client_exception_falls_back(monkeypatch):
     sentinel = _stub_rule_based(monkeypatch)
     monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
     _stub_client(monkeypatch, raises=RuntimeError("all providers down"))
-    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+    assert (
+        wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
+        == sentinel
+    )
 
 
 def test_empty_output_falls_back(monkeypatch):
@@ -102,7 +116,10 @@ def test_empty_output_falls_back(monkeypatch):
     sentinel = _stub_rule_based(monkeypatch)
     monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
     _stub_client(monkeypatch, content="   ")
-    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+    assert (
+        wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
+        == sentinel
+    )
 
 
 # ── Sabbath rule: LLM on but Sunday → prescriptive rest line, model untouched ─
@@ -112,8 +129,13 @@ def test_sabbath_always_rule_based(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
     monkeypatch.setattr(wn, "_is_sabbath", lambda: True)
-    _stub_client(monkeypatch, raises=AssertionError("model must not be called on the Sabbath"))
-    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+    _stub_client(
+        monkeypatch, raises=AssertionError("model must not be called on the Sabbath")
+    )
+    assert (
+        wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
+        == sentinel
+    )
 
 
 # ── pure helpers ─────────────────────────────────────────────────────────────

--- a/rivaflow/tests/unit/test_whoop_narrative.py
+++ b/rivaflow/tests/unit/test_whoop_narrative.py
@@ -1,0 +1,144 @@
+"""Wave 2.3 — NarrativeProvider seam (pure; no DB, no network).
+
+Verifies the seam contract: rule-based by default (byte-identical), LLM adapter
+only when enabled + honest + non-Sabbath, and a hard fallback to the rule-based
+line on any failure or honesty-check violation — the cockpit can never break or
+over-claim because of this seam.
+"""
+
+from __future__ import annotations
+
+import rivaflow.core.services.whoop_narrative as wn
+
+READY = {"state": "Prime", "score": 87, "headline": "push"}
+NIGHT = {"available": True, "duration_hours": 7.5}
+CROSS = {
+    "hrv_ln_trend": [3.9, 4.0, 4.1],
+    "rhr_trend": [50, 51, 53],
+    "acwr": 1.4,
+    "cardio_today": 9.0,
+    "strain_target": 12.0,
+    "prevention": {"tier": "amber", "headline": "resting HR drifting up"},
+}
+
+RULE_SENTINEL = "RULE_BASED_NARRATIVE_LINE"
+
+
+def _stub_rule_based(monkeypatch, sentinel=RULE_SENTINEL):
+    monkeypatch.setattr(
+        wn.whoop_analytics, "daily_narrative", lambda *a, **k: sentinel
+    )
+    return sentinel
+
+
+def _stub_client(monkeypatch, *, content=None, raises=None):
+    class _FakeClient:
+        def chat_sync(self, *a, **k):
+            if raises is not None:
+                raise raises
+            return {"content": content, "provider": "groq", "model": "x"}
+
+    monkeypatch.setattr(
+        "rivaflow.core.services.grapple.llm_client.GrappleLLMClient",
+        lambda *a, **k: _FakeClient(),
+    )
+
+
+# ── ISC-B2: LLM off (default) → exactly the rule-based line ──────────────────
+
+
+def test_llm_disabled_returns_rule_based(monkeypatch):
+    monkeypatch.delenv("WHOOP_NARRATIVE_LLM", raising=False)
+    sentinel = _stub_rule_based(monkeypatch)
+    # Even if a client were reachable, it must not be consulted when disabled.
+    _stub_client(monkeypatch, raises=AssertionError("client must not be called"))
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT) == sentinel
+
+
+# ── ISC-B3/B5: LLM on + honest + non-Sabbath → the model's cross-signal story ─
+
+
+def test_llm_enabled_uses_honest_output(monkeypatch):
+    monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
+    _stub_rule_based(monkeypatch)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    story = "Your resting HR has crept up three days running while HRV held — ease into technical work."
+    _stub_client(monkeypatch, content=story)
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == story
+
+
+# ── ISC-B4: honesty post-checks reject over-claiming output → fallback ───────
+
+
+def test_diagnosis_output_falls_back(monkeypatch):
+    monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
+    sentinel = _stub_rule_based(monkeypatch)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    _stub_client(monkeypatch, content="Your numbers suggest you have the flu — rest up.")
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+
+
+def test_false_health_allclear_falls_back(monkeypatch):
+    monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
+    sentinel = _stub_rule_based(monkeypatch)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    _stub_client(monkeypatch, content="Everything's green — you're healthy, push hard today.")
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+
+
+# ── ISC-B6: any adapter failure → rule-based, never raises ───────────────────
+
+
+def test_client_exception_falls_back(monkeypatch):
+    monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
+    sentinel = _stub_rule_based(monkeypatch)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    _stub_client(monkeypatch, raises=RuntimeError("all providers down"))
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+
+
+def test_empty_output_falls_back(monkeypatch):
+    monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
+    sentinel = _stub_rule_based(monkeypatch)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    _stub_client(monkeypatch, content="   ")
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+
+
+# ── Sabbath rule: LLM on but Sunday → prescriptive rest line, model untouched ─
+
+
+def test_sabbath_always_rule_based(monkeypatch):
+    monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
+    sentinel = _stub_rule_based(monkeypatch)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda: True)
+    _stub_client(monkeypatch, raises=AssertionError("model must not be called on the Sabbath"))
+    assert wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS) == sentinel
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+
+
+def test_passes_honesty_checks():
+    assert wn._passes_honesty_checks("HRV's up — green light to push.") is True
+    assert wn._passes_honesty_checks("") is False
+    assert wn._passes_honesty_checks("   ") is False
+    assert wn._passes_honesty_checks("x" * 500) is False
+    assert wn._passes_honesty_checks("You likely have a viral infection.") is False
+    assert wn._passes_honesty_checks("You're healthy, no worries.") is False
+
+
+def test_llm_enabled_env_variants(monkeypatch):
+    for v in ("1", "true", "on", "YES"):
+        monkeypatch.setenv("WHOOP_NARRATIVE_LLM", v)
+        assert wn._llm_enabled() is True
+    for v in ("", "0", "off", "no"):
+        monkeypatch.setenv("WHOOP_NARRATIVE_LLM", v)
+        assert wn._llm_enabled() is False
+
+
+def test_cross_signal_brief_includes_trends():
+    brief = wn._build_cross_signal_brief(READY, NIGHT, None, CROSS)
+    assert "Resting HR" in brief and "ACWR 1.4" in brief
+    assert "amber" in brief  # prevention deviation surfaced, framed as deviation
+    assert "Prime" in brief


### PR DESCRIPTION
Two P1 model-upgrade seams from the Bitter-Lesson audit (REPORT.md §6 Wave 2). Both server-side, both provider-agnostic via the existing `GrappleLLMClient`, both fully backward-compatible (adapters off by default).

## Wave 2.1 — Coach → VPS, provider-agnostic (H1/H2)
The audit found the phone's coach triple-hardwired to an *unofficial* OpenAI backend, reasoning over the **dead on-device Extract scores** — so it could contradict the home screen and never benefited from VPS improvements.

- **`POST /api/v1/whoop/coach`** — reasons over the SAME `whoop_summary` the phone renders (so answers cite the numbers Ruby sees) and generates via `GrappleLLMClient`. Provider + model are a server config row → swapping the model is an env edit, **no app rebuild**. The phone becomes a chat renderer.
- **`core/services/whoop_coach.py`** — raw-derived context (zero dead cloud/Extract reads), Grapple-consistent honesty rails: no medical diagnosis, defer to professionals, green ≠ healthy, Sabbath rest, honest biometric ceiling (no SpO₂/temp/staging).
- Write-scoped (a paid outbound LLM call is a side-effect; a read-only `rf_vk_` view key can't invoke it) + rate-limited (30/min) as an LLM-budget backstop. Degrades gracefully (message, not 500) when no provider is configured.
- **Sunset test:** switching provider is a config edit, no app rebuild; coach answers cite the same numbers SlimHomeView shows.

## Wave 2.3 — NarrativeProvider seam (E1)
The cockpit narrative was a hand-written prose state machine — it could never notice a 3-day resting-HR climb or an ACWR spike even though both are computed in the same call. The violation wasn't the text; it was that a template was the *only possible* implementation.

- **`core/services/whoop_narrative.py`** → `compose_narrative()`. The rule-based `daily_narrative` stays the **deterministic default** (byte-identical with the adapter OFF). The optional LLM adapter composes the story from the full cross-signal ctx (RHR trend, HRV trend, ACWR, prevention) the template bank can't combine, at snapshot time (cached, a few calls/day).
- **Honesty post-checks** (diagnosis-term ban, false-health all-clear ban, length bound) + **Sabbath always rule-based**. ANY failure or failed check → falls straight back to the rule-based line. The cockpit can never break or over-claim because of this seam.
- Gated by `WHOOP_NARRATIVE_LLM` (off by default). Wired into `_build_cockpit_page`; also deduped a redundant second `prevention_watch()` call.
- **Test:** cockpit renders identically with the adapter off; with it on, the narrative can reference a cross-signal not in the template bank.

## Shared
- **`GrappleLLMClient.chat_sync()`** — blocking sibling of `chat()` (httpx.Client, same provider priority/config) so the sync snapshot builder — which runs inside the async cron job — uses the same provider-agnostic adapter without event-loop gymnastics.

## Tests
`test_whoop_coach.py` + `test_whoop_narrative.py` — 16 pure unit tests (no DB): context-cites-real-numbers, no-dead-cache anti-criterion, provider passthrough, history sanitize, and the full narrative fallback matrix (disabled / honest / diagnosis / false-health / exception / empty / Sabbath). `ruff check` clean. Verified locally via standalone MonkeyPatch runner (Postgres-backed suite runs in CI).

## Verify after deploy
- `POST /api/v1/whoop/coach` with a full key → 200 citing today's readiness/HRV that `/summary` returns; with a `rf_vk_` read key → 403.
- `/summary`, `/cockpit`, `/view`, `/cockpit-metrics` unchanged (adapters default-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)