### PR TITLE
fix(cockpit): surface amber/red prevention alerts in web Tier-1 + hourly escalation guard

### DIFF
--- a/rivaflow/rivaflow/core/scheduler.py
+++ b/rivaflow/rivaflow/core/scheduler.py
@@ -31,7 +31,19 @@ _LOCK_IDS = {
     "coach_settings_reminder": 900004,
     "token_cleanup": 900005,
     "cockpit_snapshot": 900006,
+    "prevention_escalation": 900007,
 }
+
+# Prevention tiers as a monotonic safety scale so the escalation guard can ask "did it get WORSE?" —
+# green/none (0) < amber (1) < red (2). An unavailable/missing tier (building baselines) reads as 0.
+_PREVENTION_TIER_RANK = {"green": 0, "amber": 1, "red": 2}
+
+
+def _prevention_rank(prevention: dict | None) -> int:
+    """Rank a prevention_watch()/snapshot prevention dict on the safety scale (green/none=0, amber=1, red=2)."""
+    if not prevention or not prevention.get("available"):
+        return 0
+    return _PREVENTION_TIER_RANK.get(prevention.get("tier", "green"), 0)
 
 
 def _try_advisory_lock(job_name: str) -> bool:
@@ -364,6 +376,86 @@ async def _cockpit_snapshot_job() -> None:
         _release_advisory_lock("cockpit_snapshot")
 
 
+async def _prevention_escalation_job() -> None:
+    """Hourly SAFETY guard against a stale snapshot hiding a fresh alert.
+
+    The cockpit/summary snapshot only rebuilds 4x/day (6/9/18/21 Melbourne), so a midday tier escalation
+    (green→amber, amber→red) could sit hidden under a ≤4h-old snapshot for hours — exactly the illness/injury
+    warning a user most needs to see promptly. Each hour we cheaply re-run the co-occurrence prevention engine
+    (whoop_analytics.prevention_watch — seconds, a few day-windowed reads, NOT the ~40s full cockpit recompute)
+    for every recently-active WHOOP user and compare it to the tier baked into their stored snapshot's
+    metrics_json. Only an ESCALATION rebuilds+stores a fresh snapshot immediately (reusing the exact
+    build+store the 4x/day job uses), so the banner reaches the user without waiting for the next tick.
+
+    De-escalation (red→amber/green, amber→green) is DELIBERATELY NOT fast-pathed: a safety ALARM should raise
+    on the first corroborated reading, but 'all clear' must not flip on a single hourly sample — a lone reading
+    can dip back into range transiently. Clearing therefore waits for the normal 4x/day cadence to corroborate,
+    so the banner can't flicker off prematurely and under-warn. Unchanged tiers are likewise left to the cadence.
+    """
+    if not _try_advisory_lock("prevention_escalation"):
+        return
+    try:
+        import json
+
+        from rivaflow.core.whoop_analytics import (
+            build_cockpit_snapshot,
+            prevention_watch,
+        )
+        from rivaflow.db.database import convert_query, get_connection
+        from rivaflow.db.repositories.whoop_repo import WhoopRepository
+
+        # Same active-user population the cockpit snapshot job rebuilds: any WHOOP HR captured in the last ~72h.
+        cutoff = (utcnow() - timedelta(hours=72)).isoformat()
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                convert_query("SELECT DISTINCT user_id FROM whoop_hr WHERE ts >= ?"),
+                (cutoff,),
+            )
+            rows = cursor.fetchall()
+
+        user_ids = [r["user_id"] if hasattr(r, "keys") else r[0] for r in rows]
+        logger.debug(
+            "Prevention escalation: checking %d active WHOOP users", len(user_ids)
+        )
+
+        rebuilt = 0
+        for uid in user_ids:
+            try:
+                stored = WhoopRepository.get_cockpit_metrics(uid)
+                if not stored or not stored.get("metrics_json"):
+                    # No snapshot yet — the 4x/day cadence job (+ its startup warmup) builds the first one;
+                    # there's no stale snapshot to escalate against, so skip rather than build a second path.
+                    continue
+                stored_prevention = json.loads(stored["metrics_json"]).get("prevention")
+                current = prevention_watch(uid)
+                if _prevention_rank(current) > _prevention_rank(stored_prevention):
+                    # Escalated since the snapshot was built — rebuild+store NOW (reuses the cadence job's
+                    # build+store) so the amber/red banner surfaces immediately instead of up to 4h late.
+                    html, metrics_json, deriver_version = build_cockpit_snapshot(uid)
+                    WhoopRepository.upsert_cockpit_snapshot(
+                        uid, html, metrics_json, deriver_version
+                    )
+                    rebuilt += 1
+                    logger.info(
+                        "Prevention escalation: rebuilt snapshot for user %d (tier %s → %s)",
+                        uid,
+                        (stored_prevention or {}).get("tier", "none"),
+                        (current or {}).get("tier", "none"),
+                    )
+            except Exception:
+                logger.warning(
+                    "Prevention escalation check failed for user %d", uid, exc_info=True
+                )
+
+        if rebuilt:
+            logger.info("Prevention escalation: rebuilt %d snapshots", rebuilt)
+    except Exception:
+        logger.error("Prevention escalation job failed", exc_info=True)
+    finally:
+        _release_advisory_lock("prevention_escalation")
+
+
 async def _token_cleanup_job() -> None:
     """Delete expired refresh tokens and password reset tokens (daily 03:00 UTC)."""
     if not _try_advisory_lock("token_cleanup"):
