### PR TITLE
Run APScheduler in a dedicated sidecar, not inside gunicorn workers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,12 +31,42 @@ services:
       PORT: "8000"
       ENV: production
       DATABASE_URL: postgresql://rivaflow:${DB_PASSWORD}@db:5432/rivaflow
+      # the `scheduler` service below owns APScheduler now — starting it here
+      # too would double-fire every job (one scheduler per gunicorn worker).
+      RIVAFLOW_RUN_SCHEDULER: "0"
     depends_on:
       db:
         condition: service_healthy
     ports:
       - "127.0.0.1:8000:8000"   # internal only; tunnel reaches this
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 768m
+
+  # Dedicated APScheduler process. Previously the scheduler ran inside both
+  # gunicorn api workers; the cockpit-snapshot job (~128s) exceeds gunicorn's
+  # --timeout 120 and got SIGABRT'd mid-build, silently losing every
+  # 06/09/18/21 snapshot and killing live requests on that worker. This
+  # service is the same image as api, just running rivaflow.scheduler_main
+  # instead of start.sh — no migrations, no HTTP server, one process.
+  scheduler:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile.api
+    env_file:
+      - .env.prod
+    environment:
+      ENV: production
+      DATABASE_URL: postgresql://rivaflow:${DB_PASSWORD}@db:5432/rivaflow
+    command: python -m rivaflow.scheduler_main
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      disable: true
     deploy:
       resources:
         limits:

--- a/rivaflow/rivaflow/api/main.py
+++ b/rivaflow/rivaflow/api/main.py
@@ -89,31 +89,9 @@ _VERSION_FILE = Path(__file__).parent.parent / "VERSION"
 _APP_VERSION = _VERSION_FILE.read_text().strip() if _VERSION_FILE.exists() else "0.5.0"
 
 # Configure logging — JSON in production, plain text elsewhere
-if settings.IS_PRODUCTION:
-    try:
-        from pythonjsonlogger.json import JsonFormatter
+from rivaflow.core.logging_config import configure_logging  # noqa: E402
 
-        _handler = logging.StreamHandler()
-        _handler.setFormatter(
-            JsonFormatter(
-                fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
-                datefmt="%Y-%m-%dT%H:%M:%S",
-            )
-        )
-        logging.root.handlers = [_handler]
-        logging.root.setLevel(logging.INFO)
-    except ImportError:
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-else:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+configure_logging()
 
 # Initialize Sentry error tracking (only if SDK installed and DSN configured)
 _sentry_dsn = os.getenv("SENTRY_DSN")
@@ -174,9 +152,7 @@ async def _lifespan(_app: FastAPI):
 
     if not settings.IS_TEST:
         try:
-            from rivaflow.core.scheduler import start_scheduler
-
-            start_scheduler()
+            _start_scheduler_if_enabled()
         except Exception as e:
             logging.warning(f"Background scheduler failed to start: {e}")
 
@@ -188,11 +164,39 @@ async def _lifespan(_app: FastAPI):
     close_connection_pool()
 
     try:
-        from rivaflow.core.scheduler import stop_scheduler
-
-        stop_scheduler()
+        _stop_scheduler_if_enabled()
     except Exception:
         pass
