### PR TITLE
Wave 3 batch 1: WhoopProfile seam + Banister cardio load + daily-agg rollups

### DIFF
--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -126,11 +126,37 @@ class WhoopIngest(BaseModel):
     device: str | None = None
     kind: str | None = "realtime"  # 'realtime' | 'historical_drain'
     batch_id: str | None = None
+    device_tz: str | None = None  # IANA tz the phone last reported (e.g. travel)
     raw_frames: list[RawFrame] = Field(default_factory=list)
     hr: list[HrSample] = Field(default_factory=list)
     rr: list[RrSample] = Field(default_factory=list)
     hrv: list[HrvSample] = Field(default_factory=list)
     battery: list[BatterySample] = Field(default_factory=list)
+
+
+def _persist_device_tz(user_id: int, device_tz: str | None) -> None:
+    """Validate + persist the phone-reported device tz on the profile (WhoopProfile
+    seam, Wave 3.6) — one UPDATE per genuine change, not per ingest batch. An
+    invalid/unknown IANA name is logged and ignored; the ingest still returns 200.
+    """
+    if not device_tz:
+        return
+    try:
+        ZoneInfo(device_tz)
+    except Exception:
+        logger.info("Ignoring invalid device_tz=%r for user %s", device_tz, user_id)
+        return
+
+    from rivaflow.db.repositories.base_repository import BaseRepository
+
+    row = BaseRepository._fetchone(
+        "SELECT device_tz FROM profile WHERE user_id = ?", (user_id,)
+    )
+    if row is None or row.get("device_tz") == device_tz:
+        return  # no profile row yet, or already up to date — skip the write
+    BaseRepository._execute(
+        "UPDATE profile SET device_tz = ? WHERE user_id = ?", (device_tz, user_id)
+    )
 
 
 def _span(payload: WhoopIngest) -> tuple[str | None, str | None]:
@@ -160,6 +186,8 @@ def ingest(
     unbounded raw-frame pollution.
     """
     user_id: int = current_user["id"]
+
+    _persist_device_tz(user_id, payload.device_tz)
 
     raw = WhoopRepository.ingest_raw_frames(
         user_id, [f.model_dump() for f in payload.raw_frames]

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -25,6 +25,7 @@ from rivaflow.api.rate_limit import limiter
 from rivaflow.core.dependencies import get_current_user, require_write_scope
 from rivaflow.core.error_handling import route_error_handler
 from rivaflow.core.exceptions import NotFoundError
+from rivaflow.core.whoop_profile import today_is_rest_day
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
 logger = logging.getLogger(__name__)
@@ -363,9 +364,7 @@ def readiness(current_user: dict = Depends(get_current_user)) -> dict:
     """Ruby Readiness Score — at-rest HRV vs rolling baseline. Sabbath-silent (Sunday rest)."""
     from rivaflow.core.whoop_analytics import compute_readiness
 
-    is_sabbath = (
-        datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
-    )  # Sunday = Ruby's rest day (adjust if Saturday-Sabbath)
+    is_sabbath = today_is_rest_day(current_user["id"])
     return compute_readiness(current_user["id"], today_is_sabbath=is_sabbath)
 
 
@@ -375,9 +374,7 @@ def strain_target_endpoint(current_user: dict = Depends(get_current_user)) -> di
     """B5 — today's prescribed strain target (0–21) from readiness, capped when Strained. Sabbath-silent."""
     from rivaflow.core.whoop_analytics import strain_target
 
-    is_sabbath = (
-        datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
-    )  # Sunday = Ruby's rest day
+    is_sabbath = today_is_rest_day(current_user["id"])
     return strain_target(current_user["id"], today_is_sabbath=is_sabbath)
 
 
@@ -520,7 +517,7 @@ def digest_endpoint(current_user: dict = Depends(get_current_user)) -> dict:
     """P2 — once-daily digest preview (readiness + strain + prevention, tier→channel routed). Sabbath-aware."""
     from rivaflow.core.whoop_analytics import morning_digest
 
-    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
+    is_sabbath = today_is_rest_day(current_user["id"])
     return morning_digest(current_user["id"], today_is_sabbath=is_sabbath)
 
 
@@ -660,7 +657,7 @@ def summary(current_user: dict = Depends(get_current_user)) -> dict:
     """One-call rollup for a thin display client: readiness + HRV + resting HR + last night's sleep.
     The whole point of the server-side architecture — the phone/dashboard fetches this and just renders it.
     """
-    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
+    is_sabbath = today_is_rest_day(current_user["id"])
     return _cached_whoop_summary(current_user["id"], today_is_sabbath=is_sabbath)
 
 
@@ -692,7 +689,7 @@ async def coach(
     """
     from rivaflow.core.services import whoop_coach
 
-    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
+    is_sabbath = today_is_rest_day(current_user["id"])
     try:
         return await whoop_coach.answer(
             current_user["id"],
@@ -757,7 +754,7 @@ def view(key: str) -> HTMLResponse:
     if not api_key:
         return HTMLResponse(_UNAUTH_HTML, status_code=401)
 
-    is_sabbath = datetime.now(ZoneInfo("Australia/Melbourne")).weekday() == 6
+    is_sabbath = today_is_rest_day(api_key["user_id"])
     s = _cached_whoop_summary(api_key["user_id"], today_is_sabbath=is_sabbath)
     return HTMLResponse(_render_whoop_view(s))
 

--- a/rivaflow/rivaflow/api/routes/whoop.py
+++ b/rivaflow/rivaflow/api/routes/whoop.py
@@ -630,24 +630,28 @@ def stress(current_user: dict = Depends(get_current_user)) -> dict:
     return today_stress(current_user["id"])
 
 
-# whoop_summary recomputes readiness/HRV/sleep/strain from the raw HR/RR tables on every call —
-# 26-35s at ~280k HR rows (2026-07-08 access logs), which times out the phone tiles and stacks a
-# fresh 30s recompute under every retry. New data only lands every ~2.5 min (uploader flush), so a
-# short-TTL in-process copy loses nothing a client could observe. Per-worker duplication is fine.
-_SUMMARY_CACHE: dict[tuple[int, bool], tuple[float, dict]] = {}
-_SUMMARY_TTL_S = 300.0
+# whoop_summary used to recompute readiness/HRV/sleep/strain from the raw HR/RR tables on every call —
+# 26-35s at ~280k HR rows (2026-07-08 access logs), which timed out the phone tiles and stacked a fresh
+# 30s recompute under every retry. Wave 3.4 (whoop_daily_agg) fixed the root cause: historical days are
+# rolled up once and served from a per-day cache, so only today is genuinely computed live. The TTL
+# band-aid that papered over the slow path is gone; this just measures + logs so a regression is loud.
+_SUMMARY_SLOW_MS = 2000
 
 
-def _cached_whoop_summary(user_id: int, today_is_sabbath: bool) -> dict:
+def _timed_whoop_summary(user_id: int, today_is_sabbath: bool) -> dict:
     from rivaflow.core.whoop_analytics import whoop_summary
 
-    key = (user_id, today_is_sabbath)
-    now = time.monotonic()
-    hit = _SUMMARY_CACHE.get(key)
-    if hit and hit[0] > now:
-        return hit[1]
+    started = time.monotonic()
     result = whoop_summary(user_id, today_is_sabbath=today_is_sabbath)
-    _SUMMARY_CACHE[key] = (now + _SUMMARY_TTL_S, result)
+    elapsed_ms = round((time.monotonic() - started) * 1000)
+    logger.info("whoop_summary rendered in %dms for user %s", elapsed_ms, user_id)
+    if elapsed_ms > _SUMMARY_SLOW_MS:
+        logger.warning(
+            "whoop_summary rendered in %dms for user %s — over the %dms budget",
+            elapsed_ms,
+            user_id,
+            _SUMMARY_SLOW_MS,
+        )
     return result
 
 
@@ -658,7 +662,7 @@ def summary(current_user: dict = Depends(get_current_user)) -> dict:
     The whole point of the server-side architecture — the phone/dashboard fetches this and just renders it.
     """
     is_sabbath = today_is_rest_day(current_user["id"])
-    return _cached_whoop_summary(current_user["id"], today_is_sabbath=is_sabbath)
+    return _timed_whoop_summary(current_user["id"], today_is_sabbath=is_sabbath)
 
 
 class CoachTurn(BaseModel):
@@ -755,7 +759,7 @@ def view(key: str) -> HTMLResponse:
         return HTMLResponse(_UNAUTH_HTML, status_code=401)
 
     is_sabbath = today_is_rest_day(api_key["user_id"])
-    s = _cached_whoop_summary(api_key["user_id"], today_is_sabbath=is_sabbath)
+    s = _timed_whoop_summary(api_key["user_id"], today_is_sabbath=is_sabbath)
     return HTMLResponse(_render_whoop_view(s))
 
 

--- a/rivaflow/rivaflow/core/cardio_load.py
+++ b/rivaflow/rivaflow/core/cardio_load.py
@@ -1,0 +1,118 @@
+"""Cardio load — Banister TRIMP (Wave 3.2).
+
+The ONE place zone-weight/TRIMP math lives. Before this module, `whoop_analytics.daily_cardio_load`
+and `whoop_cockpit.session_load_hardness` each carried their own ad-hoc 5-zone step-weight table
+(1/2/4/8/16 per zone), and the two had already drifted apart. Both now import from here instead.
+
+Male Banister TRIMP (Banister 1991): minutes at heart-rate-reserve intensity x = (bpm-rest)/(max-rest),
+weighted by the exponential curve 0.64·e^(1.92·x) — a continuous relative-intensity weighting that
+doesn't cliff at zone boundaries the way the old step table did.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from math import exp, log1p
+
+LOAD_VERSION = "banister-v1"
+
+# A capture dropout (strap off-wrist / charging) contributes at most this many seconds of load rather
+# than either the full (possibly hours-long) gap or nothing — same 10s convention the pre-Wave-3.2
+# daily_cardio_load used, but clamped instead of dropped so a dropout can't create a hard discontinuity
+# right at the 10s boundary.
+_GAP_CLAMP_SEC = 10.0
+
+_MALE_K = 0.64
+_MALE_E = 1.92
+
+# scale_to_21: min(21, A·log1p(raw/B)), constants re-fit to raw Banister units (see
+# tests/unit/test_cardio_load.py for the synthetic fixtures + the bands they're pinned to: a rest-day
+# all-day wear ≈ 7-9, a rest day + hard 90min BJJ session ≈ 15-17 — matching the feel of the pre-Wave-3.2
+# zone-weight scale).
+_SCALE_A = 6.28
+_SCALE_B = 29.5
+
+# Fallback hardness cutoffs (raw Banister TRIMP units) when there are <8 stored sessions to derive
+# percentiles from — see hardness_cutoffs(). Anchored on the synthetic hard-BJJ 90min session fixture's
+# raw load (~242.6, tests/unit/test_cardio_load.py): a session at or above the fixture's own load is "the
+# fixture itself", so HARD_CUTOFF is set at 90% of it (any hard-effort session close to that shape still
+# qualifies). MODERATE_CUTOFF is 40% of HARD_CUTOFF — chosen because the exponential HRR weighting means a
+# genuinely moderate/technical session (lower average intensity, no sustained high-HRR intervals) lands
+# well under half of a hard session's raw load, not linearly at half.
+_FALLBACK_HARD_CUTOFF = 218.3
+_FALLBACK_MODERATE_CUTOFF = 87.3
+
+
+def banister_trimp(
+    samples: list[tuple[datetime, int]], max_hr: float, rest_hr: float
+) -> float:
+    """Raw (unscaled) Banister TRIMP over a (ts, bpm) stream: minutes-at-intensity weighted by the
+    exponential HRR curve. Each sample is weighted by actual seconds since the previous sample,
+    gap-clamped (see _GAP_CLAMP_SEC) so a multi-hour capture dropout can't inject hours of phantom load.
+    Degenerate max_hr<=rest_hr (no valid HRR range to place bpm within) → 0.0. Empty input → 0.0.
+    """
+    if not samples or max_hr <= rest_hr:
+        return 0.0
+    hrr = max_hr - rest_hr
+    ordered = sorted(samples, key=lambda p: p[0])
+    total = 0.0
+    prev_ts: datetime | None = None
+    for ts, bpm in ordered:
+        if prev_ts is not None:
+            gap = (ts - prev_ts).total_seconds()
+            if gap > 0:
+                dur_min = min(gap, _GAP_CLAMP_SEC) / 60.0
+                x = max(0.0, min(1.0, (bpm - rest_hr) / hrr))
+                total += dur_min * x * _MALE_K * exp(_MALE_E * x)
+        prev_ts = ts
+    return total
+
+
+def session_load(
+    samples: list[tuple[datetime, int]], max_hr: float, rest_hr: float
+) -> float:
+    """Raw Banister TRIMP for one workout window — same math as banister_trimp, with no 0-21 display
+    scaling applied (that's scale_to_21, kept separate so hardness classification can work in raw units).
+    """
+    return banister_trimp(samples, max_hr, rest_hr)
+
+
+def scale_to_21(raw: float) -> float:
+    """Map a raw Banister TRIMP total onto the WHOOP-strain-feel 0-21 display band."""
+    return round(min(21.0, _SCALE_A * log1p(raw / _SCALE_B)), 1)
+
+
+def hardness_cutoffs(recent_session_loads: list[float]) -> tuple[float, float]:
+    """(moderate_cutoff, hard_cutoff) in raw Banister TRIMP units. With >=8 recent session loads, use this
+    person's own P40/P75 — a session below the 40th percentile of their own recent efforts is EASY, at or
+    above the 75th is HARD, in between is MODERATE. Data-driven and self-relative rather than a fixed
+    absolute band, since raw TRIMP scale depends on session duration and this person's HRR range. Below 8
+    samples there isn't enough history for percentiles to be stable, so fall back to cutoffs anchored on
+    the synthetic hard-BJJ fixture (see the module docstring constants).
+    """
+    if len(recent_session_loads) >= 8:
+        return _percentile(recent_session_loads, 40), _percentile(
+            recent_session_loads, 75
+        )
+    return _FALLBACK_MODERATE_CUTOFF, _FALLBACK_HARD_CUTOFF
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (no numpy dependency)."""
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo, hi = int(rank), min(int(rank) + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def classify_hardness(load: float, cutoffs: tuple[float, float]) -> str:
+    """Raw TRIMP load → 'EASY'/'MODERATE'/'HARD' (labels match the cockpit's existing badge classes)."""
+    moderate_cutoff, hard_cutoff = cutoffs
+    if load >= hard_cutoff:
+        return "HARD"
+    if load >= moderate_cutoff:
+        return "MODERATE"
+    return "EASY"

--- a/rivaflow/rivaflow/core/services/whoop_daily_agg.py
+++ b/rivaflow/rivaflow/core/services/whoop_daily_agg.py
@@ -1,0 +1,211 @@
+"""whoop_daily_agg — append-only per-day rollup service (Wave 3.4).
+
+whoop_summary() re-scanned weeks of raw whoop_hr/whoop_rr on EVERY call — each of daily_resting_rmssd,
+daily_resting_hr, nightly_sleep_history, and daily_cardio_load independently fetched and re-derived its
+full N-day window's HRV/resting-HR/sleep/cardio-load every time, and compute_readiness + prevention_watch
+each call several of them again over their own (overlapping) windows. A day's true value never changes
+once the day is over — except the phone's offline spool and historical drains can land whoop_hr/whoop_rr
+rows for a day DAYS after it first looked complete, so "over" isn't quite "never changes again" either.
+
+This module is the fix: compute_day() derives ONE day's full metrics set straight from raw, reusing the
+exact per-day math already in whoop_analytics (_day_rmssd / _day_resting_hr / _day_sleep / _day_cardio —
+the ONE place that math lives, no duplication here). get_range() is what whoop_analytics' four series
+functions now call: serve a historical day from whoop_daily_agg when it's fresh, recompute + persist it
+when it's missing, on a deriver-version bump, or when its raw HR+RR count has grown since it was rolled up
+(the late-data case) — and always compute TODAY live, never persisted, since it's still accruing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+
+from rivaflow.core import whoop_analytics
+from rivaflow.core.cardio_load import LOAD_VERSION
+from rivaflow.core.whoop_profile import get_whoop_profile
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+logger = logging.getLogger(__name__)
+
+# Bumps whenever compute_day's math changes — directly, or transitively via cardio_load.LOAD_VERSION (a
+# load-math upgrade must invalidate every stored cardio rollup too). A version mismatch on a stored row
+# forces a recompute, same idea as whoop_cockpit's deriver_version (see whoop_analytics.build_cockpit_snapshot).
+DERIVER_VERSION = f"daily-agg-v1+{LOAD_VERSION}"
+
+# Cold-start / off-wrist fallback rest-HR for a day whose own resting-HR reading isn't available — mirrors
+# whoop_analytics._DEFAULT_REST_HR. compute_day is deliberately day-isolated (a persisted rollup can't
+# depend on which window size some future caller happens to ask for), so unlike the pre-Wave-3.4
+# daily_cardio_load it does NOT borrow a neighbouring day's resting-HR; see compute_day's docstring.
+_DEFAULT_REST_HR = 60.0
+
+_METRIC_KEYS = ("rmssd", "resting_hr", "sleep", "cardio")
+
+
+def _day_bounds_iso(day: str, tz) -> tuple[str, str]:
+    """[start, end] ISO bounds (inclusive) for `day`'s local calendar window [00:00, 24:00) — the shared
+    window definition compute_day and the raw-count staleness check both use."""
+    d = date.fromisoformat(day)
+    start = datetime.combine(d, datetime.min.time(), tz)
+    end = start + timedelta(days=1) - timedelta(microseconds=1)
+    return start.isoformat(), end.isoformat()
+
+
+def compute_day(user_id: int, day: str, *, max_hr: float | None = None) -> dict:
+    """One local calendar day's full rollup, straight from raw whoop_hr/whoop_rr — the expensive path
+    get_range() below calls ONCE per (missing or stale) day and then persists, instead of every series
+    function re-deriving it on every call. Reuses the per-day math whoop_analytics already has
+    (_day_rmssd / _day_resting_hr / _day_sleep / _day_cardio) — no duplicated math.
+
+    `sample_count` = whoop_hr rows + whoop_rr rows in `day`'s local calendar window [00:00, 24:00) — the
+    staleness signal get_range() uses to catch late-arriving data (the phone's offline spool / a
+    historical drain can land rows for a day well after it first looked complete). Sleep's OWN window
+    (18:00 `day` -> 12:00 the next day) straddles into the next calendar day, so a late row landing after
+    midnight bumps the NEXT day's sample_count rather than this one's — an accepted approximation; the
+    next day's own rollup gets re-checked on its own account regardless, so the same late-arriving event
+    is never silently lost, just occasionally attributed to the neighbouring day's recheck instead.
+
+    cardio's rest_hr uses THIS day's own resting-HR reading when available, else _DEFAULT_REST_HR — a
+    day-isolated rule, not the multi-day "borrow the nearest prior day within the caller's window" rule
+    the pre-Wave-3.4 daily_cardio_load used (whoop_analytics._rest_hr_lookup), since a persisted rollup
+    can't depend on a future caller's window size. This only differs from the old behaviour on a day that
+    itself has <60 resting-HR samples (rare — continuous wear).
+
+    `max_hr` defaults to the cheap whoop_analytics.MAX_HR fallback (not a fresh calibration scan) so a
+    standalone call — or an incidental cardio sub-computation triggered by an rmssd/resting_hr/sleep
+    request — never surprises the caller with an expensive 90-day HR scan; get_range() overrides this with
+    the real calibrated value specifically when the caller asked for the "cardio" metric itself.
+    """
+    profile = get_whoop_profile(user_id)
+    tz = profile.tz
+    d = date.fromisoformat(day)
+    start = datetime.combine(d, datetime.min.time(), tz)
+    end = start + timedelta(days=1) - timedelta(microseconds=1)
+
+    hr_rows = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
+    rr_rows = WhoopRepository.rr_range_between(
+        user_id, start.isoformat(), end.isoformat()
+    )
+    bpms = [int(h["bpm"]) for h in hr_rows if h.get("bpm")]
+    rr_vals = [int(r["rr_ms"]) for r in rr_rows if r.get("rr_ms")]
+
+    rmssd_metric = whoop_analytics._day_rmssd(rr_vals, len(bpms))
+    resting_hr_metric = whoop_analytics._day_resting_hr(bpms)
+    sleep_metric = whoop_analytics._day_sleep(user_id, d, tz)
+
+    mx = max_hr if max_hr is not None else whoop_analytics.MAX_HR
+    rest_hr = (
+        float(resting_hr_metric["resting_hr"])
+        if resting_hr_metric
+        else _DEFAULT_REST_HR
+    )
+    samples = sorted(
+        (
+            (whoop_analytics._parse_ts(str(h["ts"])), int(h["bpm"]))
+            for h in hr_rows
+            if h.get("bpm")
+        ),
+        key=lambda p: p[0],
+    )
+    cardio_metric = whoop_analytics._day_cardio(samples, mx, rest_hr)
+
+    metrics: dict = {
+        "day": day,
+        "rmssd": rmssd_metric,
+        "resting_hr": resting_hr_metric,
+        "sleep": sleep_metric,
+        "cardio": cardio_metric,
+    }
+    metrics["sample_count"] = len(hr_rows) + len(rr_rows)
+    metrics["complete"] = all(metrics[k] is not None for k in _METRIC_KEYS)
+    return metrics
+
+
+def _rollup_for_day(user_id: int, day: str, tz, *, max_hr: float | None) -> dict | None:
+    """Serve `day` from whoop_daily_agg when it's fresh (deriver version AND raw count both match); else
+    recompute + upsert. The count check is two cheap COUNT(*) queries (index range scan, no row
+    materialization) — this is what catches the late-arriving-data case (see compute_day's docstring). A
+    day whose window has never captured anything (count 0) returns None WITHOUT writing a row — matches
+    the pre-rollup series functions, where a day with no data just never appears in the output.
+    """
+    start_iso, end_iso = _day_bounds_iso(day, tz)
+    current_count = WhoopRepository.hr_count_range(
+        user_id, start_iso, end_iso
+    ) + WhoopRepository.rr_count_range(user_id, start_iso, end_iso)
+
+    stored = WhoopRepository.get_daily_agg(user_id, day)
+    if (
+        stored is not None
+        and stored.get("deriver_version") == DERIVER_VERSION
+        and int(stored.get("sample_count") or 0) == current_count
+    ):
+        cached: dict = json.loads(stored["metrics_json"])
+        return cached
+
+    if current_count == 0:
+        return None
+
+    computed = compute_day(user_id, day, max_hr=max_hr)
+    WhoopRepository.upsert_daily_agg(
+        user_id,
+        day,
+        json.dumps(computed, default=str),
+        DERIVER_VERSION,
+        computed["sample_count"],
+        computed["complete"],
+    )
+    return computed
+
+
+def get_range(
+    user_id: int, days: int, metric: str, *, max_hr: float | None = None
+) -> list[dict]:
+    """The per-day series for one metric ('rmssd' | 'resting_hr' | 'sleep' | 'cardio') over the last `days`
+    (for 'sleep', the last `days` NIGHTS — matching nightly_sleep_history's own convention, which never
+    included the still-in-progress current night either). Historical days are served from whoop_daily_agg
+    (see _rollup_for_day); TODAY (profile-local) is always computed live via compute_day and never
+    persisted, since it's still accruing.
+
+    Output shape per day matches exactly what the pre-rollup series function it replaces produced — a day
+    with no captured data is simply absent, and 'sleep' entries carry no 'day' key (matching
+    nightly_sleep_history's own shape; every other metric prepends {"day": ...}).
+    """
+    if metric not in _METRIC_KEYS:
+        raise ValueError(f"unknown whoop_daily_agg metric {metric!r}")
+    profile = get_whoop_profile(user_id)
+    tz = profile.tz
+    today = datetime.now(tz).date()
+
+    if metric == "sleep":
+        day_list = [today - timedelta(days=n) for n in range(days, 0, -1)]
+    else:
+        day_list = [today - timedelta(days=n) for n in range(days - 1, -1, -1)]
+
+    # "cardio" is what daily_cardio_load itself returns — resolve the REAL calibrated max-HR (same default
+    # daily_cardio_load always used) so its own values are unchanged. Any OTHER metric's request only feeds
+    # compute_day's incidental cardio sub-value (nobody asked for it), so it stays cheap by default —
+    # see compute_day's docstring.
+    if metric == "cardio":
+        mx = (
+            max_hr
+            if max_hr is not None
+            else whoop_analytics.user_max_hr(user_id)["max_hr"]
+        )
+    else:
+        mx = max_hr if max_hr is not None else whoop_analytics.MAX_HR
+
+    out: list[dict] = []
+    for d in day_list:
+        day = d.isoformat()
+        computed = (
+            compute_day(user_id, day, max_hr=mx)
+            if d == today
+            else _rollup_for_day(user_id, day, tz, max_hr=mx)
+        )
+        if computed is None:
+            continue
+        val = computed[metric]
+        if val is None:
+            continue
+        out.append(val if metric == "sleep" else {"day": day, **val})
+    return out

--- a/rivaflow/rivaflow/core/services/whoop_narrative.py
+++ b/rivaflow/rivaflow/core/services/whoop_narrative.py
@@ -27,7 +27,7 @@ from datetime import datetime
 from typing import Any
 
 from rivaflow.core import whoop_analytics
-from rivaflow.core.whoop_analytics import LOCAL_TZ
+from rivaflow.core.whoop_profile import get_whoop_profile, is_rest_day
 
 logger = logging.getLogger(__name__)
 
@@ -80,10 +80,11 @@ def _llm_enabled() -> bool:
     )
 
 
-def _is_sabbath() -> bool:
-    """Sunday is Ruby's rest day — the Sabbath narrative is prescriptive rest and
-    must never be reframed by the model."""
-    return datetime.now(LOCAL_TZ).weekday() == 6
+def _is_sabbath(user_id: int) -> bool:
+    """The user's configured rest day (default Sunday) — the Sabbath narrative is
+    prescriptive rest and must never be reframed by the model."""
+    profile = get_whoop_profile(user_id)
+    return is_rest_day(profile, datetime.now(profile.tz))
 
 
 def _passes_honesty_checks(text: str) -> bool:
@@ -155,7 +156,7 @@ def compose_narrative(
         return rule_based
 
     # The Sabbath line is prescriptive rest — never let the model reframe it.
-    if _is_sabbath():
+    if _is_sabbath(user_id):
         return rule_based
 
     try:

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -10,17 +10,24 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import datetime, timedelta
-from math import log1p
 from statistics import mean, median, pstdev
 from zoneinfo import ZoneInfo
 
 from rivaflow.core.assessment import period_assessment
 from rivaflow.core.behaviour import behaviour_effect
+from rivaflow.core.cardio_load import (
+    LOAD_VERSION,
+    banister_trimp,
+    classify_hardness,
+    hardness_cutoffs,
+    scale_to_21,
+    session_load,
+)
 from rivaflow.core.circadian import cosinor
 from rivaflow.core.coverage import assess_coverage, coverage_in_days
 from rivaflow.core.hrv_spectral import MIN_BEATS, dfa_alpha1, frequency_domain, poincare
 from rivaflow.core.longevity import cardio_age_proxy, passive_vo2max
-from rivaflow.core.max_hr import calibrate_max_hr
+from rivaflow.core.max_hr import DEFAULT_PLATEAU_SEC, calibrate_max_hr, tanaka_max
 from rivaflow.core.prevention import (
     WORSE_WHEN,
     cusum_positive,
@@ -56,7 +63,6 @@ from rivaflow.core.whoop_cockpit import (
     render_today_story,
     render_trends,
     render_workouts_list,
-    session_load_hardness,
 )
 from rivaflow.core.whoop_digest import compile_digest
 from rivaflow.core.whoop_profile import get_whoop_profile, is_rest_day
@@ -71,14 +77,28 @@ def user_max_hr(user_id: int, days: int = 90) -> dict:
     """B1 — calibrated max-HR from recent HR: artifact-rejected sustained plateau, Tanaka sanity band,
     sub-maximal floor flag, uncertainty band. Everything zone/strain/stress derived should use this, not the
     MAX_HR fallback. Falls back to the age-predicted value when there isn't enough near-max effort captured.
-    Age comes from the WhoopProfile seam (date_of_birth, or Ruby's preserved DOB fallback).
+    Age comes from the WhoopProfile seam (date_of_birth, or Ruby's preserved DOB fallback). A profile
+    `max_hr_override` (a user-entered known max, e.g. from a lab test) short-circuits calibration entirely —
+    it's a stronger source of truth than anything inferred from the HR stream.
     """
+    profile = get_whoop_profile(user_id)
+    if profile.max_hr_override is not None:
+        return {
+            "max_hr": profile.max_hr_override,
+            "source": "override",
+            "observed_sustained": None,
+            "tanaka": round(tanaka_max(profile.age)),
+            "floor": False,
+            "uncertainty": [profile.max_hr_override, profile.max_hr_override],
+            "plateau_sec": DEFAULT_PLATEAU_SEC,
+            "samples": 0,
+            "note": "User-set max-HR override in their WHOOP profile — calibration skipped.",
+        }
     hr = [
         int(h["bpm"])
         for h in WhoopRepository.recent_hr(user_id, hours=days * 24)
         if h.get("bpm")
     ]
-    profile = get_whoop_profile(user_id)
     return calibrate_max_hr(hr, profile.age)
 
 
@@ -815,33 +835,90 @@ def _whoop_session_window(row: dict) -> tuple[datetime, datetime] | None:
     return start, start + timedelta(minutes=_SESSION_OPEN_MINUTES)
 
 
-def _attach_session_hr(
-    user_id: int, start: datetime, end: datetime, analytics: dict
-) -> dict:
-    """Attach the downsampled in-window HR curve + protocol-HRR to a session's analytics (in place)."""
+def _session_hr_points(
+    user_id: int, start: datetime, end: datetime
+) -> list[tuple[datetime, int]]:
+    """Full-resolution, time-ordered (ts, bpm) points across a session window — the shared input for the
+    HR curve, the session's Banister load, and the raw-load pool hardness_cutoffs draws percentiles from.
+    """
     hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
-    pts = sorted(
+    return sorted(
         ((_parse_ts(str(h["ts"])), int(h["bpm"])) for h in hr if h.get("bpm")),
         key=lambda p: p[0],
     )
+
+
+def _attach_session_hr(
+    user_id: int,
+    start: datetime,
+    end: datetime,
+    analytics: dict,
+    max_hr: float,
+    rest_hr: float,
+) -> dict:
+    """Attach the downsampled in-window HR curve, protocol-HRR, and the session's Banister load (in place).
+    Load is computed from the FULL-resolution points before they're downsampled for the chart — the
+    exponential HRR weighting needs real sample timing, not bucket-averaged chart points.
+    """
+    pts = _session_hr_points(user_id, start, end)
     times = [(t - start).total_seconds() / 60.0 for t, _ in pts]
     vals = [float(b) for _, b in pts]
     xs, ys = _downsample_xy(times, vals, max_points=200)
     analytics["times"], analytics["values"] = xs, ys
     hrr = analytics.get("protocol_hrr") or {}
     analytics["hrr"] = hrr.get("hrr_bpm") if hrr.get("available") else None
+    raw = session_load(pts, max_hr, rest_hr)
+    analytics["raw_load"] = round(raw, 1)
+    analytics["load"] = scale_to_21(raw)
     return analytics
+
+
+# Stored sessions sampled to build the hardness_cutoffs percentile pool — independent of the display
+# `limit`, since a small display page (e.g. 5) would otherwise never reach the >=8 samples percentiles need.
+_HARDNESS_CUTOFF_POOL = 30
+# Window wide enough to day-match rest_hr for the whole cutoff pool even when sessions are sparse (once a
+# week -> 30 sessions spans ~7 months); not tied to `days`/`limit` elsewhere in this module.
+_CUTOFF_REST_HR_WINDOW_DAYS = 120
+
+
+def _stored_session_raw_loads(
+    user_id: int, mx: float, resolve_rest_hr, pool: int = _HARDNESS_CUTOFF_POOL
+) -> list[float]:
+    """Raw Banister loads for recent stored sessions with HR coverage — the pool session_load_hardness's
+    percentile cutoffs are drawn from. A pool session with too little HR contributes nothing (same
+    _SESSION_MIN_HR_SAMPLES bar the display path uses)."""
+    tz = get_whoop_profile(user_id).tz
+    loads: list[float] = []
+    for row in WhoopRepository.list_whoop_sessions(user_id, limit=pool):
+        window = _whoop_session_window(row)
+        if window is None:
+            continue
+        start, end = window
+        pts = _session_hr_points(user_id, start, end)
+        if len(pts) < _SESSION_MIN_HR_SAMPLES:
+            continue
+        loads.append(session_load(pts, mx, resolve_rest_hr(_local_day(start, tz))))
+    return loads
 
 
 def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
     """P3.5 — per-session HR analytics for the Workouts list + the Tier-1 last-workout card. Sources
     timestamped workouts from whoop_sessions and attaches in-window WHOOP HR (curve, zones via the
-    B1-calibrated max-HR, avg/peak, HRR). A session with too little in-window HR is still listed, but
-    marked 'no HR coverage'. Returns [] when there are no logged sessions. Shape per item is stable:
-    {"label": str, "day": "YYYY-MM-DD", "analytics": {...}} — consumed by render_workouts_list and the card.
+    B1-calibrated max-HR, avg/peak, HRR, Banister load + HARD/MODERATE/EASY hardness). A session with too
+    little in-window HR is still listed, but marked 'no HR coverage'. Returns [] when there are no logged
+    sessions. Shape per item is stable: {"label": str, "day": "YYYY-MM-DD", "analytics": {...}} — consumed
+    by render_workouts_list and the card. Hardness is classified here (not in the renderer) so the
+    zone-weight/load math stays in exactly one place — see rivaflow.core.cardio_load.
     """
     mx = user_max_hr(user_id)["max_hr"]
     tz = get_whoop_profile(user_id).tz
+    resolve_rest_hr = _rest_hr_lookup(
+        {
+            d["day"]: float(d["resting_hr"])
+            for d in daily_resting_hr(user_id, days=_CUTOFF_REST_HR_WINDOW_DAYS)
+        }
+    )
+    cutoffs = hardness_cutoffs(_stored_session_raw_loads(user_id, mx, resolve_rest_hr))
     out: list[dict] = []
     for row in WhoopRepository.list_whoop_sessions(user_id, limit=limit):
         window = _whoop_session_window(row)
@@ -852,7 +929,9 @@ def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
             user_id, start.isoformat(), end.isoformat(), max_hr=mx
         )
         if a.get("available") and a.get("samples", 0) >= _SESSION_MIN_HR_SAMPLES:
-            a = _attach_session_hr(user_id, start, end, a)
+            rest_hr = resolve_rest_hr(_local_day(start, tz))
+            a = _attach_session_hr(user_id, start, end, a, mx, rest_hr)
+            a["hardness"] = classify_hardness(a["raw_load"], cutoffs)
         else:
             a = {"available": False, "reason": "no HR coverage"}
         out.append(
@@ -903,8 +982,7 @@ def _workout_clause(last_workout: dict | None) -> str:
     a = last_workout.get("analytics", {})
     if not a.get("available"):
         return ""
-    _, hardness = session_load_hardness(a)
-    if hardness == "HARD":
+    if a.get("hardness") == "HARD":
         return f"you're coming off a hard {str(last_workout.get('label', 'session')).lower()}"
     return ""
 
@@ -1600,46 +1678,56 @@ def capture_coverage(user_id: int, days: int = 21) -> dict:
     }
 
 
+# No resting-HR reading yet for a day (cold start, or a day forward-fill can't reach) → assume a typical
+# adult resting HR rather than skip the day. Only ever used as a last resort by _rest_hr_lookup below.
+_DEFAULT_REST_HR = 60.0
+
+
+def _rest_hr_lookup(rest_by_day: dict[str, float]):
+    """Build a day -> rest_hr resolver: exact match, else the most recent PRIOR day with a resting-HR
+    reading (a much better guess than a fixed constant for an isolated coverage gap), else _DEFAULT_REST_HR
+    (cold start, or a day with no earlier history at all). Shared by daily_cardio_load and the session-load
+    cutoff pool so rest_hr provenance is one rule, not two."""
+    known_days = sorted(rest_by_day)
+
+    def resolve(day: str) -> float:
+        if day in rest_by_day:
+            return rest_by_day[day]
+        prior = [d for d in known_days if d < day]
+        return rest_by_day[prior[-1]] if prior else _DEFAULT_REST_HR
+
+    return resolve
+
+
 def daily_cardio_load(
     user_id: int, days: int = 7, max_hr: int | None = None
 ) -> list[dict]:
-    """Daily cardio load / strain from HR-zone-weighted minutes (Banister-TRIMP style), hard zones
-    weighted exponentially, compressed to a ~0–21 scale (WHOOP-strain feel). Zones use the B1-calibrated
-    max-HR (not the 190 fallback), so the strain scale is correct for Ruby."""
+    """Daily cardio load / strain — Banister TRIMP (see rivaflow.core.cardio_load, the one place this math
+    lives), compressed to a ~0–21 scale (WHOOP-strain feel). Zones use the B1-calibrated max-HR (not the
+    190 fallback). rest_hr per day comes from daily_resting_hr over the same window (see _rest_hr_lookup)
+    — the 5th-percentile-of-day-HR proxy we already compute, so no extra plumbing."""
     hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
     mx = max_hr or user_max_hr(user_id)["max_hr"]
-    zone_weight = {1: 1, 2: 2, 3: 4, 4: 8, 5: 16}
-    # Time-weighted TRIMP: weight each sample by the ACTUAL seconds since the previous one. WHOOP capture
-    # density varies (much denser during active/workout capture), so the old fixed "1 sample/s → /60"
-    # assumption over-counted busy periods and saturated the scale at 21 every day. Gaps >10s (strap
-    # off-wrist / charging) are clamped to add no load.
-    rows = sorted(
-        (
-            (_parse_ts(h["ts"]), int(h["bpm"]))
-            for h in hr
-            if h.get("bpm") and h.get("ts")
-        ),
-        key=lambda r: r[0],
+    tz = get_whoop_profile(user_id).tz
+    by_day: dict[str, list[tuple[datetime, int]]] = defaultdict(list)
+    for h in hr:
+        bpm, ts = h.get("bpm"), h.get("ts")
+        if bpm and ts:
+            by_day[_local_day(ts, tz)].append((_parse_ts(ts), int(bpm)))
+
+    resolve_rest_hr = _rest_hr_lookup(
+        {d["day"]: float(d["resting_hr"]) for d in daily_resting_hr(user_id, days=days)}
     )
-    by_day: dict[str, float] = defaultdict(float)
-    prev_ts: datetime | None = None
-    for ts, bpm in rows:
-        if prev_ts is not None:
-            dt = (ts - prev_ts).total_seconds()
-            if 0 < dt <= 10:
-                by_day[_local_day(ts)] += zone_weight[hr_zone(bpm, mx)] * (dt / 60.0)
-        prev_ts = ts
     out = []
     for day in sorted(by_day):
-        raw = by_day[day]
+        samples = sorted(by_day[day], key=lambda p: p[0])
+        raw = banister_trimp(samples, mx, resolve_rest_hr(day))
         out.append(
             {
                 "day": day,
-                # Compression recalibrated for all-day continuous wear (was saturating at 21 daily):
-                # a light day ~8, a hard session ~16, only a genuinely maximal day approaches 21.
-                # Tuned on early data — will refine as more days accrue.
-                "cardio_load": round(min(21.0, 16.0 * log1p(raw / 600.0)), 1),
+                "cardio_load": scale_to_21(raw),
                 "raw_trimp": round(raw, 1),
+                "load_version": LOAD_VERSION,
             }
         )
     return out

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -1711,11 +1711,17 @@ def _rest_hr_lookup(rest_by_day: dict[str, float]):
 
 def _day_cardio(
     samples: list[tuple[datetime, int]], max_hr: float, rest_hr: float
-) -> dict:
+) -> dict | None:
     """One day's Banister cardio load (see rivaflow.core.cardio_load, the one place this math lives) from
     that day's ordered (ts, bpm) samples, compressed to a ~0-21 scale (WHOOP-strain feel). Shared by
-    daily_cardio_load's rollup-backed series and the whoop_daily_agg per-day compute (Wave 3.4).
+    daily_cardio_load's rollup-backed series and the whoop_daily_agg per-day compute (Wave 3.4). A day with
+    no captured HR samples returns None (mirrors _day_resting_hr's None-on-insufficient-data contract) — a
+    day with zero data is simply absent from the series, not a phantom cardio_load=0.0 entry. This matters
+    most for TODAY, which compute_day always evaluates live (unlike historical days, never gated on a
+    current_count==0 check) — a fresh user with no HR ever captured must not show up as "1 day of history".
     """
+    if not samples:
+        return None
     raw = banister_trimp(samples, max_hr, rest_hr)
     return {
         "cardio_load": scale_to_21(raw),

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -59,32 +59,32 @@ from rivaflow.core.whoop_cockpit import (
     session_load_hardness,
 )
 from rivaflow.core.whoop_digest import compile_digest
+from rivaflow.core.whoop_profile import get_whoop_profile, is_rest_day
 from rivaflow.db.repositories.whoop_repo import WhoopRepository
 
-# Ruby's profile-tuned constants
-RUBY_AGE = (
-    44  # TODO(profile): derive from DOB 1982-05-27 once wired to the profile repo
-)
 MAX_HR = 190  # FALLBACK ONLY — real ceiling comes from user_max_hr() (B1). Kept so
 # hr_zone() has a default; a ~30yo value, ~13 bpm above Ruby's ~177.
 READINESS_MIN_BASELINE_DAYS = 5  # cold-start guard before a score is meaningful
 
 
 def user_max_hr(user_id: int, days: int = 90) -> dict:
-    """B1 — Ruby's calibrated max-HR from recent HR: artifact-rejected sustained plateau, Tanaka sanity band,
+    """B1 — calibrated max-HR from recent HR: artifact-rejected sustained plateau, Tanaka sanity band,
     sub-maximal floor flag, uncertainty band. Everything zone/strain/stress derived should use this, not the
     MAX_HR fallback. Falls back to the age-predicted value when there isn't enough near-max effort captured.
+    Age comes from the WhoopProfile seam (date_of_birth, or Ruby's preserved DOB fallback).
     """
     hr = [
         int(h["bpm"])
         for h in WhoopRepository.recent_hr(user_id, hours=days * 24)
         if h.get("bpm")
     ]
-    return calibrate_max_hr(hr, RUBY_AGE)
+    profile = get_whoop_profile(user_id)
+    return calibrate_max_hr(hr, profile.age)
 
 
-# Ruby is Melbourne-based. All day-bucketing + display use his local day, not UTC (which would split the
-# day at ~10am and skew daily HRV/resting-HR). TODO(travel): switch to the device-reported tz per-ingest.
+# Melbourne is the module-level default so behaviour with an empty/missing profile is
+# identical to before the WhoopProfile seam (Wave 3.6) — day-bucketing + display now
+# resolve tz per-user via get_whoop_profile() instead of this hardcoded constant.
 LOCAL_TZ = ZoneInfo("Australia/Melbourne")
 
 
@@ -94,13 +94,14 @@ def _parse_ts(ts: str) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=ZoneInfo("UTC"))
 
 
-def _local_day(ts) -> str:
-    """UTC timestamp → Ruby's LOCAL (Melbourne) calendar day 'YYYY-MM-DD' — so a day is his day."""
+def _local_day(ts, tz: ZoneInfo = LOCAL_TZ) -> str:
+    """UTC timestamp → the user's LOCAL calendar day 'YYYY-MM-DD' (default Melbourne) — so a day is
+    their day, not UTC's."""
     try:
         dt = ts if isinstance(ts, datetime) else _parse_ts(str(ts))
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=ZoneInfo("UTC"))
-        return dt.astimezone(LOCAL_TZ).date().isoformat()
+        return dt.astimezone(tz).date().isoformat()
     except (ValueError, TypeError):
         return str(ts)[:10]
 
@@ -110,11 +111,12 @@ def daily_resting_hr(user_id: int, days: int = 14) -> list[dict]:
     (the true minimum is noisy). Needs >=60 samples/day. Falls out of the HR stream we already capture,
     so no extra plumbing."""
     hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
+    tz = get_whoop_profile(user_id).tz
     by_day: dict[str, list[int]] = defaultdict(list)
     for h in hr:
         bpm, ts = h.get("bpm"), h.get("ts")
         if bpm and ts:
-            by_day[_local_day(ts)].append(int(bpm))
+            by_day[_local_day(ts, tz)].append(int(bpm))
     out: list[dict] = []
     for day in sorted(by_day):
         vals = sorted(by_day[day])
@@ -257,6 +259,7 @@ def nightly_sleep(user_id: int, lookback_hours: int = 24) -> dict:
     a ~9pm onset checked the next evening isn't clipped; the window picker still isolates the one night.
     """
     hr = WhoopRepository.recent_hr(user_id, hours=lookback_hours)
+    tz = get_whoop_profile(user_id).tz
     pts = [
         (_parse_ts(str(h["ts"])), int(h["bpm"]))
         for h in hr
@@ -266,7 +269,7 @@ def nightly_sleep(user_id: int, lookback_hours: int = 24) -> dict:
     # have almost no data, there is no sleep to detect — a short quiet block after the strap wakes in the
     # morning is a capture artifact, not last night's sleep. Say so instead of inventing a number.
     core = [
-        t for t, _ in pts if 0 <= t.astimezone(LOCAL_TZ).hour < 5
+        t for t, _ in pts if 0 <= t.astimezone(tz).hour < 5
     ]  # local small-hours samples
     if (
         len(core) < 60
@@ -278,7 +281,7 @@ def nightly_sleep(user_id: int, lookback_hours: int = 24) -> dict:
         }
     res = _sleep_from_points(pts)
     if res.get("available"):
-        onset = _parse_ts(res["sleep_start"]).astimezone(LOCAL_TZ)
+        onset = _parse_ts(res["sleep_start"]).astimezone(tz)
         # a genuine sleep onset is evening/late-night; a short block onsetting in the morning/day is a
         # post-wake artifact, not the night — reject it rather than label it "last night's sleep"
         plausible_onset = onset.hour >= 19 or onset.hour < 4
@@ -296,11 +299,12 @@ def nightly_sleep_history(user_id: int, nights: int = 7) -> list[dict]:
     Reuses the single-night extractor over per-night HR windows."""
     from datetime import timedelta
 
-    now = datetime.now(LOCAL_TZ)
+    tz = get_whoop_profile(user_id).tz
+    now = datetime.now(tz)
     out: list[dict] = []
     for back in range(nights, 0, -1):
         day = (now - timedelta(days=back)).date()
-        start = datetime.combine(day, datetime.min.time(), LOCAL_TZ).replace(hour=18)
+        start = datetime.combine(day, datetime.min.time(), tz).replace(hour=18)
         end = start + timedelta(hours=18)  # 18:00 → next 12:00
         hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
         pts = [
@@ -416,6 +420,7 @@ def _signal_reading(name: str, series: list[float]) -> dict | None:
 
 def _prevention_series(user_id: int, days: int) -> dict[str, dict[str, float]]:
     """Per-signal {day → value} maps for the four prevention signals (no cardiac rhythm)."""
+    tz = get_whoop_profile(user_id).tz
     return {
         "rhr": {
             d["day"]: float(d["resting_hr"])
@@ -430,7 +435,7 @@ def _prevention_series(user_id: int, days: int) -> dict[str, dict[str, float]]:
             for d in daily_respiratory_rate(user_id, days=days)
         },
         "sleeping_hr": {
-            _local_day(h["sleep_start"]): float(h["avg_sleeping_hr"])
+            _local_day(h["sleep_start"], tz): float(h["avg_sleeping_hr"])
             for h in nightly_sleep_history(user_id, nights=days)
         },
     }
@@ -522,9 +527,10 @@ def deliver_digest(user_id: int) -> dict:
     """P2 — compute today's digest with the cooldown applied and RECORD any safety alert that fires (the
     delivery record + cooldown state, idempotent per (day, key)). Called once each morning by the external
     briefing cron. Anti-anxiety: one digest per day, no live-refresh flags."""
-    now = datetime.now(LOCAL_TZ)
+    profile = get_whoop_profile(user_id)
+    now = datetime.now(profile.tz)
     today = now.date()
-    is_sabbath = now.weekday() == 6  # Sunday = Ruby's rest day
+    is_sabbath = is_rest_day(profile, now)
     readiness = compute_readiness(user_id, today_is_sabbath=is_sabbath)
     strain = strain_target(user_id, today_is_sabbath=is_sabbath)
     prevention = prevention_watch(user_id)
@@ -579,11 +585,12 @@ def _downsample_xy(
 
 def today_hr_ribbon(user_id: int) -> dict:
     """P3.5 — today's full local-day HR (downsampled) + zone edges, for the intraday HR-ribbon panel."""
-    now = datetime.now(LOCAL_TZ)
-    start = datetime.combine(now.date(), datetime.min.time(), LOCAL_TZ)
+    tz = get_whoop_profile(user_id).tz
+    now = datetime.now(tz)
+    start = datetime.combine(now.date(), datetime.min.time(), tz)
     hr = WhoopRepository.hr_range(user_id, start.isoformat(), now.isoformat())
     pts = [
-        (_parse_ts(str(h["ts"])).astimezone(LOCAL_TZ), int(h["bpm"]))
+        (_parse_ts(str(h["ts"])).astimezone(tz), int(h["bpm"]))
         for h in hr
         if h.get("bpm") and h.get("ts")
     ]
@@ -706,12 +713,13 @@ def sleep_hr_dip(user_id: int) -> dict:
         if waking_avg
         else "—"
     )
+    tz = get_whoop_profile(user_id).tz
     return {
         "available": True,
         "times": xs,
         "values": ys,
-        "onset": start.astimezone(LOCAL_TZ).strftime("%H:%M"),
-        "offset": end.astimezone(LOCAL_TZ).strftime("%H:%M"),
+        "onset": start.astimezone(tz).strftime("%H:%M"),
+        "offset": end.astimezone(tz).strftime("%H:%M"),
         "dip_pct": dip_pct,
     }
 
@@ -751,8 +759,9 @@ def respiratory_trace(user_id: int, days: int = 1) -> dict:
 
 def stress_ribbon_series(user_id: int) -> dict:
     """P3.5 — hourly stress-vs-baseline across today, from HR-reserve elevation over resting baseline."""
-    now = datetime.now(LOCAL_TZ)
-    start = datetime.combine(now.date(), datetime.min.time(), LOCAL_TZ)
+    tz = get_whoop_profile(user_id).tz
+    now = datetime.now(tz)
+    start = datetime.combine(now.date(), datetime.min.time(), tz)
     hr = WhoopRepository.hr_range(user_id, start.isoformat(), now.isoformat())
     rhr_list = daily_resting_hr(user_id, days=3)
     if not hr or not rhr_list:
@@ -765,7 +774,7 @@ def stress_ribbon_series(user_id: int) -> dict:
     by_hour: dict[int, list[int]] = defaultdict(list)
     for h in hr:
         if h.get("bpm") and h.get("ts"):
-            dt = _parse_ts(str(h["ts"])).astimezone(LOCAL_TZ)
+            dt = _parse_ts(str(h["ts"])).astimezone(tz)
             by_hour[dt.hour].append(int(h["bpm"]))
     times: list[float] = []
     values: list[float] = []
@@ -832,6 +841,7 @@ def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
     {"label": str, "day": "YYYY-MM-DD", "analytics": {...}} — consumed by render_workouts_list and the card.
     """
     mx = user_max_hr(user_id)["max_hr"]
+    tz = get_whoop_profile(user_id).tz
     out: list[dict] = []
     for row in WhoopRepository.list_whoop_sessions(user_id, limit=limit):
         window = _whoop_session_window(row)
@@ -848,7 +858,7 @@ def session_deepdives(user_id: int, limit: int = 5) -> list[dict]:
         out.append(
             {
                 "label": str(row.get("activity", "Session")),
-                "day": _local_day(start),
+                "day": _local_day(start, tz),
                 "analytics": a,
             }
         )
@@ -911,7 +921,8 @@ def daily_narrative(
     the Sabbath. Safe on thin data — returns a clean 'building' line rather than inventing a story. Accepts
     pre-computed inputs so the cockpit doesn't recompute readiness, and stays standalone-callable for tests.
     """
-    is_sabbath = datetime.now(LOCAL_TZ).weekday() == 6
+    profile = get_whoop_profile(user_id)
+    is_sabbath = is_rest_day(profile, datetime.now(profile.tz))
     if readiness is None:
         readiness = compute_readiness(user_id, today_is_sabbath=is_sabbath)
     if night is None:
@@ -1084,8 +1095,9 @@ def _build_cockpit_page(user_id: int) -> str:
     a Workouts drill-down sit on top of the collapsed Tier-2 Lab (the 15 technical panels, each with a plain
     -English takeaway). All series compute here; the page only renders. Graceful on thin data throughout.
     """
-    now = datetime.now(LOCAL_TZ)
-    is_sabbath = now.weekday() == 6
+    profile = get_whoop_profile(user_id)
+    now = datetime.now(profile.tz)
+    is_sabbath = is_rest_day(profile, now)
     mx = user_max_hr(user_id)["max_hr"]
     readiness = compute_readiness(user_id, today_is_sabbath=is_sabbath)
     strain = strain_target(user_id, today_is_sabbath=is_sabbath, readiness=readiness)
@@ -1178,10 +1190,11 @@ def behaviour_correlation(
 def sleep_analysis(user_id: int, nights: int = 7) -> dict:
     """B9 + B10 — sleep need/debt (vs Ruby's >9h DNA need) + bedtime regularity, from the per-night history."""
     history = nightly_sleep_history(user_id, nights=nights)
+    tz = get_whoop_profile(user_id).tz
     durations = [h["duration_hours"] for h in history]
     onsets = [
-        _parse_ts(h["sleep_start"]).astimezone(LOCAL_TZ).hour
-        + _parse_ts(h["sleep_start"]).astimezone(LOCAL_TZ).minute / 60.0
+        _parse_ts(h["sleep_start"]).astimezone(tz).hour
+        + _parse_ts(h["sleep_start"]).astimezone(tz).minute / 60.0
         for h in history
     ]
     return {
@@ -1212,8 +1225,9 @@ def longevity_metrics(user_id: int) -> dict:
         return {"available": False, "reason": "Need resting-HR history first."}
     rest = min(r["resting_hr"] for r in rhr)  # best nocturnal resting HR
     vo2 = passive_vo2max(mx, rest)
+    age = get_whoop_profile(user_id).age
     cv = (
-        cardio_age_proxy(vo2["vo2max_estimate"], RUBY_AGE)
+        cardio_age_proxy(vo2["vo2max_estimate"], age)
         if vo2.get("available")
         else {"available": False}
     )
@@ -1242,10 +1256,11 @@ def resilience_metrics(user_id: int, days: int = 45) -> dict:
 def circadian_rhythm(user_id: int, days: int = 3) -> dict:
     """B17 — cosinor of time-of-day HR over recent days (mesor/amplitude/acrophase + implied nocturnal dip)."""
     hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
+    tz = get_whoop_profile(user_id).tz
     hours, vals = [], []
     for h in hr:
         if h.get("bpm") and h.get("ts"):
-            dt = _parse_ts(str(h["ts"])).astimezone(LOCAL_TZ)
+            dt = _parse_ts(str(h["ts"])).astimezone(tz)
             hours.append(dt.hour + dt.minute / 60.0)
             vals.append(float(h["bpm"]))
     return cosinor(hours, vals)
@@ -1352,21 +1367,24 @@ def hrv_lab(user_id: int, days: int = 2) -> dict:
 
 
 def _rr_by_day(user_id: int, days: int) -> dict[str, list[int]]:
-    """All whoop_rr intervals bucketed by Ruby's local day (any band — band filtering happens downstream)."""
+    """All whoop_rr intervals bucketed by the user's local day (any band — band filtering happens
+    downstream)."""
+    tz = get_whoop_profile(user_id).tz
     by_day: dict[str, list[int]] = defaultdict(list)
     for r in WhoopRepository.rr_range(user_id, days):
         rr_ms, ts = r.get("rr_ms"), r.get("ts")
         if rr_ms and ts:
-            by_day[_local_day(ts)].append(int(rr_ms))
+            by_day[_local_day(ts, tz)].append(int(rr_ms))
     return by_day
 
 
 def _hr_count_by_day(user_id: int, days: int) -> dict[str, int]:
     """HR sample count per local day — the HR-coverage side of the B3 guard (contrast against RR minutes)."""
+    tz = get_whoop_profile(user_id).tz
     counts: dict[str, int] = defaultdict(int)
     for h in WhoopRepository.recent_hr(user_id, hours=days * 24):
         if h.get("bpm") and h.get("ts"):
-            counts[_local_day(h["ts"])] += 1
+            counts[_local_day(h["ts"], tz)] += 1
     return counts
 
 

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -9,7 +9,7 @@ HRV only, and BJJ session analytics use HR (not HRV) because motion corrupts bea
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from statistics import mean, median, pstdev
 from zoneinfo import ZoneInfo
 
@@ -126,32 +126,30 @@ def _local_day(ts, tz: ZoneInfo = LOCAL_TZ) -> str:
         return str(ts)[:10]
 
 
-def daily_resting_hr(user_id: int, days: int = 14) -> list[dict]:
+def _day_resting_hr(bpms: list[int]) -> dict | None:
+    """One day's resting HR ≈ the 5th-percentile of that day's raw bpm samples — a robust resting proxy
+    (the true minimum is noisy). Needs >=60 samples/day, else None. Shared by daily_resting_hr's
+    rollup-backed series and the whoop_daily_agg per-day compute (Wave 3.4) — the ONE place this math
+    lives."""
+    if len(bpms) < 60:
+        return None
+    vals = sorted(bpms)
+    idx = max(0, int(len(vals) * 0.05))
+    return {"resting_hr": vals[idx], "min_hr": vals[0], "samples": len(vals)}
+
+
+def daily_resting_hr(
+    user_id: int, days: int = 14, max_hr: float | None = None
+) -> list[dict]:
     """Per-day resting HR ≈ the 5th-percentile of the day's HR — a robust resting proxy from whoop_hr
-    (the true minimum is noisy). Needs >=60 samples/day. Falls out of the HR stream we already capture,
-    so no extra plumbing."""
-    hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
-    tz = get_whoop_profile(user_id).tz
-    by_day: dict[str, list[int]] = defaultdict(list)
-    for h in hr:
-        bpm, ts = h.get("bpm"), h.get("ts")
-        if bpm and ts:
-            by_day[_local_day(ts, tz)].append(int(bpm))
-    out: list[dict] = []
-    for day in sorted(by_day):
-        vals = sorted(by_day[day])
-        if len(vals) < 60:
-            continue
-        idx = max(0, int(len(vals) * 0.05))
-        out.append(
-            {
-                "day": day,
-                "resting_hr": vals[idx],
-                "min_hr": vals[0],
-                "samples": len(vals),
-            }
-        )
-    return out
+    (the true minimum is noisy). Needs >=60 samples/day. Served from the whoop_daily_agg rollup (Wave 3.4)
+    — historical days are computed once and cached; only today is computed live. `max_hr` is optional and
+    only feeds the rollup's incidental cardio sub-metric when a fresh day is computed alongside this call
+    (see services/whoop_daily_agg.py); it does not affect the resting-HR values returned here.
+    """
+    from rivaflow.core.services.whoop_daily_agg import get_range
+
+    return get_range(user_id, days, "resting_hr", max_hr=max_hr)
 
 
 def _best_sleep_window(
@@ -314,28 +312,33 @@ def nightly_sleep(user_id: int, lookback_hours: int = 24) -> dict:
     return res
 
 
-def nightly_sleep_history(user_id: int, nights: int = 7) -> list[dict]:
-    """Per-night sleep for the last `nights` nights (each 18:00→12:00 local), for B9 debt + B10 regularity.
-    Reuses the single-night extractor over per-night HR windows."""
-    from datetime import timedelta
+def _day_sleep(user_id: int, day: date, tz: ZoneInfo) -> dict | None:
+    """One night's sleep — the night starting 18:00 on local calendar `day`, ending 12:00 the next day —
+    from the HR-bucketed window detector (_sleep_from_points). None when no sleep window is detected.
+    Shared by nightly_sleep_history's rollup-backed series and the whoop_daily_agg per-day compute
+    (Wave 3.4) — the ONE place this math lives."""
+    start = datetime.combine(day, datetime.min.time(), tz).replace(hour=18)
+    end = start + timedelta(hours=18)  # 18:00 → next 12:00
+    hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
+    pts = [
+        (_parse_ts(str(h["ts"])), int(h["bpm"]))
+        for h in hr
+        if h.get("bpm") and h.get("ts")
+    ]
+    s = _sleep_from_points(pts)
+    return s if s.get("available") else None
 
-    tz = get_whoop_profile(user_id).tz
-    now = datetime.now(tz)
-    out: list[dict] = []
-    for back in range(nights, 0, -1):
-        day = (now - timedelta(days=back)).date()
-        start = datetime.combine(day, datetime.min.time(), tz).replace(hour=18)
-        end = start + timedelta(hours=18)  # 18:00 → next 12:00
-        hr = WhoopRepository.hr_range(user_id, start.isoformat(), end.isoformat())
-        pts = [
-            (_parse_ts(str(h["ts"])), int(h["bpm"]))
-            for h in hr
-            if h.get("bpm") and h.get("ts")
-        ]
-        s = _sleep_from_points(pts)
-        if s.get("available"):
-            out.append(s)
-    return out
+
+def nightly_sleep_history(
+    user_id: int, nights: int = 7, max_hr: float | None = None
+) -> list[dict]:
+    """Per-night sleep for the last `nights` nights (each 18:00→12:00 local), for B9 debt + B10 regularity.
+    Served from the whoop_daily_agg rollup (Wave 3.4) — historical nights are computed once and cached;
+    the most recent (still-accruing) night is always computed live. `max_hr` is optional — see
+    daily_resting_hr's docstring."""
+    from rivaflow.core.services.whoop_daily_agg import get_range
+
+    return get_range(user_id, nights, "sleep", max_hr=max_hr)
 
 
 def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
@@ -345,11 +348,13 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
     HR+RR we already capture."""
     max_hr = user_max_hr(
         user_id
-    )  # B1 — compute once, thread into every HR-zone consumer
+    )  # B1 — compute once, thread into every HR-zone consumer (and into whoop_daily_agg's
+    # incidental cardio sub-metric for any day rmssd/resting_hr freshly roll up here — Wave 3.4)
+    mx = max_hr["max_hr"]
     readiness = compute_readiness(user_id, today_is_sabbath=today_is_sabbath)
-    hrv = daily_resting_rmssd(user_id, days=14)
-    rhr = daily_resting_hr(user_id, days=14)
-    cardio = daily_cardio_load(user_id, days=14, max_hr=max_hr["max_hr"])
+    hrv = daily_resting_rmssd(user_id, days=14, max_hr=mx)
+    rhr = daily_resting_hr(user_id, days=14, max_hr=mx)
+    cardio = daily_cardio_load(user_id, days=14, max_hr=mx)
     sleep = nightly_sleep(user_id)
     if sleep.get("available"):
         # Simple quality score vs Ruby's >9h sleep-need (DNA): duration is the dominant driver.
@@ -359,8 +364,7 @@ def whoop_summary(user_id: int, today_is_sabbath: bool = False) -> dict:
     acute = cardio[-1]["cardio_load"] if cardio else None
     strain = prescribe_strain(readiness.get("state"), _chronic_load(cardio), acute)
     load_series = [
-        c["cardio_load"]
-        for c in daily_cardio_load(user_id, days=28, max_hr=max_hr["max_hr"])
+        c["cardio_load"] for c in daily_cardio_load(user_id, days=28, max_hr=mx)
     ]
     return {
         "readiness": readiness,
@@ -1466,37 +1470,43 @@ def _hr_count_by_day(user_id: int, days: int) -> dict[str, int]:
     return counts
 
 
-def daily_resting_rmssd(user_id: int, days: int = 21) -> list[dict]:
+def _day_rmssd(rr_vals: list[int], hr_count: int) -> dict | None:
+    """One day's resting HRV (RMSSD/lnRMSSD) from that day's RR intervals + HR sample count. Two gates
+    before it can anchor a baseline: the B3 coverage guard (enough usable, contiguous RR — excludes
+    RR-starved charging nights the HR view masks) and the B0 QC gate (widened bradycardia band + Malik
+    relative filter + ectopy interpolation). None when either gate fails. Shared by daily_resting_rmssd's
+    rollup-backed series and the whoop_daily_agg per-day compute (Wave 3.4) — the ONE place this math
+    lives."""
+    cov = assess_coverage(rr_vals, hr_count)
+    if not cov.sufficient:
+        return None
+    q = assess_rr(rr_vals)
+    if not q.usable:
+        return None
+    value = rmssd(q.cleaned)
+    ln_value = ln_rmssd(q.cleaned)
+    if value is None or ln_value is None:
+        return None
+    return {
+        "rmssd": round(value, 1),
+        "ln_rmssd": round(ln_value, 3),
+        "quality": q.as_meta(),
+        "coverage": cov.as_dict(),
+    }
+
+
+def daily_resting_rmssd(
+    user_id: int, days: int = 21, max_hr: float | None = None
+) -> list[dict]:
     """Per-day resting HRV (RMSSD, ms) derived from the whoop_rr intervals already flowing — so readiness
-    works without a separate HRV feed. Each day passes TWO gates before it can anchor a baseline: the B3
-    coverage guard (enough usable, contiguous RR — excludes RR-starved charging nights the HR view masks)
-    and the B0 QC gate (widened bradycardia band + Malik relative filter + ectopy interpolation). Each value
-    carries its artifact-% and RR-minutes; under-covered or over-artifact days are dropped.
+    works without a separate HRV feed. Each value carries its artifact-% and RR-minutes; under-covered or
+    over-artifact days are dropped (see _day_rmssd). Served from the whoop_daily_agg rollup (Wave 3.4) —
+    historical days are computed once and cached; only today is computed live. `max_hr` is optional — see
+    daily_resting_hr's docstring.
     """
-    by_day = _rr_by_day(user_id, days)
-    hr_counts = _hr_count_by_day(user_id, days)
-    out: list[dict] = []
-    for day in sorted(by_day):
-        cov = assess_coverage(by_day[day], hr_counts.get(day, 0))
-        if not cov.sufficient:
-            continue
-        q = assess_rr(by_day[day])
-        if not q.usable:
-            continue
-        value = rmssd(q.cleaned)
-        ln_value = ln_rmssd(q.cleaned)
-        if value is None or ln_value is None:
-            continue
-        out.append(
-            {
-                "day": day,
-                "rmssd": round(value, 1),
-                "ln_rmssd": round(ln_value, 3),
-                "quality": q.as_meta(),
-                "coverage": cov.as_dict(),
-            }
-        )
-    return out
+    from rivaflow.core.services.whoop_daily_agg import get_range
+
+    return get_range(user_id, days, "rmssd", max_hr=max_hr)
 
 
 def compute_readiness(user_id: int, today_is_sabbath: bool = False) -> dict:
@@ -1699,38 +1709,32 @@ def _rest_hr_lookup(rest_by_day: dict[str, float]):
     return resolve
 
 
+def _day_cardio(
+    samples: list[tuple[datetime, int]], max_hr: float, rest_hr: float
+) -> dict:
+    """One day's Banister cardio load (see rivaflow.core.cardio_load, the one place this math lives) from
+    that day's ordered (ts, bpm) samples, compressed to a ~0-21 scale (WHOOP-strain feel). Shared by
+    daily_cardio_load's rollup-backed series and the whoop_daily_agg per-day compute (Wave 3.4).
+    """
+    raw = banister_trimp(samples, max_hr, rest_hr)
+    return {
+        "cardio_load": scale_to_21(raw),
+        "raw_trimp": round(raw, 1),
+        "load_version": LOAD_VERSION,
+    }
+
+
 def daily_cardio_load(
     user_id: int, days: int = 7, max_hr: int | None = None
 ) -> list[dict]:
-    """Daily cardio load / strain — Banister TRIMP (see rivaflow.core.cardio_load, the one place this math
-    lives), compressed to a ~0–21 scale (WHOOP-strain feel). Zones use the B1-calibrated max-HR (not the
-    190 fallback). rest_hr per day comes from daily_resting_hr over the same window (see _rest_hr_lookup)
-    — the 5th-percentile-of-day-HR proxy we already compute, so no extra plumbing."""
-    hr = WhoopRepository.recent_hr(user_id, hours=days * 24)
-    mx = max_hr or user_max_hr(user_id)["max_hr"]
-    tz = get_whoop_profile(user_id).tz
-    by_day: dict[str, list[tuple[datetime, int]]] = defaultdict(list)
-    for h in hr:
-        bpm, ts = h.get("bpm"), h.get("ts")
-        if bpm and ts:
-            by_day[_local_day(ts, tz)].append((_parse_ts(ts), int(bpm)))
+    """Daily cardio load / strain — Banister TRIMP, compressed to a ~0-21 scale. Zones use the
+    B1-calibrated max-HR (not the 190 fallback) unless a caller-supplied `max_hr` is given. rest_hr per day
+    is that day's own resting-HR reading (see _day_cardio / _day_resting_hr). Served from the
+    whoop_daily_agg rollup (Wave 3.4) — historical days are computed once and cached; only today is
+    computed live."""
+    from rivaflow.core.services.whoop_daily_agg import get_range
 
-    resolve_rest_hr = _rest_hr_lookup(
-        {d["day"]: float(d["resting_hr"]) for d in daily_resting_hr(user_id, days=days)}
-    )
-    out = []
-    for day in sorted(by_day):
-        samples = sorted(by_day[day], key=lambda p: p[0])
-        raw = banister_trimp(samples, mx, resolve_rest_hr(day))
-        out.append(
-            {
-                "day": day,
-                "cardio_load": scale_to_21(raw),
-                "raw_trimp": round(raw, 1),
-                "load_version": LOAD_VERSION,
-            }
-        )
-    return out
+    return get_range(user_id, days, "cardio", max_hr=max_hr)
 
 
 def today_stress(user_id: int, max_hr: int | None = None) -> dict:

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -10,7 +10,6 @@ Sub-phased by panel group; P3.1 ships Recovery & Load. Every dynamic string is H
 from __future__ import annotations
 
 import html
-from math import log1p
 
 _ACCENT = {
     "Prime": "#34d399",
@@ -948,7 +947,7 @@ def _session_card_html(s: dict, idx: int = 0) -> str:
             f'<div class="sub">{esc(s.get("label", "Session"))} · {esc(s.get("day", ""))} — '
             f'{esc(a.get("reason", "no HR captured"))}</div></div>'
         )
-    load, hardness = session_load_hardness(a)
+    load, hardness = a.get("load", 0.0), a.get("hardness", "EASY")
     curve = svg_area_line(
         a.get("times", []),
         a.get("values", []),
@@ -988,22 +987,6 @@ def render_session_deepdives(sessions: list[dict]) -> str:
 
 
 # ── P6 "Story over Lab" — a glanceable Tier-1 band on top of the technical Lab ──
-
-
-def session_load_hardness(analytics: dict) -> tuple[float, str]:
-    """Compressed 0–21 cardio-load + a HARD/MODERATE/EASY label from a session's zone-seconds (same TRIMP
-    weighting daily_cardio_load uses). Lives here (not analytics) so both the renderer and narrative can
-    reuse it without an import cycle. Returns (0.0, 'EASY') on empty/missing zone data.
-    """
-    zone_secs = analytics.get("hr_zone_secs", {}) or {}
-    weights = {1: 1, 2: 2, 3: 4, 4: 8, 5: 16}
-    raw = sum(weights.get(int(z), 0) * (secs / 60.0) for z, secs in zone_secs.items())
-    load = round(min(21.0, 6.0 * log1p(raw / 20.0)), 1)
-    if load >= 12:
-        return load, "HARD"
-    if load >= 6:
-        return load, "MODERATE"
-    return load, "EASY"
 
 
 def _hardness_badge(hardness: str) -> str:
@@ -1169,7 +1152,7 @@ def _workout_card(last_workout: dict | None) -> str:
             f'<div class="big">{esc(label)}</div>'
             f'<div class="sub">{esc(day)} — {esc(a.get("reason", "no HR captured"))}</div></div>'
         )
-    load, hardness = session_load_hardness(a)
+    load, hardness = a.get("load", 0.0), a.get("hardness", "EASY")
     dur_min = a.get("duration_sec", 0) // 60
     return (
         '<details class="card"><summary>'
@@ -1246,7 +1229,7 @@ def _workout_row(s: dict, idx: int = 0) -> str:
             f"{esc(day)} · {esc(label)} — {esc(a.get('reason', 'no HR captured'))}"
             f"</summary>{_session_card_html(s, idx=idx)}</details>"
         )
-    load, hardness = session_load_hardness(a)
+    load, hardness = a.get("load", 0.0), a.get("hardness", "EASY")
     dur_min = a.get("duration_sec", 0) // 60
     return (
         '<details class="workout-row"><summary>'

--- a/rivaflow/rivaflow/core/whoop_profile.py
+++ b/rivaflow/rivaflow/core/whoop_profile.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 # (1982-05-27), so behaviour with an empty/missing profile row is identical.
 _DEFAULT_DOB = "1982-05-27"
 _DEFAULT_TZ_NAME = "Australia/Melbourne"
-_DEFAULT_SLEEP_NEED_H = 8.0
+# Matches the sleep-need literals still hardcoded directly in whoop_analytics (quality-score /9.0,
+# the "Xh under your 9h need" clause, readiness's sleep_z) — Ruby's >9h DNA sleep need. Not yet wired to
+# those literals (that's batch 2); this default just avoids a silent 8.0/9.0 mismatch once it is.
+_DEFAULT_SLEEP_NEED_H = 9.0
 _DEFAULT_REST_WEEKDAY = 6  # Sunday
 
 _CACHE_TTL_SEC = 60

--- a/rivaflow/rivaflow/core/whoop_profile.py
+++ b/rivaflow/rivaflow/core/whoop_profile.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 from rivaflow.db.repositories.base_repository import BaseRepository
@@ -139,7 +139,15 @@ def get_whoop_profile(user_id: int) -> WhoopProfile:
     return profile
 
 
-def is_rest_day(profile: WhoopProfile, now) -> bool:
+def is_rest_day(profile: WhoopProfile, now: datetime) -> bool:
     """True when `now` (any tz-aware datetime) falls on the profile's rest weekday,
     evaluated in the profile's own tz."""
     return now.astimezone(profile.tz).weekday() == profile.rest_weekday
+
+
+def today_is_rest_day(user_id: int) -> bool:
+    """Route-level convenience: fetch the profile and evaluate 'now' against it in one
+    call — every /whoop route that needs today's Sabbath/rest-day flag has a user_id
+    (current_user or api_key) in scope but no reason to hold a WhoopProfile itself."""
+    profile = get_whoop_profile(user_id)
+    return is_rest_day(profile, datetime.now(profile.tz))

--- a/rivaflow/rivaflow/core/whoop_profile.py
+++ b/rivaflow/rivaflow/core/whoop_profile.py
@@ -1,0 +1,145 @@
+"""WhoopProfile seam (Wave 3.6) — per-user tz/age/sleep-need/rest-day/max-HR-override,
+read once from `profile` and threaded through whoop_analytics instead of the hardcoded
+RUBY_AGE / LOCAL_TZ / Sunday-only rest-day checks it replaces.
+
+Kept dependency-light on purpose: a direct SELECT via BaseRepository, no new
+repository class. Missing row or any DB error returns full defaults — this must
+never raise, since it sits in front of every analytics call.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import date
+from zoneinfo import ZoneInfo
+
+from rivaflow.db.repositories.base_repository import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+# Preserved fallback — the DOB whoop_analytics.RUBY_AGE was hardcoded from
+# (1982-05-27), so behaviour with an empty/missing profile row is identical.
+_DEFAULT_DOB = "1982-05-27"
+_DEFAULT_TZ_NAME = "Australia/Melbourne"
+_DEFAULT_SLEEP_NEED_H = 8.0
+_DEFAULT_REST_WEEKDAY = 6  # Sunday
+
+_CACHE_TTL_SEC = 60
+
+
+@dataclass(frozen=True)
+class WhoopProfile:
+    user_id: int
+    tz: ZoneInfo
+    age: int
+    sleep_need_h: float
+    rest_weekday: int
+    max_hr_override: int | None
+
+
+def _years_between(dob: date, today: date) -> int:
+    return today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
+
+
+def _default_age(today: date | None = None) -> int:
+    """Age from the preserved DOB fallback, computed the same way ProfileRepository does.
+    `today` is injectable for deterministic tests; production callers omit it."""
+    return _years_between(date.fromisoformat(_DEFAULT_DOB), today or date.today())
+
+
+def _age_from_dob(dob_iso: str | None, today: date | None = None) -> int:
+    """Age from an ISO date string; falls back to the default DOB on any parse issue."""
+    today = today or date.today()
+    if not dob_iso:
+        return _default_age(today)
+    try:
+        dob = date.fromisoformat(str(dob_iso)[:10])
+    except (ValueError, TypeError):
+        return _default_age(today)
+    return _years_between(dob, today)
+
+
+def _resolve_tz(device_tz: str | None, timezone: str | None) -> ZoneInfo:
+    """device_tz (most recent, device-reported) > profile.timezone (user-set) > Melbourne default.
+    Invalid/unknown IANA names are skipped rather than raising.
+    """
+    for candidate in (device_tz, timezone):
+        if not candidate:
+            continue
+        try:
+            return ZoneInfo(str(candidate))
+        except Exception:  # noqa: BLE001 — any bad tz string just falls through
+            continue
+    return ZoneInfo(_DEFAULT_TZ_NAME)
+
+
+def _row_to_profile(user_id: int, row: dict | None) -> WhoopProfile:
+    row = row or {}
+    return WhoopProfile(
+        user_id=user_id,
+        tz=_resolve_tz(row.get("device_tz"), row.get("timezone")),
+        age=_age_from_dob(row.get("date_of_birth")),
+        sleep_need_h=(
+            float(row["sleep_need_h"])
+            if row.get("sleep_need_h") is not None
+            else _DEFAULT_SLEEP_NEED_H
+        ),
+        rest_weekday=(
+            int(row["rest_weekday"])
+            if row.get("rest_weekday") is not None
+            else _DEFAULT_REST_WEEKDAY
+        ),
+        max_hr_override=(
+            int(row["max_hr_override"])
+            if row.get("max_hr_override") is not None
+            else None
+        ),
+    )
+
+
+# Per-process cache keyed by user_id: (profile, fetched_at_monotonic). Hot analytics
+# paths (whoop_summary, the cockpit build) fetch the profile several times per call
+# chain, so a short TTL avoids hammering the DB without ever going stale for long.
+_cache: dict[int, tuple[WhoopProfile, float]] = {}
+
+
+def _clear_profile_cache() -> None:
+    """Test hook — reset the per-process cache between test cases."""
+    _cache.clear()
+
+
+def get_whoop_profile(user_id: int) -> WhoopProfile:
+    """Read (and cache, ~60s TTL) the WhoopProfile for `user_id`. Never raises — a
+    missing row or DB error resolves to full defaults (Melbourne tz, the preserved
+    RUBY_AGE-equivalent age, 8h sleep need, Sunday rest day, no max-HR override).
+    """
+    cached = _cache.get(user_id)
+    now = time.monotonic()
+    if cached is not None and now - cached[1] < _CACHE_TTL_SEC:
+        return cached[0]
+
+    try:
+        row = BaseRepository._fetchone(
+            "SELECT date_of_birth, timezone, device_tz, sleep_need_h, "
+            "rest_weekday, max_hr_override FROM profile WHERE user_id = ?",
+            (user_id,),
+        )
+        profile = _row_to_profile(user_id, row)
+    except Exception:  # noqa: BLE001 — profile lookup must never break analytics
+        logger.warning(
+            "get_whoop_profile failed for user %s; using defaults",
+            user_id,
+            exc_info=True,
+        )
+        profile = _row_to_profile(user_id, None)
+
+    _cache[user_id] = (profile, now)
+    return profile
+
+
+def is_rest_day(profile: WhoopProfile, now) -> bool:
+    """True when `now` (any tz-aware datetime) falls on the profile's rest weekday,
+    evaluated in the profile's own tz."""
+    return now.astimezone(profile.tz).weekday() == profile.rest_weekday

--- a/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam.sql
+++ b/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam.sql
@@ -1,0 +1,9 @@
+-- 116_whoop_profile_seam.sql
+-- Per-user profile fields the WhoopProfile seam reads (SQLite/test): sleep-need
+-- hours, which weekday is the rest day, an optional manual max-HR override, and
+-- the device-reported IANA tz (distinct from profile.timezone, which is user-set;
+-- device_tz is what the WHOOP strap/phone last reported at ingest).
+ALTER TABLE profile ADD COLUMN sleep_need_h REAL DEFAULT 8.0;
+ALTER TABLE profile ADD COLUMN rest_weekday INTEGER DEFAULT 6;
+ALTER TABLE profile ADD COLUMN max_hr_override INTEGER;
+ALTER TABLE profile ADD COLUMN device_tz TEXT;

--- a/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam.sql
+++ b/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam.sql
@@ -3,7 +3,7 @@
 -- hours, which weekday is the rest day, an optional manual max-HR override, and
 -- the device-reported IANA tz (distinct from profile.timezone, which is user-set;
 -- device_tz is what the WHOOP strap/phone last reported at ingest).
-ALTER TABLE profile ADD COLUMN sleep_need_h REAL DEFAULT 8.0;
+ALTER TABLE profile ADD COLUMN sleep_need_h REAL DEFAULT 9.0;
 ALTER TABLE profile ADD COLUMN rest_weekday INTEGER DEFAULT 6;
 ALTER TABLE profile ADD COLUMN max_hr_override INTEGER;
 ALTER TABLE profile ADD COLUMN device_tz TEXT;

--- a/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam_pg.sql
@@ -3,7 +3,7 @@
 -- which weekday is the rest day, an optional manual max-HR override, and the
 -- device-reported IANA tz (distinct from profile.timezone, which is user-set;
 -- device_tz is what the WHOOP strap/phone last reported at ingest).
-ALTER TABLE profile ADD COLUMN IF NOT EXISTS sleep_need_h REAL DEFAULT 8.0;
+ALTER TABLE profile ADD COLUMN IF NOT EXISTS sleep_need_h REAL DEFAULT 9.0;
 ALTER TABLE profile ADD COLUMN IF NOT EXISTS rest_weekday INTEGER DEFAULT 6;
 ALTER TABLE profile ADD COLUMN IF NOT EXISTS max_hr_override INTEGER;
 ALTER TABLE profile ADD COLUMN IF NOT EXISTS device_tz TEXT;

--- a/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/116_whoop_profile_seam_pg.sql
@@ -1,0 +1,9 @@
+-- 116_whoop_profile_seam_pg.sql
+-- Per-user profile fields the WhoopProfile seam reads (PG): sleep-need hours,
+-- which weekday is the rest day, an optional manual max-HR override, and the
+-- device-reported IANA tz (distinct from profile.timezone, which is user-set;
+-- device_tz is what the WHOOP strap/phone last reported at ingest).
+ALTER TABLE profile ADD COLUMN IF NOT EXISTS sleep_need_h REAL DEFAULT 8.0;
+ALTER TABLE profile ADD COLUMN IF NOT EXISTS rest_weekday INTEGER DEFAULT 6;
+ALTER TABLE profile ADD COLUMN IF NOT EXISTS max_hr_override INTEGER;
+ALTER TABLE profile ADD COLUMN IF NOT EXISTS device_tz TEXT;

--- a/rivaflow/rivaflow/db/migrations/117_whoop_daily_agg.sql
+++ b/rivaflow/rivaflow/db/migrations/117_whoop_daily_agg.sql
@@ -1,0 +1,18 @@
+-- 117_whoop_daily_agg.sql
+-- SQLite local-dev variant of 117_whoop_daily_agg_pg.sql.
+-- (Keep these comments free of the semicolon character, which the migration runner splits on.)
+CREATE TABLE IF NOT EXISTS whoop_daily_agg (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL,
+    day             TEXT    NOT NULL,
+    metrics_json    TEXT    NOT NULL,
+    deriver_version TEXT    NOT NULL,
+    sample_count    INTEGER NOT NULL,
+    complete        BOOLEAN NOT NULL DEFAULT 1,
+    updated_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    UNIQUE (user_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS whoop_daily_agg_user_day_idx
+    ON whoop_daily_agg (user_id, day);

--- a/rivaflow/rivaflow/db/migrations/117_whoop_daily_agg_pg.sql
+++ b/rivaflow/rivaflow/db/migrations/117_whoop_daily_agg_pg.sql
@@ -1,0 +1,29 @@
+-- 117_whoop_daily_agg_pg.sql
+-- Append-only per-day rollup cache for the WHOOP data platform (PostgreSQL / production).
+-- See 117_whoop_daily_agg.sql for the SQLite (local dev) variant.
+--
+-- whoop_summary() re-scanned weeks of raw whoop_hr/whoop_rr rows on EVERY call — each of
+-- daily_resting_rmssd, daily_resting_hr, nightly_sleep_history, and daily_cardio_load independently
+-- re-derived HRV/resting-HR/sleep/cardio-load over their own N-day window every time. A day's raw rows
+-- rarely change once the day is over, so this table lets a historical day be computed ONCE and served
+-- from metrics_json thereafter — only today (still accruing) is ever computed live. sample_count is the
+-- staleness signal: the phone's offline spool and historical drains can land whoop_hr/whoop_rr rows for a
+-- day well after it first looked complete, so a stored day whose CURRENT raw count no longer matches what
+-- it was rolled up from gets recomputed. One row per (user_id, day), upserted in place — see
+-- rivaflow.core.services.whoop_daily_agg.
+-- (Keep these comments free of the semicolon character, which the migration runner treats as a
+--  statement separator even inside a comment.)
+CREATE TABLE IF NOT EXISTS whoop_daily_agg (
+    id              SERIAL      PRIMARY KEY,
+    user_id         INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    day             TEXT        NOT NULL,
+    metrics_json    TEXT        NOT NULL,
+    deriver_version TEXT        NOT NULL,
+    sample_count    INTEGER     NOT NULL,
+    complete        BOOLEAN     NOT NULL DEFAULT TRUE,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS whoop_daily_agg_user_day_idx
+    ON whoop_daily_agg (user_id, day);

--- a/rivaflow/rivaflow/db/repositories/whoop_repo.py
+++ b/rivaflow/rivaflow/db/repositories/whoop_repo.py
@@ -211,6 +211,82 @@ class WhoopRepository:
         )
 
     @staticmethod
+    def rr_range_between(user_id: int, start_iso: str, end_iso: str) -> list[dict]:
+        """RR intervals within [start, end] (inclusive), ascending — the bounded-window counterpart to
+        hr_range, for computing one specific historical day's rollup (whoop_daily_agg, Wave 3.4) where
+        rr_range's 'last N days from now' doesn't line up with an arbitrary past local day.
+        """
+        return BaseRepository._fetchall(
+            convert_query(
+                "SELECT ts, rr_ms FROM whoop_rr WHERE user_id = ? AND ts >= ? AND ts <= ? ORDER BY ts ASC"
+            ),
+            (user_id, start_iso, end_iso),
+        )
+
+    @staticmethod
+    def hr_count_range(user_id: int, start_iso: str, end_iso: str) -> int:
+        """COUNT(*) of whoop_hr rows in [start, end] — an index range-scan count, no row materialization.
+        Half of the whoop_daily_agg staleness check (see rr_count_range): a stored rollup whose CURRENT raw
+        count no longer matches the count it was computed from has had rows land late (the phone's offline
+        spool / a historical drain) and must be recomputed."""
+        row = BaseRepository._fetchone(
+            convert_query(
+                "SELECT COUNT(*) AS n FROM whoop_hr WHERE user_id = ? AND ts >= ? AND ts <= ?"
+            ),
+            (user_id, start_iso, end_iso),
+        )
+        return int(row["n"]) if row else 0
+
+    @staticmethod
+    def rr_count_range(user_id: int, start_iso: str, end_iso: str) -> int:
+        """COUNT(*) of whoop_rr rows in [start, end] — see hr_count_range."""
+        row = BaseRepository._fetchone(
+            convert_query(
+                "SELECT COUNT(*) AS n FROM whoop_rr WHERE user_id = ? AND ts >= ? AND ts <= ?"
+            ),
+            (user_id, start_iso, end_iso),
+        )
+        return int(row["n"]) if row else 0
+
+    # ── Daily aggregate rollups (whoop_daily_agg — Wave 3.4, append-only per-day compute cache) ──
+
+    @staticmethod
+    def get_daily_agg(user_id: int, day: str) -> dict | None:
+        """The stored rollup for one user/day, or None if this day has never been computed."""
+        return BaseRepository._fetchone(
+            convert_query(
+                "SELECT metrics_json, deriver_version, sample_count, complete, updated_at "
+                "FROM whoop_daily_agg WHERE user_id = ? AND day = ?"
+            ),
+            (user_id, day),
+        )
+
+    @staticmethod
+    def upsert_daily_agg(
+        user_id: int,
+        day: str,
+        metrics_json: str,
+        deriver_version: str,
+        sample_count: int,
+        complete: bool,
+    ) -> None:
+        """Insert or replace one day's rollup. A day is only ever REPLACED by a fresher computation of the
+        SAME day (deriver-version bump, or late-arriving raw data changing its sample_count) — never
+        deleted, so the table stays append-only in spirit."""
+        BaseRepository._execute(
+            convert_query(
+                "INSERT INTO whoop_daily_agg "
+                "(user_id, day, metrics_json, deriver_version, sample_count, complete, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP) "
+                "ON CONFLICT (user_id, day) DO UPDATE SET "
+                "metrics_json = EXCLUDED.metrics_json, deriver_version = EXCLUDED.deriver_version, "
+                "sample_count = EXCLUDED.sample_count, complete = EXCLUDED.complete, "
+                "updated_at = CURRENT_TIMESTAMP"
+            ),
+            (user_id, day, metrics_json, deriver_version, sample_count, complete),
+        )
+
+    @staticmethod
     def latest_capture(user_id: int) -> dict | None:
         """Most recent ingest heartbeat (capture-health)."""
         return BaseRepository._fetchone(

--- a/rivaflow/tests/unit/test_cardio_load.py
+++ b/rivaflow/tests/unit/test_cardio_load.py
@@ -198,9 +198,13 @@ def test_classify_hardness_matches_fallback_hard_fixture():
 
 
 def test_daily_cardio_load_carries_load_version(monkeypatch):
+    # Wave 3.4: daily_cardio_load now reads via the whoop_daily_agg rollup service, which fetches a
+    # bounded per-day window through hr_range/rr_range_between rather than recent_hr — with days=1 the
+    # only day requested is "today", so compute_day() runs directly (no rollup-store round trip to mock).
     rows = [{"ts": t.isoformat(), "bpm": bpm} for t, bpm in _rest_day_samples()]
+    monkeypatch.setattr(WhoopRepository, "hr_range", staticmethod(lambda *a, **k: rows))
     monkeypatch.setattr(
-        WhoopRepository, "recent_hr", staticmethod(lambda *a, **k: rows)
+        WhoopRepository, "rr_range_between", staticmethod(lambda *a, **k: [])
     )
     out = whoop_analytics.daily_cardio_load(1, days=1, max_hr=180)
     assert out, "expected at least one day of cardio load"

--- a/rivaflow/tests/unit/test_cardio_load.py
+++ b/rivaflow/tests/unit/test_cardio_load.py
@@ -1,0 +1,210 @@
+"""Wave 3.2 — Banister-TRIMP cardio load (pure; no DB, no network).
+
+Fixtures model two synthetic all-day HR streams (a quiet rest day, and a rest day plus a 90-minute hard
+BJJ session) at a fixed max_hr/rest_hr, used both to pin the 0-21 display band (scale_to_21) and to
+exercise the raw TRIMP math (banister_trimp/session_load) directly. `test_scale_to_21_*` are the pins the
+module's _SCALE_A/_SCALE_B were fit against — if those constants ever change, these are the tests that
+should catch it.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+
+import rivaflow.core.cardio_load as cl
+from rivaflow.core import whoop_analytics
+from rivaflow.core.cardio_load import (
+    banister_trimp,
+    classify_hardness,
+    hardness_cutoffs,
+    scale_to_21,
+    session_load,
+)
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+MAX_HR = 180.0
+REST_HR = 55.0
+HRR = MAX_HR - REST_HR
+
+
+# ── Synthetic fixtures ────────────────────────────────────────────────────────
+
+
+def _rest_day_samples(
+    start: datetime = datetime(2026, 1, 1, 6, 0, 0), hours: int = 14, step_sec: int = 5
+) -> list[tuple[datetime, int]]:
+    """~14h wear: baseline sinusoid 55-75bpm, two 15-min 'errand' blocks at ~90-110bpm."""
+    out = []
+    n = int(hours * 3600 / step_sec)
+    for i in range(n):
+        t = start + timedelta(seconds=i * step_sec)
+        minutes = i * step_sec / 60.0
+        bpm = 65 + 8 * math.sin(minutes / 37.0)
+        if 180 <= minutes < 195 or 420 <= minutes < 450:
+            bpm = 100 + 8 * math.sin(minutes / 3.0)
+        out.append((t, round(bpm)))
+    return out
+
+
+def _bjj_hard_block(
+    start: datetime, minutes: int = 90, step_sec: int = 2
+) -> list[tuple[datetime, int]]:
+    """90min oscillating between 75% and 92% HRR (~6min round+rest period) — a hard BJJ session."""
+    out = []
+    n = int(minutes * 60 / step_sec)
+    for i in range(n):
+        t = start + timedelta(seconds=i * step_sec)
+        m = i * step_sec / 60.0
+        frac = 0.5 * (1 - math.cos(2 * math.pi * m / 6.0))
+        pct_hrr = 0.75 + frac * (0.92 - 0.75)
+        bpm = REST_HR + pct_hrr * HRR
+        out.append((t, round(bpm)))
+    return out
+
+
+def _hard_day_samples() -> list[tuple[datetime, int]]:
+    """A rest day immediately followed by a 90min hard BJJ session."""
+    rest = _rest_day_samples()
+    hard = _bjj_hard_block(rest[-1][0] + timedelta(seconds=5))
+    return rest + hard
+
+
+# ── scale_to_21 band pins ──────────────────────────────────────────────────────
+
+
+def test_scale_to_21_rest_day_lands_in_light_band():
+    raw = banister_trimp(_rest_day_samples(), MAX_HR, REST_HR)
+    scaled = scale_to_21(raw)
+    assert 7.0 <= scaled <= 9.0
+
+
+def test_scale_to_21_hard_bjj_day_lands_in_hard_band():
+    raw = banister_trimp(_hard_day_samples(), MAX_HR, REST_HR)
+    scaled = scale_to_21(raw)
+    assert 15.0 <= scaled <= 17.0
+
+
+def test_scale_to_21_never_exceeds_21():
+    huge = [(datetime(2026, 1, 1) + timedelta(seconds=i), 179) for i in range(20000)]
+    raw = banister_trimp(huge, MAX_HR, REST_HR)
+    assert scale_to_21(raw) <= 21.0
+
+
+# ── gap-clamp behaviour ─────────────────────────────────────────────────────────
+
+
+def test_gap_clamp_bounds_a_long_dropout():
+    """A 2h capture dropout must add no more than the 10s-worth of load the clamp allows — not the full
+    2h of implied duration."""
+    samples = [
+        (datetime(2026, 1, 1, 6, 0, 0), 70),
+        (datetime(2026, 1, 1, 8, 0, 0), 70),  # 2h later
+    ]
+    raw = banister_trimp(samples, MAX_HR, REST_HR)
+    x = (70 - REST_HR) / HRR
+    max_allowed = (10.0 / 60.0) * x * 0.64 * math.exp(1.92 * x)
+    assert raw == max_allowed
+
+
+def test_gap_clamp_short_gap_is_uncapped():
+    """A normal <=10s gap contributes its actual duration, not the clamp ceiling."""
+    samples = [
+        (datetime(2026, 1, 1, 6, 0, 0), 70),
+        (datetime(2026, 1, 1, 6, 0, 3), 70),  # 3s later
+    ]
+    raw = banister_trimp(samples, MAX_HR, REST_HR)
+    x = (70 - REST_HR) / HRR
+    expected = (3.0 / 60.0) * x * 0.64 * math.exp(1.92 * x)
+    assert math.isclose(raw, expected, rel_tol=1e-9)
+
+
+# ── monotonicity ────────────────────────────────────────────────────────────────
+
+
+def test_more_time_at_higher_hrr_yields_more_load():
+    low = [(datetime(2026, 1, 1) + timedelta(seconds=i), 100) for i in range(600)]
+    high = [(datetime(2026, 1, 1) + timedelta(seconds=i), 160) for i in range(600)]
+    assert banister_trimp(high, MAX_HR, REST_HR) > banister_trimp(low, MAX_HR, REST_HR)
+
+
+def test_more_duration_at_same_intensity_yields_more_load():
+    short = [(datetime(2026, 1, 1) + timedelta(seconds=i), 150) for i in range(300)]
+    long_ = [(datetime(2026, 1, 1) + timedelta(seconds=i), 150) for i in range(600)]
+    assert banister_trimp(long_, MAX_HR, REST_HR) > banister_trimp(
+        short, MAX_HR, REST_HR
+    )
+
+
+# ── degenerate inputs ───────────────────────────────────────────────────────────
+
+
+def test_empty_samples_is_zero():
+    assert banister_trimp([], MAX_HR, REST_HR) == 0.0
+    assert session_load([], MAX_HR, REST_HR) == 0.0
+
+
+def test_max_hr_at_or_below_rest_hr_is_zero():
+    samples = [(datetime(2026, 1, 1) + timedelta(seconds=i), 150) for i in range(100)]
+    assert banister_trimp(samples, rest_hr=100.0, max_hr=100.0) == 0.0
+    assert banister_trimp(samples, rest_hr=100.0, max_hr=90.0) == 0.0
+
+
+def test_session_load_matches_banister_trimp():
+    samples = _bjj_hard_block(datetime(2026, 1, 1, 18, 0, 0))
+    assert session_load(samples, MAX_HR, REST_HR) == banister_trimp(
+        samples, MAX_HR, REST_HR
+    )
+
+
+# ── hardness cutoffs + classification ────────────────────────────────────────────
+
+
+def test_hardness_cutoffs_fallback_below_eight_samples():
+    loads = [10.0, 20.0, 30.0]
+    assert hardness_cutoffs(loads) == (
+        cl._FALLBACK_MODERATE_CUTOFF,
+        cl._FALLBACK_HARD_CUTOFF,
+    )
+
+
+def test_hardness_cutoffs_percentile_path_at_eight_samples():
+    loads = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+    moderate, hard = hardness_cutoffs(loads)
+    assert (moderate, hard) != (cl._FALLBACK_MODERATE_CUTOFF, cl._FALLBACK_HARD_CUTOFF)
+    assert moderate == cl._percentile(loads, 40)
+    assert hard == cl._percentile(loads, 75)
+    assert moderate < hard
+
+
+def test_classify_hardness_labels():
+    cutoffs = (10.0, 20.0)
+    assert classify_hardness(25.0, cutoffs) == "HARD"
+    assert classify_hardness(20.0, cutoffs) == "HARD"  # boundary is inclusive
+    assert classify_hardness(15.0, cutoffs) == "MODERATE"
+    assert classify_hardness(10.0, cutoffs) == "MODERATE"  # boundary is inclusive
+    assert classify_hardness(5.0, cutoffs) == "EASY"
+
+
+def test_classify_hardness_matches_fallback_hard_fixture():
+    """The synthetic hard-BJJ session the fallback HARD_CUTOFF was anchored on must itself classify HARD."""
+    samples = _bjj_hard_block(datetime(2026, 1, 1, 18, 0, 0))
+    raw = session_load(samples, MAX_HR, REST_HR)
+    cutoffs = hardness_cutoffs([])  # <8 -> fallback
+    assert classify_hardness(raw, cutoffs) == "HARD"
+
+
+# ── load_version threaded through daily_cardio_load ──────────────────────────────
+
+
+def test_daily_cardio_load_carries_load_version(monkeypatch):
+    rows = [{"ts": t.isoformat(), "bpm": bpm} for t, bpm in _rest_day_samples()]
+    monkeypatch.setattr(
+        WhoopRepository, "recent_hr", staticmethod(lambda *a, **k: rows)
+    )
+    out = whoop_analytics.daily_cardio_load(1, days=1, max_hr=180)
+    assert out, "expected at least one day of cardio load"
+    for day in out:
+        assert day["load_version"] == cl.LOAD_VERSION
+        assert "cardio_load" in day
+        assert "raw_trimp" in day

--- a/rivaflow/tests/unit/test_whoop_daily_agg.py
+++ b/rivaflow/tests/unit/test_whoop_daily_agg.py
@@ -1,0 +1,434 @@
+"""Wave 3.4 — whoop_daily_agg per-day rollup service (pure; no DB, no network).
+
+Verifies the rollup contract: a missing day is computed + upserted, a fresh stored day is served WITHOUT
+recompute, a day whose raw HR+RR count has grown since it was rolled up (the late-data case — the phone's
+offline spool / a historical drain) forces a recompute, a deriver-version bump forces a recompute, today is
+always computed live and never persisted, and get_range's per-day series matches compute_day's own output
+field-for-field. Also covers the route-level render-duration WARN threshold — the other half of Wave 3.4,
+which retired the whoop_summary TTL cache now that historical days are rolled up once instead of re-scanned
+on every call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import rivaflow.api.routes.whoop as whoop_route
+import rivaflow.core.services.whoop_daily_agg as wda
+from rivaflow.core import whoop_analytics
+from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+MELBOURNE = ZoneInfo("Australia/Melbourne")
+TODAY = date(2026, 7, 10)
+YESTERDAY = date(2026, 7, 9)
+TWO_DAYS_AGO = date(2026, 7, 8)
+
+RMSSD_METRIC = {
+    "rmssd": 40.0,
+    "ln_rmssd": 3.7,
+    "quality": {"artifact_pct": 2.0},
+    "coverage": {"rr_minutes": 20.0},
+}
+RESTING_HR_METRIC = {"resting_hr": 52, "min_hr": 50, "samples": 400}
+SLEEP_METRIC = {
+    "available": True,
+    "duration_hours": 7.5,
+    "sleep_start": "x",
+    "sleep_end": "y",
+}
+CARDIO_METRIC = {"cardio_load": 9.0, "raw_trimp": 40.0, "load_version": "banister-v1"}
+
+
+def _ts(d: date, hour: int, minute: int = 0) -> str:
+    return datetime(d.year, d.month, d.day, hour, minute, tzinfo=MELBOURNE).isoformat()
+
+
+def _fixed_now(fixed: datetime):
+    """Same pattern as test_whoop_profile.py's _fixed_now — a datetime subclass whose .now() is pinned."""
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    return _FixedDatetime
+
+
+class _FakeProfile:
+    tz = MELBOURNE
+
+
+class _RawStore:
+    """Stand-in for whoop_hr/whoop_rr: (ts_iso, value) pairs, filtered by [start, end] like the real
+    bounded-window repository queries."""
+
+    def __init__(self) -> None:
+        self.hr: list[tuple[str, int]] = []
+        self.rr: list[tuple[str, int]] = []
+
+    def hr_range(self, user_id, start_iso, end_iso):
+        return [
+            {"ts": ts, "bpm": bpm} for ts, bpm in self.hr if start_iso <= ts <= end_iso
+        ]
+
+    def rr_range_between(self, user_id, start_iso, end_iso):
+        return [
+            {"ts": ts, "rr_ms": v} for ts, v in self.rr if start_iso <= ts <= end_iso
+        ]
+
+    def hr_count_range(self, user_id, start_iso, end_iso):
+        return len(self.hr_range(user_id, start_iso, end_iso))
+
+    def rr_count_range(self, user_id, start_iso, end_iso):
+        return len(self.rr_range_between(user_id, start_iso, end_iso))
+
+
+class _RollupStore:
+    """Stand-in for whoop_daily_agg."""
+
+    def __init__(self) -> None:
+        self.rows: dict[tuple[int, str], dict] = {}
+
+    def get(self, user_id, day):
+        return self.rows.get((user_id, day))
+
+    def upsert(
+        self, user_id, day, metrics_json, deriver_version, sample_count, complete
+    ):
+        self.rows[(user_id, day)] = {
+            "metrics_json": metrics_json,
+            "deriver_version": deriver_version,
+            "sample_count": sample_count,
+            "complete": complete,
+        }
+
+
+def _install_fakes(monkeypatch) -> tuple[_RawStore, _RollupStore]:
+    raw = _RawStore()
+    rollup = _RollupStore()
+    monkeypatch.setattr(WhoopRepository, "hr_range", staticmethod(raw.hr_range))
+    monkeypatch.setattr(
+        WhoopRepository, "rr_range_between", staticmethod(raw.rr_range_between)
+    )
+    monkeypatch.setattr(
+        WhoopRepository, "hr_count_range", staticmethod(raw.hr_count_range)
+    )
+    monkeypatch.setattr(
+        WhoopRepository, "rr_count_range", staticmethod(raw.rr_count_range)
+    )
+    monkeypatch.setattr(WhoopRepository, "get_daily_agg", staticmethod(rollup.get))
+    monkeypatch.setattr(
+        WhoopRepository, "upsert_daily_agg", staticmethod(rollup.upsert)
+    )
+    return raw, rollup
+
+
+def _freeze(
+    monkeypatch, when: datetime = datetime(2026, 7, 10, 9, 0, tzinfo=MELBOURNE)
+) -> None:
+    monkeypatch.setattr(wda, "datetime", _fixed_now(when))
+    monkeypatch.setattr(wda, "get_whoop_profile", lambda uid: _FakeProfile())
+    # get_range's "cardio" branch calls whoop_analytics.user_max_hr when no max_hr is supplied — stub it
+    # so it never falls through to a real (unmocked) WhoopRepository.recent_hr scan.
+    monkeypatch.setattr(whoop_analytics, "user_max_hr", lambda uid: {"max_hr": 180.0})
+
+
+def _stub_day_math(
+    monkeypatch,
+    *,
+    rmssd=RMSSD_METRIC,
+    resting_hr=RESTING_HR_METRIC,
+    sleep=SLEEP_METRIC,
+    cardio=CARDIO_METRIC,
+) -> dict[str, int]:
+    """Stub the per-day math whoop_analytics owns (see whoop_analytics._day_rmssd/_day_resting_hr/
+    _day_sleep/_day_cardio) so these tests exercise ONLY the rollup orchestration — the math itself is
+    covered where it lives (e.g. tests/unit/test_cardio_load.py)."""
+    called = {"rmssd": 0, "resting_hr": 0, "sleep": 0, "cardio": 0}
+
+    def _rmssd(rr_vals, hr_count):
+        called["rmssd"] += 1
+        return rmssd
+
+    def _resting_hr(bpms):
+        called["resting_hr"] += 1
+        return resting_hr
+
+    def _sleep(uid, day, tz):
+        called["sleep"] += 1
+        return sleep
+
+    def _cardio(samples, mx, rest):
+        called["cardio"] += 1
+        return cardio
+
+    monkeypatch.setattr(whoop_analytics, "_day_rmssd", _rmssd)
+    monkeypatch.setattr(whoop_analytics, "_day_resting_hr", _resting_hr)
+    monkeypatch.setattr(whoop_analytics, "_day_sleep", _sleep)
+    monkeypatch.setattr(whoop_analytics, "_day_cardio", _cardio)
+    return called
+
+
+# ── (a) missing day → computed + upserted ─────────────────────────────────────
+
+
+def test_missing_day_is_computed_and_upserted(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(YESTERDAY, 10), 60), (_ts(YESTERDAY, 11), 61)]
+    raw.rr = [(_ts(YESTERDAY, 10), 900)]
+
+    result = wda._rollup_for_day(1, YESTERDAY.isoformat(), MELBOURNE, max_hr=None)
+
+    assert result is not None
+    assert result["rmssd"] == RMSSD_METRIC
+    assert result["cardio"] == CARDIO_METRIC
+    stored = rollup.get(1, YESTERDAY.isoformat())
+    assert stored is not None
+    assert stored["deriver_version"] == wda.DERIVER_VERSION
+    assert stored["sample_count"] == 3  # 2 hr + 1 rr
+    assert json.loads(stored["metrics_json"])["cardio"] == CARDIO_METRIC
+
+
+def test_day_with_no_raw_data_returns_none_and_writes_nothing(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    _stub_day_math(monkeypatch)
+    # raw.hr / raw.rr stay empty for YESTERDAY
+
+    result = wda._rollup_for_day(1, YESTERDAY.isoformat(), MELBOURNE, max_hr=None)
+
+    assert result is None
+    assert rollup.get(1, YESTERDAY.isoformat()) is None
+
+
+# ── (b) fresh stored day → served WITHOUT recompute ───────────────────────────
+
+
+def test_fresh_stored_day_is_served_without_recompute(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    called = _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(YESTERDAY, 10), 60)]
+    raw.rr = [(_ts(YESTERDAY, 10), 900)]
+    rollup.upsert(
+        1,
+        YESTERDAY.isoformat(),
+        json.dumps(
+            {
+                "day": YESTERDAY.isoformat(),
+                "rmssd": RMSSD_METRIC,
+                "resting_hr": RESTING_HR_METRIC,
+                "sleep": SLEEP_METRIC,
+                "cardio": CARDIO_METRIC,
+            }
+        ),
+        wda.DERIVER_VERSION,
+        2,
+        True,
+    )
+
+    result = wda._rollup_for_day(1, YESTERDAY.isoformat(), MELBOURNE, max_hr=None)
+
+    assert result["rmssd"] == RMSSD_METRIC
+    assert called == {"rmssd": 0, "resting_hr": 0, "sleep": 0, "cardio": 0}
+
+
+# ── (c) late-arriving data (raw count grew since rollup) → recomputed ─────────
+
+
+def test_late_arriving_data_forces_recompute(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    called = _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(YESTERDAY, 10), 60)]
+    raw.rr = [(_ts(YESTERDAY, 10), 900)]
+    rollup.upsert(
+        1,
+        YESTERDAY.isoformat(),
+        json.dumps({"day": YESTERDAY.isoformat()}),
+        wda.DERIVER_VERSION,
+        2,  # rolled up when only 2 raw rows existed
+        True,
+    )
+    # a historical drain lands one more HR row for yesterday AFTER it was first rolled up
+    raw.hr.append((_ts(YESTERDAY, 23), 58))
+
+    result = wda._rollup_for_day(1, YESTERDAY.isoformat(), MELBOURNE, max_hr=None)
+
+    assert called["rmssd"] == 1
+    stored = rollup.get(1, YESTERDAY.isoformat())
+    assert stored["sample_count"] == 3
+    assert result["rmssd"] == RMSSD_METRIC
+
+
+# ── (d) deriver-version bump → recomputed ─────────────────────────────────────
+
+
+def test_deriver_version_bump_forces_recompute(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    called = _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(YESTERDAY, 10), 60)]
+    raw.rr = [(_ts(YESTERDAY, 10), 900)]
+    rollup.upsert(
+        1,
+        YESTERDAY.isoformat(),
+        json.dumps({"day": YESTERDAY.isoformat()}),
+        "stale-deriver-version",
+        2,
+        True,
+    )
+
+    result = wda._rollup_for_day(1, YESTERDAY.isoformat(), MELBOURNE, max_hr=None)
+
+    assert called["rmssd"] == 1
+    assert (
+        rollup.get(1, YESTERDAY.isoformat())["deriver_version"] == wda.DERIVER_VERSION
+    )
+    assert result["rmssd"] == RMSSD_METRIC
+
+
+# ── (e) today is always live, never persisted ─────────────────────────────────
+
+
+def test_today_is_never_persisted(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    called = _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(TODAY, 10), 60)]
+    raw.rr = [(_ts(TODAY, 10), 900)]
+
+    series = wda.get_range(1, 1, "cardio")
+
+    assert series == [{"day": TODAY.isoformat(), **CARDIO_METRIC}]
+    assert rollup.get(1, TODAY.isoformat()) is None
+    assert called["cardio"] == 1
+
+    # calling again re-derives today from scratch — nothing was cached for it
+    series_again = wda.get_range(1, 1, "cardio")
+    assert series_again == series
+    assert called["cardio"] == 2
+
+
+def test_sleep_series_excludes_today_by_construction(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(TODAY, 10), 60)]
+    raw.rr = [(_ts(TODAY, 10), 900)]
+
+    series = wda.get_range(1, 1, "sleep")
+
+    # the only day with raw data is TODAY, and sleep's day_list never includes today
+    assert series == []
+
+
+# ── (f) get_range's per-day series matches compute_day field-for-field ────────
+
+
+def test_get_range_matches_compute_day_per_field(monkeypatch):
+    _freeze(monkeypatch)
+    raw, rollup = _install_fakes(monkeypatch)
+    _stub_day_math(monkeypatch)
+    for d in (TWO_DAYS_AGO, YESTERDAY, TODAY):
+        raw.hr.append((_ts(d, 10), 60))
+        raw.rr.append((_ts(d, 10), 900))
+
+    for metric, expected in (
+        ("rmssd", RMSSD_METRIC),
+        ("resting_hr", RESTING_HR_METRIC),
+        ("cardio", CARDIO_METRIC),
+    ):
+        series = wda.get_range(1, 3, metric)
+        assert [e["day"] for e in series] == [
+            TWO_DAYS_AGO.isoformat(),
+            YESTERDAY.isoformat(),
+            TODAY.isoformat(),
+        ]
+        for entry in series:
+            assert {k: v for k, v in entry.items() if k != "day"} == expected
+
+    # sleep: nights back, excludes today — same 2 historical days
+    sleep_series = wda.get_range(1, 2, "sleep")
+    assert sleep_series == [SLEEP_METRIC, SLEEP_METRIC]
+
+    # cross-check against compute_day directly, for the same synthetic fixture
+    for d in (TWO_DAYS_AGO, YESTERDAY):
+        direct = wda.compute_day(1, d.isoformat(), max_hr=180.0)
+        assert direct["rmssd"] == RMSSD_METRIC
+        assert direct["resting_hr"] == RESTING_HR_METRIC
+        assert direct["cardio"] == CARDIO_METRIC
+        assert direct["sleep"] == SLEEP_METRIC
+        assert direct["sample_count"] == 2
+        assert direct["complete"] is True
+
+
+# ── compute_day: sample_count + complete flag (pure math, no DB) ──────────────
+
+
+def test_compute_day_sample_count_and_complete_flag(monkeypatch):
+    _freeze(monkeypatch)
+    raw, _rollup = _install_fakes(monkeypatch)
+    _stub_day_math(monkeypatch)
+    raw.hr = [(_ts(YESTERDAY, h), 60) for h in range(5)]
+    raw.rr = [(_ts(YESTERDAY, 5), 900), (_ts(YESTERDAY, 6), 910)]
+
+    result = wda.compute_day(1, YESTERDAY.isoformat(), max_hr=180.0)
+
+    assert result["sample_count"] == 7  # 5 hr + 2 rr
+    assert result["complete"] is True
+
+
+def test_compute_day_incomplete_when_a_metric_is_unavailable(monkeypatch):
+    _freeze(monkeypatch)
+    raw, _rollup = _install_fakes(monkeypatch)
+    _stub_day_math(monkeypatch, resting_hr=None)
+    raw.hr = [(_ts(YESTERDAY, 10), 60)]
+    raw.rr = [(_ts(YESTERDAY, 10), 900)]
+
+    result = wda.compute_day(1, YESTERDAY.isoformat(), max_hr=180.0)
+
+    assert result["resting_hr"] is None
+    assert result["complete"] is False
+
+
+# ── (g) route-level render-duration WARN threshold (Wave 3.4 — TTL cache retired) ──
+
+
+def test_slow_summary_logs_warning(monkeypatch, caplog):
+    times = iter([0.0, 2.5])  # 2500ms elapsed — over the 2000ms budget
+    monkeypatch.setattr(whoop_route.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(
+        "rivaflow.core.whoop_analytics.whoop_summary", lambda *a, **k: {"ok": True}
+    )
+    with caplog.at_level(logging.INFO, logger="rivaflow.api.routes.whoop"):
+        result = whoop_route._timed_whoop_summary(1, today_is_sabbath=False)
+
+    assert result == {"ok": True}
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "over the" in warnings[0].message
+
+
+def test_fast_summary_does_not_log_warning(monkeypatch, caplog):
+    times = iter([0.0, 0.1])  # 100ms elapsed — under budget
+    monkeypatch.setattr(whoop_route.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(
+        "rivaflow.core.whoop_analytics.whoop_summary", lambda *a, **k: {"ok": True}
+    )
+    with caplog.at_level(logging.INFO, logger="rivaflow.api.routes.whoop"):
+        whoop_route._timed_whoop_summary(1, today_is_sabbath=False)
+
+    assert not any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_ttl_cache_mechanism_is_gone():
+    """The band-aid this wave retires — regression guard against it creeping back."""
+    assert not hasattr(whoop_route, "_cached_whoop_summary")
+    assert not hasattr(whoop_route, "_SUMMARY_CACHE")
+    assert not hasattr(whoop_route, "_SUMMARY_TTL_S")

--- a/rivaflow/tests/unit/test_whoop_ingest_device_tz.py
+++ b/rivaflow/tests/unit/test_whoop_ingest_device_tz.py
@@ -1,0 +1,96 @@
+"""Wave 3.6 — ingest device_tz persistence helper (pure logic; DB calls mocked).
+
+`_persist_device_tz` is the factored-out piece of the /whoop/ingest route that
+validates a phone-reported IANA tz and writes it to profile.device_tz only when
+it's a genuine change — never per-batch, never on an invalid tz, never raising
+(the ingest route must always return 200 regardless of this helper's outcome).
+"""
+
+from __future__ import annotations
+
+from rivaflow.api.routes import whoop as whoop_route
+from rivaflow.db.repositories.base_repository import BaseRepository
+
+
+def test_persist_skips_when_no_device_tz(monkeypatch):
+    calls = {"fetch": 0, "execute": 0}
+    monkeypatch.setattr(
+        BaseRepository,
+        "_fetchone",
+        staticmethod(lambda *a, **k: calls.__setitem__("fetch", calls["fetch"] + 1)),
+    )
+    monkeypatch.setattr(
+        BaseRepository,
+        "_execute",
+        staticmethod(
+            lambda *a, **k: calls.__setitem__("execute", calls["execute"] + 1)
+        ),
+    )
+    whoop_route._persist_device_tz(1, None)
+    assert calls == {"fetch": 0, "execute": 0}
+
+
+def test_persist_ignores_invalid_tz(monkeypatch):
+    execute_calls = []
+    monkeypatch.setattr(
+        BaseRepository,
+        "_execute",
+        staticmethod(lambda *a, **k: execute_calls.append((a, k))),
+    )
+    # No _fetchone patch needed — an invalid tz must short-circuit before any DB read.
+    monkeypatch.setattr(
+        BaseRepository,
+        "_fetchone",
+        staticmethod(
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not query"))
+        ),
+    )
+    whoop_route._persist_device_tz(1, "Not/A/Real/Zone")
+    assert execute_calls == []
+
+
+def test_persist_writes_on_genuine_change(monkeypatch):
+    monkeypatch.setattr(
+        BaseRepository,
+        "_fetchone",
+        staticmethod(lambda *a, **k: {"device_tz": "Australia/Melbourne"}),
+    )
+    execute_calls = []
+    monkeypatch.setattr(
+        BaseRepository,
+        "_execute",
+        staticmethod(lambda *a, **k: execute_calls.append((a, k))),
+    )
+    whoop_route._persist_device_tz(1, "America/Chicago")
+    assert len(execute_calls) == 1
+    query, params = execute_calls[0][0]
+    assert "UPDATE profile SET device_tz" in query
+    assert params == ("America/Chicago", 1)
+
+
+def test_persist_skips_when_value_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        BaseRepository,
+        "_fetchone",
+        staticmethod(lambda *a, **k: {"device_tz": "America/Chicago"}),
+    )
+    execute_calls = []
+    monkeypatch.setattr(
+        BaseRepository,
+        "_execute",
+        staticmethod(lambda *a, **k: execute_calls.append((a, k))),
+    )
+    whoop_route._persist_device_tz(1, "America/Chicago")
+    assert execute_calls == []
+
+
+def test_persist_skips_when_no_profile_row_yet(monkeypatch):
+    monkeypatch.setattr(BaseRepository, "_fetchone", staticmethod(lambda *a, **k: None))
+    execute_calls = []
+    monkeypatch.setattr(
+        BaseRepository,
+        "_execute",
+        staticmethod(lambda *a, **k: execute_calls.append((a, k))),
+    )
+    whoop_route._persist_device_tz(1, "America/Chicago")
+    assert execute_calls == []  # no profile row to update — never fabricate one here

--- a/rivaflow/tests/unit/test_whoop_narrative.py
+++ b/rivaflow/tests/unit/test_whoop_narrative.py
@@ -59,7 +59,7 @@ def test_llm_disabled_returns_rule_based(monkeypatch):
 def test_llm_enabled_uses_honest_output(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     _stub_rule_based(monkeypatch)
-    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda uid: False)
     story = "Your resting HR has crept up three days running while HRV held — ease into technical work."
     _stub_client(monkeypatch, content=story)
     assert (
@@ -74,7 +74,7 @@ def test_llm_enabled_uses_honest_output(monkeypatch):
 def test_diagnosis_output_falls_back(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
-    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda uid: False)
     _stub_client(
         monkeypatch, content="Your numbers suggest you have the flu — rest up."
     )
@@ -87,7 +87,7 @@ def test_diagnosis_output_falls_back(monkeypatch):
 def test_false_health_allclear_falls_back(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
-    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda uid: False)
     _stub_client(
         monkeypatch, content="Everything's green — you're healthy, push hard today."
     )
@@ -103,7 +103,7 @@ def test_false_health_allclear_falls_back(monkeypatch):
 def test_client_exception_falls_back(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
-    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda uid: False)
     _stub_client(monkeypatch, raises=RuntimeError("all providers down"))
     assert (
         wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
@@ -114,7 +114,7 @@ def test_client_exception_falls_back(monkeypatch):
 def test_empty_output_falls_back(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
-    monkeypatch.setattr(wn, "_is_sabbath", lambda: False)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda uid: False)
     _stub_client(monkeypatch, content="   ")
     assert (
         wn.compose_narrative(1, readiness=READY, night=NIGHT, cross_signals=CROSS)
@@ -128,7 +128,7 @@ def test_empty_output_falls_back(monkeypatch):
 def test_sabbath_always_rule_based(monkeypatch):
     monkeypatch.setenv("WHOOP_NARRATIVE_LLM", "1")
     sentinel = _stub_rule_based(monkeypatch)
-    monkeypatch.setattr(wn, "_is_sabbath", lambda: True)
+    monkeypatch.setattr(wn, "_is_sabbath", lambda uid: True)
     _stub_client(
         monkeypatch, raises=AssertionError("model must not be called on the Sabbath")
     )

--- a/rivaflow/tests/unit/test_whoop_profile.py
+++ b/rivaflow/tests/unit/test_whoop_profile.py
@@ -140,6 +140,34 @@ def test_is_rest_day_evaluates_in_profile_tz():
     assert wp.is_rest_day(profile, almost_midnight_utc) is True
 
 
+# ── today_is_rest_day (route-level convenience) ───────────────────────────────
+
+
+def _fixed_now(fixed: datetime):
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    return _FixedDatetime
+
+
+def test_today_is_rest_day_true_on_configured_rest_day(monkeypatch):
+    profile = wp._row_to_profile(1, {})  # default rest_weekday=6 (Sunday)
+    monkeypatch.setattr(wp, "get_whoop_profile", lambda uid: profile)
+    sunday = datetime(2026, 7, 12, 9, 0, tzinfo=MELBOURNE)  # 12 Jul 2026 is a Sunday
+    monkeypatch.setattr(wp, "datetime", _fixed_now(sunday))
+    assert wp.today_is_rest_day(1) is True
+
+
+def test_today_is_rest_day_false_on_non_rest_day(monkeypatch):
+    profile = wp._row_to_profile(1, {})
+    monkeypatch.setattr(wp, "get_whoop_profile", lambda uid: profile)
+    monday = datetime(2026, 7, 13, 9, 0, tzinfo=MELBOURNE)
+    monkeypatch.setattr(wp, "datetime", _fixed_now(monday))
+    assert wp.today_is_rest_day(1) is False
+
+
 # ── cache behaviour ────────────────────────────────────────────────────────────
 
 

--- a/rivaflow/tests/unit/test_whoop_profile.py
+++ b/rivaflow/tests/unit/test_whoop_profile.py
@@ -1,0 +1,189 @@
+"""Wave 3.6 — WhoopProfile seam (pure; no DB, no network).
+
+Verifies: defaults on a missing/empty profile row match the old hardcoded
+RUBY_AGE/LOCAL_TZ behaviour byte-for-byte, device_tz resolution order,
+the rest-day helper, the ingest device_tz persistence helper, and that
+`_local_day` with a default (empty) profile is identical to the pre-seam
+Melbourne-only behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import rivaflow.core.whoop_profile as wp
+from rivaflow.core import whoop_analytics
+
+MELBOURNE = ZoneInfo("Australia/Melbourne")
+FIXED_TODAY = date(2026, 7, 10)
+
+# The old hardcoded RUBY_AGE=44 was derived from DOB 1982-05-27 at some point in the
+# past; recomputed against FIXED_TODAY it must still land on 44 (July 10 is after the
+# May 27 birthday in 2026, so no -1 adjustment).
+OLD_RUBY_AGE = 44
+
+
+def teardown_function():
+    wp._clear_profile_cache()
+
+
+# ── (a) defaults: empty/missing profile row ──────────────────────────────────
+
+
+def test_default_age_matches_old_ruby_age():
+    assert wp._default_age(today=FIXED_TODAY) == OLD_RUBY_AGE
+
+
+def test_missing_row_resolves_full_defaults(monkeypatch):
+    monkeypatch.setattr(
+        wp.BaseRepository, "_fetchone", staticmethod(lambda *a, **k: None)
+    )
+    profile = wp.get_whoop_profile(1)
+    assert profile.tz == MELBOURNE
+    assert profile.age == wp._default_age()
+    assert profile.sleep_need_h == 8.0
+    assert profile.rest_weekday == 6
+    assert profile.max_hr_override is None
+
+
+def test_empty_row_dict_resolves_full_defaults():
+    profile = wp._row_to_profile(1, {})
+    assert profile.tz == MELBOURNE
+    assert profile.age == wp._default_age()
+    assert profile.sleep_need_h == 8.0
+    assert profile.rest_weekday == 6
+    assert profile.max_hr_override is None
+
+
+def test_db_error_resolves_full_defaults(monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(wp.BaseRepository, "_fetchone", staticmethod(_boom))
+    profile = wp.get_whoop_profile(1)
+    assert profile.tz == MELBOURNE
+    assert profile.age == wp._default_age()
+
+
+def test_populated_row_overrides_defaults():
+    row = {
+        "date_of_birth": "1990-01-01",
+        "timezone": "America/New_York",
+        "device_tz": None,
+        "sleep_need_h": 9.5,
+        "rest_weekday": 2,
+        "max_hr_override": 180,
+    }
+    profile = wp._row_to_profile(1, row)
+    assert profile.tz == ZoneInfo("America/New_York")
+    assert profile.sleep_need_h == 9.5
+    assert profile.rest_weekday == 2
+    assert profile.max_hr_override == 180
+    assert profile.age == wp._age_from_dob("1990-01-01")
+
+
+# ── (b) device_tz resolution order ────────────────────────────────────────────
+
+
+def test_tz_resolution_prefers_device_tz_over_timezone():
+    tz = wp._resolve_tz("America/Chicago", "Australia/Sydney")
+    assert tz == ZoneInfo("America/Chicago")
+
+
+def test_tz_resolution_falls_back_to_timezone():
+    tz = wp._resolve_tz(None, "Australia/Sydney")
+    assert tz == ZoneInfo("Australia/Sydney")
+
+
+def test_tz_resolution_falls_back_to_melbourne_default():
+    assert wp._resolve_tz(None, None) == MELBOURNE
+
+
+def test_tz_resolution_skips_invalid_device_tz():
+    tz = wp._resolve_tz("Not/A/Real/Zone", "Australia/Sydney")
+    assert tz == ZoneInfo("Australia/Sydney")
+
+
+def test_tz_resolution_skips_invalid_both():
+    tz = wp._resolve_tz("Nope", "AlsoNope")
+    assert tz == MELBOURNE
+
+
+# ── (c) rest-day helper ────────────────────────────────────────────────────────
+
+
+def test_is_rest_day_sunday_in_melbourne_true():
+    profile = wp._row_to_profile(1, {})  # default rest_weekday=6 (Sunday)
+    sunday = datetime(2026, 7, 12, 10, 0, tzinfo=MELBOURNE)  # 12 Jul 2026 is a Sunday
+    assert wp.is_rest_day(profile, sunday) is True
+
+
+def test_is_rest_day_monday_false():
+    profile = wp._row_to_profile(1, {})
+    monday = datetime(2026, 7, 13, 10, 0, tzinfo=MELBOURNE)
+    assert wp.is_rest_day(profile, monday) is False
+
+
+def test_is_rest_day_custom_rest_weekday():
+    profile = wp._row_to_profile(1, {"rest_weekday": 2})  # Wednesday
+    wednesday = datetime(2026, 7, 15, 10, 0, tzinfo=MELBOURNE)
+    sunday = datetime(2026, 7, 12, 10, 0, tzinfo=MELBOURNE)
+    assert wp.is_rest_day(profile, wednesday) is True
+    assert wp.is_rest_day(profile, sunday) is False
+
+
+def test_is_rest_day_evaluates_in_profile_tz():
+    # 23:30 UTC on Saturday is already Sunday in Melbourne (+10/+11h).
+    profile = wp._row_to_profile(1, {})
+    almost_midnight_utc = datetime(2026, 7, 11, 23, 30, tzinfo=ZoneInfo("UTC"))
+    assert wp.is_rest_day(profile, almost_midnight_utc) is True
+
+
+# ── cache behaviour ────────────────────────────────────────────────────────────
+
+
+def test_profile_is_cached_within_ttl(monkeypatch):
+    calls = {"n": 0}
+
+    def _fetch(*a, **k):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(wp.BaseRepository, "_fetchone", staticmethod(_fetch))
+    wp.get_whoop_profile(1)
+    wp.get_whoop_profile(1)
+    assert calls["n"] == 1  # second call served from cache
+
+
+def test_clear_profile_cache_forces_refetch(monkeypatch):
+    calls = {"n": 0}
+
+    def _fetch(*a, **k):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(wp.BaseRepository, "_fetchone", staticmethod(_fetch))
+    wp.get_whoop_profile(1)
+    wp._clear_profile_cache()
+    wp.get_whoop_profile(1)
+    assert calls["n"] == 2
+
+
+# ── (e) ANTI-criterion: _local_day with a default profile == old Melbourne
+#     behaviour ─────────────────────────────────────────────────────────────
+
+
+def test_local_day_default_matches_old_melbourne_behaviour():
+    # 2026-07-11 14:00 UTC is 2026-07-12 00:00 in Melbourne (+10h, winter/AEST) —
+    # exactly the kind of UTC-day-boundary case the local-day bucketing exists for.
+    ts = "2026-07-11T14:00:00Z"
+    assert whoop_analytics._local_day(ts) == "2026-07-12"
+    # Explicit Melbourne tz must be identical to the default.
+    assert whoop_analytics._local_day(ts, MELBOURNE) == whoop_analytics._local_day(ts)
+
+
+def test_local_day_with_non_default_tz_differs():
+    ts = "2026-07-11T14:00:00Z"
+    # Same instant is still 2026-07-11 in UTC itself.
+    assert whoop_analytics._local_day(ts, ZoneInfo("UTC")) == "2026-07-11"

--- a/rivaflow/tests/unit/test_whoop_profile.py
+++ b/rivaflow/tests/unit/test_whoop_profile.py
@@ -42,7 +42,7 @@ def test_missing_row_resolves_full_defaults(monkeypatch):
     profile = wp.get_whoop_profile(1)
     assert profile.tz == MELBOURNE
     assert profile.age == wp._default_age()
-    assert profile.sleep_need_h == 8.0
+    assert profile.sleep_need_h == 9.0
     assert profile.rest_weekday == 6
     assert profile.max_hr_override is None
 
@@ -51,7 +51,7 @@ def test_empty_row_dict_resolves_full_defaults():
     profile = wp._row_to_profile(1, {})
     assert profile.tz == MELBOURNE
     assert profile.age == wp._default_age()
-    assert profile.sleep_need_h == 8.0
+    assert profile.sleep_need_h == 9.0
     assert profile.rest_weekday == 6
     assert profile.max_hr_override is None
 

--- a/tests/test_whoop_cockpit_story.py
+++ b/tests/test_whoop_cockpit_story.py
@@ -7,14 +7,23 @@ from __future__ import annotations
 
 
 class TestStoryHelpers:
-    def test_session_load_hardness_labels(self):
-        from rivaflow.core.whoop_cockpit import session_load_hardness
+    def test_classify_hardness_labels(self):
+        """Zone-weight load math now lives in one place (rivaflow.core.cardio_load, Wave 3.2) — the
+        renderer no longer derives its own hardness label from hr_zone_secs. classify_hardness() takes a
+        raw Banister TRIMP load + cutoffs (hardness_cutoffs([]) is the <8-samples fallback band).
+        """
+        from rivaflow.core.cardio_load import classify_hardness, hardness_cutoffs
 
-        assert session_load_hardness({"hr_zone_secs": {4: 1800, 5: 900}})[1] == "HARD"
-        assert session_load_hardness({})[1] == "EASY"
-        load, label = session_load_hardness({"hr_zone_secs": {1: 600, 2: 300}})
-        assert label in ("EASY", "MODERATE")
-        assert isinstance(load, float)
+        cutoffs = hardness_cutoffs(
+            []
+        )  # fallback cutoffs (fewer than 8 recent sessions)
+        assert (
+            classify_hardness(300.0, cutoffs) == "HARD"
+        )  # heavy session, well above HARD_CUTOFF
+        assert classify_hardness(0.0, cutoffs) == "EASY"  # no load at all
+        assert (
+            classify_hardness(100.0, cutoffs) == "MODERATE"
+        )  # between the two cutoffs
 
     def test_inject_takeaway_slots_under_heading(self):
         from rivaflow.core.whoop_cockpit import inject_takeaway
@@ -66,6 +75,12 @@ class TestTodayStory:
                 "times": [0, 1, 2],
                 "values": [140, 160, 150],
                 "hrr": 20,
+                # Load/hardness are computed once in whoop_analytics.session_deepdives (Wave 3.2) and
+                # carried in the analytics dict — the renderer only displays them now, it doesn't
+                # re-derive from hr_zone_secs.
+                "raw_load": 242.6,
+                "load": 15.9,
+                "hardness": "HARD",
             },
         }
         strain = {"available": True, "target_load": 9.0, "chronic_load": 11.0}
@@ -144,6 +159,9 @@ class TestWorkoutsList:
                     "times": [0, 1, 2],
                     "values": [140, 160, 150],
                     "hrr": 20,
+                    "raw_load": 242.6,
+                    "load": 15.9,
+                    "hardness": "HARD",
                 },
             },
             {
@@ -178,6 +196,9 @@ class TestNarrative:
                     "analytics": {
                         "available": True,
                         "hr_zone_secs": {4: 1800, 5: 1200},
+                        "raw_load": 242.6,
+                        "load": 15.9,
+                        "hardness": "HARD",
                     },
                 },
             )


### PR DESCRIPTION
Bitter-Lesson resolves, Wave 3 batch 1 (REPORT §6: 3.6 + 3.2 + 3.4). Four commits, one per concern.

## 3.6 — WhoopProfile seam (`d76f279`, `6bc6de9`)
- `core/whoop_profile.py`: one source for tz / age / sleep-need / rest-day / max-HR-override, read from the existing `profile` table (60s cache). Defaults preserve today's behaviour exactly (Melbourne, DOB fallback 1982-05-27, Sunday rest).
- Migration **116**: `sleep_need_h`, `rest_weekday`, `max_hr_override`, `device_tz` on `profile`.
- Ingest accepts optional `device_tz` (IANA, validated, persisted once per change) — travel day-bucketing fixes itself the day the phone starts sending it.
- Kills `RUBY_AGE` + hardcoded `LOCAL_TZ` bucketing + **9** scattered `weekday() == 6` checks (3 analytics/narrative + 6 route-level).

## 3.2 — Banister cardio load (`1fe156d`)
- `core/cardio_load.py` is now the ONLY load math: Banister-HRR TRIMP (0.64·e^1.92x, gap-clamp 10s), replacing two drifted zone-step-weight tables (analytics + cockpit renderer duplicate — the divergence D6/E2 flagged).
- 0–21 scale re-pinned by fixture tests: rest day ≈ 7–9, hard BJJ day ≈ 15–17.
- HARD/MODERATE cutoffs self-relative (P40/P75 of your own recent sessions, ≥8; fixture-anchored fallback below).
- `user_max_hr()` honors the new `max_hr_override`. Every day dict carries `load_version: "banister-v1"`.

## 3.4 — Incremental daily aggregates (`24b396f`)
- Migration **117**: `whoop_daily_agg` (per-day metrics_json, deriver_version, sample_count, UNIQUE(user_id, day)).
- `core/services/whoop_daily_agg.py`: historical days computed once and served from the rollup; recomputed on deriver-version bump or when the day's raw HR+RR count grows (**late historical drains re-open the day**); today always live, never persisted.
- `DERIVER_VERSION = "daily-agg-v1+banister-v1"` — a future load-math change auto-invalidates stored days.
- **TTL band-aid deleted** (`_SUMMARY_CACHE`): `/summary` is now O(days) by construction; render duration logged, WARN >2000ms.
- Raw tables untouched — store evidence, re-derive judgment.

## Verification
- 295 unit tests pass locally (26 failures are pre-existing no-local-Postgres artifacts, identical on main); new suites: test_whoop_profile (17), test_whoop_ingest_device_tz, test_cardio_load, test_whoop_daily_agg.
- ruff/black/isort clean under CI's exact flags; mypy at main's 9-error baseline (zero new).
- `/summary` + `/cockpit-metrics` payload shapes unchanged (phone contract); Sabbath semantics unchanged (prevention still fires on rest day).
- Post-merge live acceptance planned: /health, /summary latency + readiness, cardio band sanity, migrations 116+117 applied.

ISA: `PAI/MEMORY/WORK/whoop-bitter-lesson-audit/ISA-wave3-batch1.md` (16/18 ISC verified; ISC-17 CI + ISC-18 live are post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)