@@ -468,6 +560,21 @@ def start_scheduler() -> None:
         minute=0,
         timezone=_MELBOURNE_TZ,
         id="cockpit_snapshot",
+        replace_existing=True,
+        misfire_grace_time=600,
+        coalesce=True,
+    )
+
+    # Hourly at :30 — safety guard that re-runs the cheap prevention engine and immediately rebuilds a
+    # user's snapshot if their tier has ESCALATED since it was built (so an amber/red alert can't sit hidden
+    # under the ≤4h-stale snapshot). Staggered to :30 so it never collides with the on-the-hour cockpit
+    # snapshot rebuilds at 6/9/18/21. Same generous misfire grace as the snapshot job — a deploy restart
+    # around a tick shouldn't make apscheduler skip a safety check.
+    _scheduler.add_job(
+        _prevention_escalation_job,
+        "cron",
+        minute=30,
+        id="prevention_escalation",
         replace_existing=True,
         misfire_grace_time=600,
         coalesce=True,

--- a/rivaflow/rivaflow/core/whoop_analytics.py
+++ b/rivaflow/rivaflow/core/whoop_analytics.py
@@ -1283,6 +1283,7 @@ def _build_cockpit_page(user_id: int) -> str:
         strain,
         is_sabbath,
         trends=trends,
+        prevention=prevention,  # safety channel — surfaces the amber/red banner in Tier-1, incl. Sabbath
     )
     workouts = render_workouts_list(sessions)
     lab = render_lab_section(_lab_panels(user_id, ctx=ctx))

--- a/rivaflow/rivaflow/core/whoop_cockpit.py
+++ b/rivaflow/rivaflow/core/whoop_cockpit.py
@@ -11,6 +11,15 @@ from __future__ import annotations
 
 import html
 