+
+
+def _start_scheduler_if_enabled() -> None:
+    """Start the in-process scheduler unless a dedicated sidecar owns it.
+
+    Gated by RIVAFLOW_RUN_SCHEDULER (via settings.RUN_SCHEDULER). Unset or
+    "1" preserves today's single-process behavior (dev/sqlite). "0" is set
+    on the prod api service now that docker-compose.prod.yml runs a
+    dedicated `scheduler` sidecar (see rivaflow.scheduler_main) — starting
+    it here too would double-fire every job.
+    """
+    if not settings.RUN_SCHEDULER:
+        logging.info(
+            "Scheduler disabled — running in sidecar (RIVAFLOW_RUN_SCHEDULER=0)"
+        )
+        return
+
+    from rivaflow.core.scheduler import start_scheduler
+
+    start_scheduler()
+
+
+def _stop_scheduler_if_enabled() -> None:
+    """Mirror of _start_scheduler_if_enabled for shutdown."""
+    if not settings.RUN_SCHEDULER:
+        return
+
+    from rivaflow.core.scheduler import stop_scheduler
+
+    stop_scheduler()
 
 
 app = FastAPI(

--- a/rivaflow/rivaflow/core/logging_config.py
+++ b/rivaflow/rivaflow/core/logging_config.py
@@ -1,0 +1,36 @@
+"""Shared root-logger configuration — JSON in production, plain text elsewhere.
+
+Used by both the API process (rivaflow.api.main) and the scheduler sidecar
+(rivaflow.scheduler_main) so their log lines share one format regardless of
+which process emits them.
+"""
+
+import logging
+
+from rivaflow.core.settings import settings
+
+
+def configure_logging() -> None:
+    """Configure the root logger. Idempotent — safe to call more than once."""
+    if settings.IS_PRODUCTION:
+        try:
+            from pythonjsonlogger.json import JsonFormatter
+
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                JsonFormatter(
+                    fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
+                    datefmt="%Y-%m-%dT%H:%M:%S",
+                )
+            )
+            logging.root.handlers = [handler]
+            logging.root.setLevel(logging.INFO)
+            return
+        except ImportError:
+            pass
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )

--- a/rivaflow/rivaflow/core/settings.py
+++ b/rivaflow/rivaflow/core/settings.py
@@ -30,6 +30,11 @@ class Settings:
         self.WAITLIST_ENABLED: bool = (
             os.getenv("WAITLIST_ENABLED", "false").lower() == "true"
         )
+        # Unset or "1" (dev/sqlite default): the API process starts its own
+        # in-process scheduler, unchanged. "0" (prod): a dedicated scheduler
+        # sidecar owns the jobs and the API skips start_scheduler() —
+        # see rivaflow.scheduler_main.
+        self.RUN_SCHEDULER: bool = os.getenv("RIVAFLOW_RUN_SCHEDULER", "1") != "0"
 
         # ======================================================================
         # SECURITY