+from rivaflow.core.whoop_tiles import _compose_hero
+
+# Prevention severity (from whoop_tiles._compose_hero) → the cockpit's hex accent. This is presentation
+# only: the amber/red OVERRIDE RULE itself lives in exactly one place, whoop_tiles._compose_hero (the same
+# function the phone's hero rides on), so the web cockpit and the phone can never disagree on WHETHER
+# prevention overrides — this table just paints the verdict we're handed. Hexes match render_prevention_log's
+# tier palette (amber #fbbf24 / red #f87171) so the banner agrees with the Lab's prevention panel.
+_PREVENTION_ACCENT = {"caution": "#fbbf24", "alert": "#f87171"}
+
 _ACCENT = {
     "Prime": "#34d399",
     "Balanced": "#60a5fa",
@@ -477,6 +486,14 @@ def render_cockpit_page(panels_html: str, rendered_at: str = "") -> str:
         ".scrub-tip b{color:#fff}.scrub svg{cursor:crosshair}"
         # Tier-1 story layer
         ".panel.hero{border-color:#334155}"
+        # Safety-channel banner — surfaces an amber/red prevention override ABOVE the readiness verdict so a
+        # web-cockpit user can't miss a strong-signal illness/injury warning (see _prevention_banner). Caution
+        # = amber warning styling (mirrors .caveat), alert = red. No banner on green/neutral.
+        ".prevention-banner{border-radius:8px;padding:10px 12px;margin:0 0 12px;font-size:13px;line-height:1.45}"
+        ".prevention-banner.caution{background:#422006;border:1px solid #a16207}"
+        ".prevention-banner.alert{background:#450a0a;border:1px solid #b91c1c}"
+        ".prevention-banner .pb-label{font-weight:700;text-transform:uppercase;letter-spacing:.04em;font-size:12px}"
+        ".prevention-banner .pb-msg{color:#e2e8f0}"
         ".verdict{font-size:34px;font-weight:700;line-height:1.1;margin:2px 0}"
         ".verdict-sub{font-size:15px;color:#cbd5e1;margin:2px 0 4px}"
         ".narrative{font-size:15px;line-height:1.5;background:#0f172a;border-left:3px solid #60a5fa;"
@@ -1058,9 +1075,62 @@ def _spark_row(
     )
 
 
-def _hero_html(readiness: dict, trends: dict | None = None) -> str:
+def _hero_override(readiness: dict, prevention: dict | None) -> dict:
+    """The single source of the prevention→hero override: delegates to whoop_tiles._compose_hero — the exact
+    same function the phone's server-driven hero rides on — so the web cockpit applies an IDENTICAL
+    severity/colour/headline override rule. Returns _compose_hero's {state, state_color, headline, severity}.
+    We hand it a minimal summary shape ({readiness, prevention}) since those are the only keys it reads.
+    """
+    return _compose_hero({"readiness": readiness, "prevention": prevention or {}})
+
+
+def _prevention_fired(prevention: dict | None) -> bool:
+    """Whether prevention ITSELF fired amber/red — the exact one-line gate whoop_tiles._compose_hero uses
+    (`tier in ("amber", "red")`) before it overrides anything. Checked directly rather than inferred from
+    `hero["severity"]` because _compose_hero's "never downgrade" rule creates two edge cases where severity
+    alone is ambiguous: a readiness-only Rundown day (severity='alert' from readiness ALONE, no prevention
+    signal) must NOT show a safety banner; a Rundown day where prevention ALSO fires amber must show one even
+    though colour/severity don't visibly move (only the headline swaps — see whoop_tiles.py's 'safety
+    headline still wins even when it doesn't need to escalate colour/severity')."""
+    prevention = prevention or {}
+    tier = prevention.get("tier") if prevention.get("available") else None
+    return tier in ("amber", "red")
+
+
+def _prevention_banner(hero: dict, fired: bool) -> str:
+    """Prominent safety banner rendered ABOVE the readiness verdict only when prevention ITSELF fired (see
+    _prevention_fired) — never merely because readiness's own severity happens to already read 'alert'.
+    The message is `hero["headline"]` — which _compose_hero has already replaced with prevention's OWN copy
+    on a fire, so this is the identical text the phone surfaces (no fresh copy). No fire → no banner.
+    """
+    if not fired:
+        return ""
+    severity = hero[
+        "severity"
+    ]  # guaranteed "caution" or "alert" whenever fired is True
+    color = _PREVENTION_ACCENT[severity]
+    label = "⚠️ Ease &amp; watch" if severity == "caution" else "🛑 Rest &amp; recover"
+    return (
+        f'<div class="prevention-banner {severity}">'
+        f'<span class="pb-label" style="color:{color}">{label}</span> '
+        f'<span class="pb-msg">{esc(hero.get("headline", ""))}</span>'
+        "</div>"
+    )
+
+
+def _hero_html(
+    readiness: dict, trends: dict | None = None, prevention: dict | None = None
+) -> str:
+    hero = _hero_override(readiness, prevention)
+    fired = _prevention_fired(prevention)
     state = str(readiness.get("state", "Building"))
-    accent = _ACCENT.get(state, "#94a3b8")
+    # When prevention fires (amber/red) the verdict accent shifts to the prevention colour — the same
+    # severity→colour mapping _compose_hero applied; otherwise the readiness accent is unchanged (no visual
+    # change when prevention is green/neutral/unavailable, byte-identical to before).
+    accent = (
+        _PREVENTION_ACCENT[hero["severity"]] if fired else _ACCENT.get(state, "#94a3b8")
+    )
+    banner = _prevention_banner(hero, fired)
     headline = esc(readiness.get("headline", ""))
     caveat = readiness.get("caveat")
     caveat_html = f'<div class="caveat">⚠️ {esc(caveat)}</div>' if caveat else ""
@@ -1083,6 +1153,7 @@ def _hero_html(readiness: dict, trends: dict | None = None) -> str:
         else ""
     )
     return (
+        f"{banner}"
         f'<div class="ico">Today\'s readiness</div>'
         f'<div class="verdict" style="color:{accent}">{esc(state)}{_trend_arrow(readiness)}</div>'
         f'<div class="verdict-sub">{headline}</div>'
@@ -1200,19 +1271,29 @@ def render_today_story(
     strain: dict,
     is_sabbath: bool,
     trends: dict | None = None,
+    prevention: dict | None = None,
 ) -> str:
     """Tier-1 — the glanceable 'Today' band: hero verdict + one honest data-story + three essential cards
     (last night's sleep, last workout, today's guidance). The plain-language layer over the technical Lab.
     `trends` (optional) drives the hero's tap-to-expand 14-day history sparklines.
+
+    `prevention` (optional) is the safety channel: when it fires amber/red the hero shows a prominent banner
+    and its accent border shifts to the prevention colour, on EVERY day including the Sabbath (the safety
+    channel is never rest-day-silenced). On the Sabbath the 'rest is prescribed' guidance card STAYS — the
+    banner appears ADDITIONALLY, not as a replacement. Green/neutral prevention → no visual change.
     """
+    hero = _hero_override(readiness, prevention)
+    fired = _prevention_fired(prevention)
+    section_accent = _PREVENTION_ACCENT[hero["severity"]] if fired else None
+    section_style = f' style="border-color:{section_accent}"' if section_accent else ""
     cards = (
         _sleep_card(night, dip, need_hours)
         + _workout_card(last_workout)
         + _guidance_card(strain, readiness, is_sabbath)
     )
     return (
-        '<section class="panel hero">'
-        f"{_hero_html(readiness, trends)}"
+        f'<section class="panel hero"{section_style}>'
+        f"{_hero_html(readiness, trends, prevention)}"
         f'<div class="narrative">{esc(narrative)}</div>'
         f'<div class="cards3">{cards}</div>'
         "</section>"

--- a/rivaflow/tests/unit/test_cockpit_prevention_visibility.py
+++ b/rivaflow/tests/unit/test_cockpit_prevention_visibility.py
@@ -1,0 +1,292 @@
+"""Cockpit Tier-1 prevention visibility + the hourly stale-snapshot escalation guard.
+
+Two safety surfaces, both pure (no Postgres, no network):
+
+1. render_today_story / _hero_html surface an amber/red prevention override in Tier-1 (banner + accent
+   shift), on every day including the Sabbath, reusing whoop_tiles._compose_hero's override rule — the
+   same rule the phone's server-driven hero rides on. Green/neutral prevention → no visual change.
+
+2. scheduler._prevention_escalation_job rebuilds a user's snapshot ONLY when their live prevention tier
+   has escalated above the tier baked into their stored snapshot — never on de-escalation or no change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from rivaflow.core import scheduler
+from rivaflow.core.scheduler import _prevention_escalation_job, _prevention_rank
+from rivaflow.core.whoop_cockpit import render_today_story
+
+# --- Prevention headlines (the real safety copy the phone surfaces via _compose_hero) ---------------
+RED_HEADLINE = (
+    "Strong multi-signal deviation from your baseline — rest and recover. This is not a "
+    "diagnosis; if you feel unwell, see a clinician."
+)
+AMBER_HEADLINE = (
+    "Your autonomics are working harder than your baseline — could be illness, training, "
+    "alcohol, heat, or poor sleep. Ease today and watch."
+)
+
+READY = {
+    "state": "Balanced",
+    "headline": "Train as planned",
+    "caveat": None,
+    "contributors": [],
+}
+STRAIN_OK = {"available": True, "target_load": 10.0, "chronic_load": 11.0}
+
+
+def _story(
+    prevention: dict | None, *, is_sabbath: bool = False, readiness: dict | None = None
+) -> str:
+    return render_today_story(
+        readiness or READY,
+        "narrative line",
+        {"available": False},
+        {"available": False},
+        9,
+        None,
+        (
+            {"available": False, "reason": "Sabbath — rest is prescribed."}
+            if is_sabbath
+            else STRAIN_OK
+        ),
+        is_sabbath=is_sabbath,
+        prevention=prevention,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Tier-1 hero override rendering
+# ---------------------------------------------------------------------------
+
+
+def test_hero_red_override_renders_alert_banner_and_red_accent():
+    out = _story({"available": True, "tier": "red", "headline": RED_HEADLINE})
+    assert "prevention-banner alert" in out  # red = alert styling
+    assert "🛑 Rest &amp; recover" in out
+    assert (
+        "Strong multi-signal deviation" in out
+    )  # message sourced from the prevention dict, not re-copied
+    assert "#f87171" in out  # red accent shift (verdict colour + hero border)
+
+
+def test_hero_amber_override_renders_caution_banner_and_amber_accent():
+    out = _story({"available": True, "tier": "amber", "headline": AMBER_HEADLINE})
+    assert "prevention-banner caution" in out  # amber = caution styling
+    assert "⚠️ Ease &amp; watch" in out
+    assert "working harder than your baseline" in out
+    assert "#fbbf24" in out  # amber accent shift
+
+
+def test_hero_green_prevention_renders_no_banner_and_no_accent_shift():
+    out = _story({"available": True, "tier": "green", "headline": "In range."})
+    assert "prevention-banner" not in out
+    # No override colour bleeds in and the hero section keeps its default (unstyled) border.
+    assert "#f87171" not in out and "#fbbf24" not in out
+    assert (
+        'class="panel hero"><div class="ico">' in out
+    )  # no inline border-color style injected
+
+
+def test_hero_unavailable_prevention_renders_no_banner():
+    out = _story({"available": False, "reason": "Building baselines."})
+    assert "prevention-banner" not in out
+
+
+def test_hero_no_prevention_arg_is_byte_compatible_default():
+    # Omitting prevention entirely (older callers) must not paint a banner or shift the accent.
+    out = render_today_story(
+        READY,
+        "n",
+        {"available": False},
+        {"available": False},
+        9,
+        None,
+        STRAIN_OK,
+        is_sabbath=False,
+    )
+    assert "prevention-banner" not in out
+    assert 'class="panel hero"' in out
+
+
+def test_readiness_only_rundown_shows_no_false_positive_banner():
+    # Rundown's OWN severity is "alert" in whoop_tiles._compose_hero — with no prevention firing at all,
+    # that must NOT be mistaken for a prevention override (the banner is a prevention-specific signal).
+    rundown = {"state": "Rundown", "headline": "well below baseline", "caveat": None}
+    out = _story(
+        {"available": False, "reason": "Building baselines."}, readiness=rundown
+    )
+    assert "prevention-banner" not in out
+    out2 = _story(None, readiness=rundown)
+    assert "prevention-banner" not in out2
+
+
+def test_rundown_plus_amber_prevention_still_shows_banner_despite_no_colour_change():
+    # _compose_hero never downgrades colour/severity (Rundown is already red/alert, and amber can't pull it
+    # down to caution), but it DOES swap the headline to prevention's own copy whenever prevention fires —
+    # the banner must track that FIRE, not a visible colour change, or a real amber signal riding on top of
+    # an already-bad readiness day goes unseen. Banner styling follows the unchanged (alert) severity.
+    rundown = {"state": "Rundown", "headline": "well below baseline", "caveat": None}
+    out = _story(
+        {"available": True, "tier": "amber", "headline": AMBER_HEADLINE},
+        readiness=rundown,
+    )
+    assert (
+        "prevention-banner alert" in out
+    )  # severity stays "alert" — Rundown's own floor, not downgraded
+    assert (
+        "working harder than your baseline" in out
+    )  # but the AMBER headline text still won through
+
+
+def test_sabbath_red_shows_both_rest_prescribed_and_alert_banner():
+    # Safety outranks Sabbath silencing: the 'rest is prescribed' guidance STAYS and the banner is ADDITIONAL.
+    out = _story(
+        {"available": True, "tier": "red", "headline": RED_HEADLINE},
+        is_sabbath=True,
+    )
+    assert "Sabbath — rest is prescribed" in out  # rest copy preserved
+    assert "prevention-banner alert" in out  # AND the red safety banner
+    assert "Strong multi-signal deviation" in out
+
+
+# ---------------------------------------------------------------------------
+# 2. Escalation guard job
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    def execute(self, *a, **k):
+        return None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    def cursor(self):
+        return _FakeCursor(self._rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _run_job(
+    monkeypatch,
+    *,
+    stored_prevention: dict | None,
+    current_prevention: dict,
+    has_snapshot: bool = True,
+) -> list[int]:
+    """Drive _prevention_escalation_job for a single user; return the uids that got rebuilt+stored."""
+    rebuilt: list[int] = []
+
+    monkeypatch.setattr(scheduler, "_try_advisory_lock", lambda name: True)
+    monkeypatch.setattr(scheduler, "_release_advisory_lock", lambda name: None)
+    monkeypatch.setattr(
+        "rivaflow.db.database.get_connection", lambda: _FakeConn([{"user_id": 7}])
+    )
+    monkeypatch.setattr("rivaflow.db.database.convert_query", lambda q: q)
+
+    def _get_metrics(uid: int):
+        if not has_snapshot:
+            return None
+        return {"metrics_json": json.dumps({"prevention": stored_prevention})}
+
+    monkeypatch.setattr(
+        "rivaflow.db.repositories.whoop_repo.WhoopRepository.get_cockpit_metrics",
+        staticmethod(_get_metrics),
+    )
+    monkeypatch.setattr(
+        "rivaflow.core.whoop_analytics.prevention_watch",
+        lambda uid: current_prevention,
+    )
+    monkeypatch.setattr(
+        "rivaflow.core.whoop_analytics.build_cockpit_snapshot",
+        lambda uid: ("<html>", "{}", "v1"),
+    )
+    monkeypatch.setattr(
+        "rivaflow.db.repositories.whoop_repo.WhoopRepository.upsert_cockpit_snapshot",
+        staticmethod(lambda uid, html, mj, dv: rebuilt.append(uid)),
+    )
+
+    asyncio.run(_prevention_escalation_job())
+    return rebuilt
+
+
+def test_prevention_rank_orders_tiers():
+    assert _prevention_rank(None) == 0
+    assert _prevention_rank({"available": False}) == 0
+    assert _prevention_rank({"available": True, "tier": "green"}) == 0
+    assert _prevention_rank({"available": True, "tier": "amber"}) == 1
+    assert _prevention_rank({"available": True, "tier": "red"}) == 2
+
+
+def test_escalation_green_to_red_rebuilds(monkeypatch):
+    rebuilt = _run_job(
+        monkeypatch,
+        stored_prevention={"available": True, "tier": "green"},
+        current_prevention={"available": True, "tier": "red", "headline": RED_HEADLINE},
+    )
+    assert rebuilt == [7]  # escalated → immediate rebuild+store
+
+
+def test_escalation_amber_to_red_rebuilds(monkeypatch):
+    rebuilt = _run_job(
+        monkeypatch,
+        stored_prevention={"available": True, "tier": "amber"},
+        current_prevention={"available": True, "tier": "red", "headline": RED_HEADLINE},
+    )
+    assert rebuilt == [7]
+
+
+def test_deescalation_red_to_amber_does_not_rebuild(monkeypatch):
+    rebuilt = _run_job(
+        monkeypatch,
+        stored_prevention={"available": True, "tier": "red"},
+        current_prevention={
+            "available": True,
+            "tier": "amber",
+            "headline": AMBER_HEADLINE,
+        },
+    )
+    assert (
+        rebuilt == []
+    )  # de-escalation is deliberately slow-pathed to the 4x/day cadence
+
+
+def test_unchanged_tier_does_not_rebuild(monkeypatch):
+    rebuilt = _run_job(
+        monkeypatch,
+        stored_prevention={"available": True, "tier": "amber"},
+        current_prevention={
+            "available": True,
+            "tier": "amber",
+            "headline": AMBER_HEADLINE,
+        },
+    )
+    assert rebuilt == []
+
+
+def test_no_stored_snapshot_skips_without_crash(monkeypatch):
+    rebuilt = _run_job(
+        monkeypatch,
+        stored_prevention=None,
+        current_prevention={"available": True, "tier": "red", "headline": RED_HEADLINE},
+        has_snapshot=False,
+    )
+    assert (
+        rebuilt == []
+    )  # no snapshot yet → cadence job creates the first; nothing to escalate against


### PR DESCRIPTION
Found live 2026-07-12: the user is ill (PCR-confirmed rhinovirus), the prevention engine fired its RED multi-signal alert — visible on the phone (server-driven hero), invisible on the web cockpit, which showed only "Sabbath — rest is prescribed". The cockpit's Tier-1 renderer never received prevention at all; the red tier lived only in the collapsed Lab panel.

## Fix
- **Tier-1 visibility, one source of truth**: the cockpit hero now delegates the override decision to `whoop_tiles._compose_hero` — the exact rule the phone renders. Amber/red prevention adds a banner above the verdict (prevention's own copy), shifts verdict + hero border to the tier color. Sabbath rest copy stays alongside — safety outranks rest-day silencing, and both are true.
- **False-positive guard**: override keys on `prevention.tier ∈ {amber, red}` — NOT on hero severity alone, which would have shown the safety banner on any naturally-Rundown day (caught in review, regression-tested both ways).
- **Hourly escalation guard** (sidecar scheduler, :30 offset, lock 900007): compares live `prevention_watch` tier to the stored snapshot's; escalation rebuilds the snapshot immediately so a midday alert can't hide behind the ≤4h cache. De-escalation deliberately waits for the 4×/day cadence — alarms raise fast, clear calmly.

## Verification
- 14 new unit tests (override paths, Sabbath+red shows both messages, Rundown false-positive guards, 6 escalation-job cases); full unit suite at the documented baseline; ruff/black/isort/mypy clean under CI flags.
- CI-tree contract check: existing hero assertions unbroken (`class="panel hero"` untouched; style attr appended only on override).
- Post-merge live acceptance: the user's CURRENT red alert must appear on the cockpit — a real-world test case is active right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)