--- a/rivaflow/rivaflow/scheduler_main.py
+++ b/rivaflow/rivaflow/scheduler_main.py
@@ -1,0 +1,117 @@
+"""Standalone scheduler sidecar entrypoint: ``python -m rivaflow.scheduler_main``.
+
+APScheduler used to start inside every gunicorn UvicornWorker. The cockpit
+snapshot build (~128s) exceeds gunicorn's ``--timeout 120``, so gunicorn
+SIGABRTs the worker mid-build — the scheduled snapshot silently fails, any
+live request on that worker dies with it, and because one scheduler runs
+per worker every job double-fires (only a PG advisory lock guards
+collisions). This process owns scheduling exclusively in prod instead: the
+API's own ``start_scheduler()`` call is gated off via
+``RIVAFLOW_RUN_SCHEDULER=0`` (see ``rivaflow.api.main``), and
+docker-compose.prod.yml runs this module as its own `scheduler` service.
+
+Does NOT run database migrations (start.sh / the api container already
+does) and does NOT import or serve the FastAPI app — this process only
+imports what start_scheduler()/stop_scheduler() need.
+"""
+
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+from collections.abc import Callable
+from types import FrameType
+
+from rivaflow.core.logging_config import configure_logging
+from rivaflow.core.scheduler import start_scheduler, stop_scheduler
+from rivaflow.db.database import get_connection
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+_DB_WAIT_TIMEOUT_SECONDS = 60.0
+_DB_WAIT_INITIAL_BACKOFF = 1.0
+_DB_WAIT_MAX_BACKOFF = 10.0
+
+
+def _wait_for_db(
+    timeout_seconds: float = _DB_WAIT_TIMEOUT_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> bool:
+    """Poll the database with a trivial query until it answers or the timeout elapses.
+
+    Returns True once the DB responds, False if timeout_seconds is exceeded
+    without a successful query. Backs off between attempts (1s, 2s, 4s, ...
+    capped at _DB_WAIT_MAX_BACKOFF) so a slow-starting Postgres container
+    isn't hammered.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    backoff = _DB_WAIT_INITIAL_BACKOFF
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            with get_connection() as conn:
+                conn.cursor().execute("SELECT 1")
+            logger.info("Database reachable after %d attempt(s)", attempt)
+            return True
+        except Exception as e:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.error(
+                    "Database not reachable after %.0fs (%d attempts): %s",
+                    timeout_seconds,
+                    attempt,
+                    e,
+                )
+                return False
+            sleep_for = min(backoff, remaining)
+            logger.warning(
+                "Database not ready (attempt %d): %s — retrying in %.1fs",
+                attempt,
+                e,
+                sleep_for,
+            )
+            sleep(sleep_for)
+            backoff = min(backoff * 2, _DB_WAIT_MAX_BACKOFF)
+
+
+def _install_signal_handlers(stop_event: threading.Event) -> None:
+    """Register SIGTERM/SIGINT to signal a clean shutdown via stop_event."""
+
+    def _handle(signum: int, _frame: FrameType | None) -> None:
+        logger.info("Received signal %s — shutting down scheduler", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
+
+def _run(stop_event: threading.Event | None = None) -> int:
+    """Start the scheduler and block until a shutdown signal (or stop_event) fires."""
+    if not _wait_for_db():
+        return 1
+
+    event = stop_event if stop_event is not None else threading.Event()
+    _install_signal_handlers(event)
+
+    start_scheduler()
+    logger.info(
+        "Scheduler sidecar running (pid=%d) — waiting for shutdown signal", os.getpid()
+    )
+
+    event.wait()
+
+    stop_scheduler()
+    logger.info("Scheduler sidecar exiting cleanly")
+    return 0
+
+
+def main() -> None:
+    sys.exit(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/rivaflow/tests/unit/test_scheduler_sidecar.py
+++ b/rivaflow/tests/unit/test_scheduler_sidecar.py
@@ -1,0 +1,257 @@
+"""Scheduler sidecar tests (pure — no Postgres, no network).
+
+Covers three surfaces:
+
+1. The env gate (RIVAFLOW_RUN_SCHEDULER via settings.RUN_SCHEDULER) that
+   decides whether the API process starts its own in-process scheduler.
+2. rivaflow.scheduler_main — the standalone `python -m rivaflow.scheduler_main`
+   entrypoint that the `scheduler` compose service runs instead.
+3. docker-compose.prod.yml — the sidecar service definition and the api
+   service's RIVAFLOW_RUN_SCHEDULER override.
+
+See rivaflow/rivaflow/core/scheduler.py for the jobs themselves (unchanged)
+and rivaflow/rivaflow/api/main.py for the gate call sites.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from rivaflow.core.settings import settings
+
+# ---------------------------------------------------------------------------
+# 1. Env gate — rivaflow.api.main._start_scheduler_if_enabled / _stop_scheduler_if_enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _restore_run_scheduler():
+    """settings is a process-wide singleton — don't leak RUN_SCHEDULER across tests."""
+    original = settings.RUN_SCHEDULER
+    yield
+    settings.RUN_SCHEDULER = original
+
+
+def test_gate_unset_or_1_starts_scheduler(monkeypatch):
+    """Default (unset/"1") behavior must be byte-identical to pre-sidecar: start_scheduler() runs."""
+    import rivaflow.api.main as main_module
+
+    settings.RUN_SCHEDULER = True
+    called = []
+    monkeypatch.setattr(
+        "rivaflow.core.scheduler.start_scheduler", lambda: called.append("start")
+    )
+
+    main_module._start_scheduler_if_enabled()
+
+    assert called == ["start"]
+
+
+def test_gate_0_skips_scheduler_start(monkeypatch, caplog):
+    """RIVAFLOW_RUN_SCHEDULER=0 must skip start_scheduler() and log why."""
+    import rivaflow.api.main as main_module
+
+    settings.RUN_SCHEDULER = False
+    called = []
+    monkeypatch.setattr(
+        "rivaflow.core.scheduler.start_scheduler", lambda: called.append("start")
+    )
+
+    with caplog.at_level("INFO"):
+        main_module._start_scheduler_if_enabled()
+
+    assert called == []
+    assert any("sidecar" in rec.message for rec in caplog.records)
+
+
+def test_gate_unset_or_1_stops_scheduler(monkeypatch):
+    import rivaflow.api.main as main_module
+
+    settings.RUN_SCHEDULER = True
+    called = []
+    monkeypatch.setattr(
+        "rivaflow.core.scheduler.stop_scheduler", lambda: called.append("stop")
+    )
+
+    main_module._stop_scheduler_if_enabled()
+
+    assert called == ["stop"]
+
+
+def test_gate_0_skips_scheduler_stop(monkeypatch):
+    import rivaflow.api.main as main_module
+
+    settings.RUN_SCHEDULER = False
+    called = []
+    monkeypatch.setattr(
+        "rivaflow.core.scheduler.stop_scheduler", lambda: called.append("stop")
+    )
+
+    main_module._stop_scheduler_if_enabled()
+
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# 2. rivaflow.scheduler_main — DB wait
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def execute(self, _query):
+        return None
+
+
+class _FakeConn:
+    def cursor(self):
+        return _FakeCursor()
+
+
+@contextmanager
+def _fake_get_connection_ok():
+    yield _FakeConn()
+
+
+@contextmanager
+def _fake_get_connection_fail():
+    raise ConnectionError("db not ready")
+    yield  # pragma: no cover — unreachable, required for generator shape
+
+
+def test_wait_for_db_success_returns_true_without_retrying(monkeypatch):
+    import rivaflow.scheduler_main as sched_main
+
+    monkeypatch.setattr(sched_main, "get_connection", _fake_get_connection_ok)
+    sleeps: list[float] = []
+
+    result = sched_main._wait_for_db(timeout_seconds=5, sleep=sleeps.append)
+
+    assert result is True
+    assert sleeps == []
+
+
+def test_wait_for_db_failure_retries_then_gives_up(monkeypatch):
+    import rivaflow.scheduler_main as sched_main
+
+    monkeypatch.setattr(sched_main, "get_connection", _fake_get_connection_fail)
+    sleeps: list[float] = []
+
+    result = sched_main._wait_for_db(timeout_seconds=0.05, sleep=sleeps.append)
+
+    assert result is False
+    assert len(sleeps) >= 1  # retried at least once before giving up
+
+
+# ---------------------------------------------------------------------------
+# 2b. rivaflow.scheduler_main — run loop (start → block → stop)
+# ---------------------------------------------------------------------------
+
+
+def test_run_exits_without_starting_scheduler_when_db_unreachable(monkeypatch):
+    import rivaflow.scheduler_main as sched_main
+
+    monkeypatch.setattr(sched_main, "_wait_for_db", lambda: False)
+    called: list[str] = []
+    monkeypatch.setattr(sched_main, "start_scheduler", lambda: called.append("start"))
+    monkeypatch.setattr(sched_main, "stop_scheduler", lambda: called.append("stop"))
+
+    exit_code = sched_main._run()
+
+    assert exit_code == 1
+    assert called == []
+
+
+def test_run_starts_then_stops_scheduler_in_order(monkeypatch):
+    import rivaflow.scheduler_main as sched_main
+
+    monkeypatch.setattr(sched_main, "_wait_for_db", lambda: True)
+    order: list[str] = []
+    monkeypatch.setattr(sched_main, "start_scheduler", lambda: order.append("start"))
+    monkeypatch.setattr(sched_main, "stop_scheduler", lambda: order.append("stop"))
+    # Don't touch the real process signal handlers from inside a test run.
+    monkeypatch.setattr(sched_main, "_install_signal_handlers", lambda _event: None)
+
+    stop_event = threading.Event()
+    stop_event.set()  # already set — event.wait() returns immediately, no real blocking
+
+    exit_code = sched_main._run(stop_event=stop_event)
+
+    assert order == ["start", "stop"]
+    assert exit_code == 0
+
+
+def test_signal_handler_sets_stop_event():
+    """SIGTERM (or SIGINT) delivered to the sidecar must flip the stop event, not exit abruptly."""
+    import rivaflow.scheduler_main as sched_main
+
+    event = threading.Event()
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+    original_sigint = signal.getsignal(signal.SIGINT)
+    try:
+        sched_main._install_signal_handlers(event)
+        handler = signal.getsignal(signal.SIGTERM)
+
+        assert not event.is_set()
+        handler(signal.SIGTERM, None)
+        assert event.is_set()
+    finally:
+        signal.signal(signal.SIGTERM, original_sigterm)
+        signal.signal(signal.SIGINT, original_sigint)
+
+
+# ---------------------------------------------------------------------------
+# 2c. rivaflow.scheduler_main — no migrations, no API app
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_main_has_no_migration_or_api_app_import():
+    import rivaflow.scheduler_main as sched_main
+
+    source = Path(sched_main.__file__).read_text()
+    import_lines = [
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ]
+
+    assert not any("migrate" in line.lower() for line in import_lines)
+    assert not any("rivaflow.api" in line for line in import_lines)
+    assert not any("fastapi" in line.lower() for line in import_lines)
+
+
+# ---------------------------------------------------------------------------
+# 3. docker-compose.prod.yml — scheduler service + api gate
+# ---------------------------------------------------------------------------
+#
+# PyYAML isn't a declared project dependency (pyproject.toml has no `yaml`/
+# `PyYAML` entry), so this asserts on the raw text rather than parsing it,
+# to avoid adding a dependency just for one test.
+
+
+def test_compose_defines_scheduler_sidecar_and_gates_api():
+    compose_path = Path(__file__).resolve().parents[3] / "docker-compose.prod.yml"
+    assert compose_path.exists(), f"expected docker-compose.prod.yml at {compose_path}"
+    text = compose_path.read_text()
+
+    assert (
+        "\n  scheduler:\n" in text
+    ), "scheduler service missing from docker-compose.prod.yml"
+    scheduler_block = text.split("\n  scheduler:\n", 1)[1].split("\n  web:\n", 1)[0]
+
+    assert "command: python -m rivaflow.scheduler_main" in scheduler_block
+    assert (
+        "condition: service_healthy" in scheduler_block
+    )  # mirrors api's db dependency
+    assert "restart: unless-stopped" in scheduler_block
+    assert "ports:" not in scheduler_block  # no ports — it's not an HTTP service
+
+    api_block = text.split("\n  api:\n", 1)[1].split("\n  scheduler:\n", 1)[0]
+    assert 'RIVAFLOW_RUN_SCHEDULER: "0"' in api_block, (
+        "api service must disable its in-process scheduler now that the "
+        "sidecar owns it — otherwise every job double-fires again"
+    )


### PR DESCRIPTION
Fixes the scheduler disease diagnosed during the Wave-2.4 live acceptance (2026-07-10): APScheduler runs inside BOTH gunicorn UvicornWorkers, so the cockpit snapshot build (~128s, grown past `--timeout 120`) gets the worker SIGABRT'd (code 134) mid-build — every scheduled 06/09/18/21 snapshot store has been silently failing since the build crossed 120s, each kill blips live requests on that worker, and every job double-fires (one scheduler per worker).

## Change
- **`rivaflow/scheduler_main.py`** — standalone blocking entrypoint (`python -m rivaflow.scheduler_main`): shared logging config, bounded DB wait, `start_scheduler()`, SIGTERM/SIGINT → clean shutdown. Explicitly does NOT run migrations (the api's start.sh owns those).
- **`scheduler` compose service** — same image + env as the api, no ports, `restart: unless-stopped`, 768m cap, healthcheck disabled (no HTTP surface). `deploy.sh`'s `compose up -d` auto-creates it on deploy.
- **`RIVAFLOW_RUN_SCHEDULER` gate** (`settings.RUN_SCHEDULER`): api service sets `"0"` — web workers no longer schedule. Unset ≡ `"1"`, so dev/single-process behavior is byte-identical.
- Shared logging setup extracted to `core/logging_config.py` (app + sidecar emit the same JSON format).

One topology move kills both failure modes: jobs no longer inherit the web worker's 120s timeout, and the per-worker double-fire is gone.

## Verification
- 382 unit tests pass locally (11 new: env gate both ways, run-loop start/stop ordering + signal path, DB-wait retry/exhaust, no-migrations assertion, compose sanity); 26 pre-existing no-local-Postgres failures identical on main.
- Four linters clean under CI flags; mypy at the 9-error baseline.
- Post-merge live acceptance planned: `rivaflow-scheduler-1` up, jobs registered once, the post-deploy warmup build **runs to completion and stores** a fresh whoop-summary-v2 snapshot, api logs free of scheduler activity and code-134 across the next tick.

ISA: `PAI/MEMORY/WORK/whoop-bitter-lesson-audit/ISA-scheduler-sidecar.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)